### PR TITLE
feat: add command_alias config to register extra :Differ aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ a live layer on top of the sidecar (optimistic updates, prefetch, warm cache, se
 
 ## Installation
 
-[lazy.nvim](https://github.com/folke/lazy.nvim):
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 {
@@ -73,6 +73,29 @@ a live layer on top of the sidecar (optimistic updates, prefetch, warm cache, se
 `setup()` is only needed to change defaults and register highlight groups eagerly. the `:Differ` command is registered on startup either way.
 
 the `build` hook compiles the go sidecar (used by pr review) on install and update. it needs go and make on `PATH`; local diffs work without it, so you can drop the hook if you only want local diffing.
+
+### vim.pack (Neovim 0.12+)
+
+vim.pack has no inline build key, so register a `PackChanged` hook (before `vim.pack.add`, so it also runs on first install):
+
+```lua
+vim.api.nvim_create_autocmd("PackChanged", {
+  callback = function(ev)
+    if ev.data.spec.name == "differ.nvim" and (ev.data.kind == "install" or ev.data.kind == "update") then
+      vim.system({ "make", "go-build" }, { cwd = ev.data.path }):wait()
+    end
+  end,
+})
+
+vim.pack.add({ "https://github.com/seanhalberthal/differ.nvim" })
+require("differ").setup()
+```
+
+pin a release with `{ src = "https://github.com/seanhalberthal/differ.nvim", version = "v0.1.0" }`.
+
+### other managers
+
+differ's only install step is building the go sidecar, so point your manager's build / post-update hook at `make go-build`: pckr `run`, vim-plug `do`, or the equivalent. it needs go and make; drop it for local diffs only.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ These re-render the active view only. No refetch, no re-diff, and the state is l
 | `:Differ context full` | Show the whole file |
 | `:Differ context +` / `-` | Widen / narrow context by one |
 
+Set `command_alias` in `setup()` to register a shorter name for the same command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must start with an uppercase letter (enforced by vim, not by me)
+
 ### Keymaps
 
 Buffer-local, active inside a differ diff:
@@ -160,6 +162,7 @@ require("differ").setup({
   },
   relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
   sidecar_bin = nil,             -- override the go sidecar path
+  command_alias = nil,           -- extra :command(s) routing to :Differ, e.g. "D" or { "D", "Df" }
 })
 ```
 

--- a/lua/differ/command.lua
+++ b/lua/differ/command.lua
@@ -387,4 +387,21 @@ function M.complete(arglead, cmdline)
     end, pool)
 end
 
+-- register an ex-command routing to dispatch/complete. used for `:Differ` and any
+-- config-supplied aliases (`command_alias`); completion is name-agnostic since it
+-- keys off token position, not the command word
+---@param name string
+---@param desc string
+function M.register(name, desc)
+    vim.api.nvim_create_user_command(name, function(opts)
+        M.dispatch(opts.fargs)
+    end, {
+        nargs = "*",
+        desc = desc,
+        complete = function(arglead, cmdline)
+            return M.complete(arglead, cmdline)
+        end,
+    })
+end
+
 return M

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -19,6 +19,7 @@
 ---@field relative_dates boolean
 ---@field base string|nil
 ---@field sidecar_bin string|nil
+---@field command_alias string|string[]|nil
 
 local M = {}
 
@@ -111,6 +112,10 @@ M.defaults = {
     -- nil auto-detects: origin/HEAD (the remote trunk), else local main/master
     base = nil,
     sidecar_bin = nil,
+    -- extra ex-command name(s) routing to the same dispatcher as `:Differ`, e.g.
+    -- "D" gives `:D HEAD~1`, `:D log`. nil registers none. names must start with an
+    -- uppercase letter (a vim user-command rule); registered by setup()
+    command_alias = nil,
 }
 
 -- resolve the keymaps config into per-surface action tables. the shared (top-level)

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -7,11 +7,36 @@ local M = {}
 ---@type differ.Config|nil
 M.config = nil
 
+-- register each `command_alias` as an ex-command routing to the `:Differ` dispatcher.
+-- a bad name (e.g. not starting uppercase) warns rather than aborting setup()
+---@param alias string|string[]|nil
+local function register_aliases(alias)
+    if not alias then
+        return
+    end
+    local names = type(alias) == "table" and alias or { alias }
+    for _, name in ipairs(names) do
+        local ok, err = pcall(
+            require("differ.command").register,
+            name,
+            "differ diff viewer (alias for :Differ)"
+        )
+        if not ok then
+            local msg = "differ: could not register command alias "
+                .. vim.inspect(name)
+                .. ": "
+                .. tostring(err)
+            vim.notify(msg, vim.log.levels.WARN)
+        end
+    end
+end
+
 -- resolve options and register highlight groups; call once from user config
 ---@param opts table|nil
 function M.setup(opts)
     M.config = config.resolve(opts)
     require("differ.ui.highlights").setup()
+    register_aliases(M.config.command_alias)
 end
 
 -- return the resolved config, defaulting if setup() was never called

--- a/plugin/differ.lua
+++ b/plugin/differ.lua
@@ -5,12 +5,4 @@ if vim.g.loaded_differ then
 end
 vim.g.loaded_differ = true
 
-vim.api.nvim_create_user_command("Differ", function(opts)
-    require("differ.command").dispatch(opts.fargs)
-end, {
-    nargs = "*",
-    desc = "differ diff viewer",
-    complete = function(arglead, cmdline)
-        return require("differ.command").complete(arglead, cmdline)
-    end,
-})
+require("differ.command").register("Differ", "differ diff viewer")


### PR DESCRIPTION
Opt-in config to register extra ex-commands routing to the same dispatcher as `:Differ`, so a user can enable e.g. `:D HEAD~1`, `:D log`.

## Changes
- `config.command_alias` (default `nil`): a string or list of strings, e.g. `"D"` or `{ "D", "Df" }`.
- extracted a shared `command.register(name, desc)` so `:Differ` and aliases share one spec; completion is name-agnostic (keys off token position), so aliases get full subcommand/rev completion.
- `setup()` registers each alias; an invalid name (not uppercase-leading) warns via `vim.notify` rather than aborting setup.
- README: documented `command_alias` in the config block and the usage section. Also includes a follow-up docs commit adding other installation methods.

## Notes
- Vim requires user-command names to start with an uppercase letter, so lowercase aliases (`:d`) aren't possible.

Verified: lua lint clean, full Lua suite passes (276 unit + 196 headless), headless smoke test confirms `:D` registers and a bad name warns without aborting.