### PR TITLE
chore: rename github owner to undont

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_BIN  := bin/differ-sidecar
 # stamped into protocol.Binary so the hello handshake reports a real version,
 # not "dev"; falls back to "dev" outside a git checkout
 GO_VERSION := $(shell git describe --tags --always 2>/dev/null | sed 's/^v//' || echo dev)
-GO_LDFLAGS := -X github.com/seanhalberthal/differ.nvim/internal/protocol.Binary=$(GO_VERSION)
+GO_LDFLAGS := -X github.com/undont/differ.nvim/internal/protocol.Binary=$(GO_VERSION)
 
 .PHONY: help \
 	lua-test lua-test-unit lua-test-nvim lua-lint lua-fmt lua-fmt-check \

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Your whole diff and review loop in one Neovim plugin: local diffs, file history, staging, PR review, and merge conflicts, all with the same UX.**
 
-[![CI](https://img.shields.io/github/actions/workflow/status/seanhalberthal/differ.nvim/ci.yml?branch=main&style=flat&logo=githubactions&logoColor=white&label=CI)](https://github.com/seanhalberthal/differ.nvim/actions)
-[![Release](https://img.shields.io/github/v/release/seanhalberthal/differ.nvim?style=flat&logo=github&logoColor=white&label=Release&color=6366F1)](https://github.com/seanhalberthal/differ.nvim/releases/latest)
-[![Licence](https://img.shields.io/github/license/seanhalberthal/differ.nvim?style=flat&label=licence&color=6366F1)](LICENCE)
+[![CI](https://img.shields.io/github/actions/workflow/status/undont/differ.nvim/ci.yml?branch=main&style=flat&logo=githubactions&logoColor=white&label=CI)](https://github.com/undont/differ.nvim/actions)
+[![Release](https://img.shields.io/github/v/release/undont/differ.nvim?style=flat&logo=github&logoColor=white&label=Release&color=6366F1)](https://github.com/undont/differ.nvim/releases/latest)
+[![Licence](https://img.shields.io/github/license/undont/differ.nvim?style=flat&label=licence&color=6366F1)](LICENCE)
 [![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?style=flat&logo=lua&logoColor=white)](https://www.lua.org)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go&logoColor=white)](https://go.dev)
 [![Neovim](https://img.shields.io/badge/Neovim-0.10+-57A143?style=flat&logo=neovim&logoColor=white)](https://neovim.io)
@@ -66,7 +66,7 @@ A live layer on top of the sidecar (optimistic updates, prefetch, warm cache, se
 
 ```lua
 {
-  "seanhalberthal/differ.nvim",
+  "undont/differ.nvim",
   build = "make go-build",
   config = function()
     require("differ").setup()
@@ -91,11 +91,11 @@ vim.api.nvim_create_autocmd("PackChanged", {
   end,
 })
 
-vim.pack.add({ "https://github.com/seanhalberthal/differ.nvim" })
+vim.pack.add({ "https://github.com/undont/differ.nvim" })
 require("differ").setup()
 ```
 
-Pin a release with `{ src = "https://github.com/seanhalberthal/differ.nvim", version = "v0.1.1" }`.
+Pin a release with `{ src = "https://github.com/undont/differ.nvim", version = "v0.1.1" }`.
 
 ### Other managers
 
@@ -195,7 +195,7 @@ differ ships no global launchers — only the in-view buffer maps above and the 
 
 ```lua
 {
-  "seanhalberthal/differ.nvim",
+  "undont/differ.nvim",
   build = "make go-build",
   cmd = "Differ",
   keys = {

--- a/cmd/differ-sidecar/main.go
+++ b/cmd/differ-sidecar/main.go
@@ -10,10 +10,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/seanhalberthal/differ.nvim/internal/github"
-	"github.com/seanhalberthal/differ.nvim/internal/handlers"
-	"github.com/seanhalberthal/differ.nvim/internal/logx"
-	"github.com/seanhalberthal/differ.nvim/internal/server"
+	"github.com/undont/differ.nvim/internal/github"
+	"github.com/undont/differ.nvim/internal/handlers"
+	"github.com/undont/differ.nvim/internal/logx"
+	"github.com/undont/differ.nvim/internal/server"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/seanhalberthal/differ.nvim
+module github.com/undont/differ.nvim
 
 go 1.26.4

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // ResolveToken finds a GitHub token without go-gh: GH_TOKEN, then

--- a/internal/github/comments.go
+++ b/internal/github/comments.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // PostComment creates a review comment. InReplyTo (a thread node id) replies into an

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // the github package is the single producer of mapped I/O codes (auth, not_found,

--- a/internal/github/files.go
+++ b/internal/github/files.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // GetFileVersions returns the full base and head blobs for one path in a PR. the

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // rtFunc is a fake http.RoundTripper: every request is answered by f, so tests

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // graphql posts a raw GraphQL query (no go-gh, no typed dep) and decodes

--- a/internal/github/merge.go
+++ b/internal/github/merge.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // MergePR merges the PR with the given method (MERGE / SQUASH / REBASE). it pre-flights

--- a/internal/github/merge_test.go
+++ b/internal/github/merge_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 func mergeOp(t *testing.T, body []byte) string {

--- a/internal/github/prs.go
+++ b/internal/github/prs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // ListPRs returns open PRs filtered by open/mine/review_requested. mine and

--- a/internal/github/read_test.go
+++ b/internal/github/read_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // ── get_file_versions ─────────────────────────────────────────────────────────

--- a/internal/github/rest.go
+++ b/internal/github/rest.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 const maxResponse = 32 * 1024 * 1024 // bound a single response body

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // prAndPendingReview returns the PR node id and the viewer's existing pending review

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // gqlOp returns the operation name from a GraphQL request body so a fake transport

--- a/internal/github/state.go
+++ b/internal/github/state.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // SetPRState transitions a PR's lifecycle: ready (mark ready for review), draft

--- a/internal/github/threads_test.go
+++ b/internal/github/threads_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 func TestResolveThread(t *testing.T) {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"log/slog"
 
-	"github.com/seanhalberthal/differ.nvim/internal/github"
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/github"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // Handler runs one method: decode params, do the work, return a result struct

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -9,8 +9,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/seanhalberthal/differ.nvim/internal/github"
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/github"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // mockAPI records what it was called with so handler routing/validation can be

--- a/internal/handlers/hello.go
+++ b/internal/handlers/hello.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type helloParams struct {

--- a/internal/handlers/mutate_comments.go
+++ b/internal/handlers/mutate_comments.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/github"
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/github"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type postCommentParams struct {

--- a/internal/handlers/mutate_pr.go
+++ b/internal/handlers/mutate_pr.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type setFileViewedParams struct {

--- a/internal/handlers/mutate_reviews.go
+++ b/internal/handlers/mutate_reviews.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // startReview creates (or reattaches to) the viewer's pending review.

--- a/internal/handlers/mutate_threads.go
+++ b/internal/handlers/mutate_threads.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type resolveThreadParams struct {

--- a/internal/handlers/read_files.go
+++ b/internal/handlers/read_files.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type getFileVersionsParams struct {

--- a/internal/handlers/read_prs.go
+++ b/internal/handlers/read_prs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 type listPRsParams struct {

--- a/internal/server/dispatch.go
+++ b/internal/server/dispatch.go
@@ -6,7 +6,7 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // dispatch routes one request. hello is handled inline (no goroutine) so the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/seanhalberthal/differ.nvim/internal/handlers"
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/handlers"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // maxLine bounds a single request frame (large get_file_versions blobs land on

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanhalberthal/differ.nvim/internal/handlers"
-	"github.com/seanhalberthal/differ.nvim/internal/protocol"
+	"github.com/undont/differ.nvim/internal/handlers"
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 const helloLine = `{"id":1,"method":"hello","params":{"client":"differ.nvim","protocol":1}}`

--- a/test/unit/pr_repo_spec.lua
+++ b/test/unit/pr_repo_spec.lua
@@ -3,8 +3,8 @@ local repo = require("differ.pr.repo")
 describe("pr.repo.parse_remote", function()
     it("parses an scp-style git@github.com remote", function()
         assert.are.same(
-            { owner = "seanhalberthal", repo = "differ.nvim" },
-            repo.parse_remote("git@github.com:seanhalberthal/differ.nvim.git")
+            { owner = "undont", repo = "differ.nvim" },
+            repo.parse_remote("git@github.com:undont/differ.nvim.git")
         )
     end)
 


### PR DESCRIPTION
Mechanical rename of the GitHub account `seanhalberthal` to `undont`: module path, in-tree imports, references, and release/install URLs. No behaviour change. Existing release assets and clones keep working via GitHub's redirect.