### PR TITLE
chore: de-identify licence to undont

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Sean Halberthal
+Copyright (c) 2026 undont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
De-identify: replace the personal name in the licence with the github handle. No code/behaviour change.