### PR TITLE
feat: diff-window keymap cheatsheet, panel file verbs, and nav boundary feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- Floating keymap cheatsheet (`g?`) on the diff window and the in-review edit window, alongside the panel and history surfaces that already had it. The cheatsheet rows come from the live keymaps, so a configured `lhs` shows correctly, and it lists only the keys actually bound for the active source (staging, edit-in-review, and the session's extra maps such as the PR unviewed nav and thread/comment verbs)
+- File-targeted diff verbs from the panel: `de` (go to the real file) and `df` (edit the real file in review) act on the file row under the cursor, opening it first so they operate on it rather than the last-shown diff
+- The float help renderer extracted to a shared `differ.ui.help` module reused by the panel, history, and diff surfaces, with a configurable title and one blank row of padding above and below the keymap rows
+
+### Changed
+
+- The staging-review navigation now notifies at the change-set boundary instead of stopping silently. `s`/`u` past the last/first hunk and `S`/`U` past the last/first file echo "no more hunks/files to stage/unstage" when there is nowhere left to step. `step`, `goto_file`, and `step_file` now return whether they actually moved, which the hunk-nav and review callers key off (replacing the old before/after path comparison)
+- The diff view now opens one line above the first hunk so the hunk is visible with a line of context, rather than landing directly on it
+
+## [0.1.2] — 2026-06-23
+
+### Added
+
+- Directory and section staging in the panel: `s` / `u` / `X` act on a directory row (every file beneath it, scoped to its section) and on a section-header row (every file in that section). The header case is the only group target when a section's files share a deep prefix the tree strips to a subtitle, leaving no directory row. `S` / `U` stay global
+- Panel navigation keymaps: `gg` / `G` jump to the first / last file; `]]` / `[[` step between sections
+
+### Changed
+
+- Pure renames now open instead of reporting "no changes". A rename (`R`/`C` with no content edit) diffs to zero hunks, so selecting one previously never opened; the view now opens for renames and renders the moved file. Initial open (`:Differ`) and edge jumps (`[[` / `]]`) skip content-less renames and land on the first file with a real diff, while untracked files (zero numstat counts but full content) are still visited
+- Renamed the GitHub owner to `undont` across the repo, badges, and plugin spec; old paths redirect for a while so existing clones keep working
+- Updated the licence copyright holder to `undont`
+- Refreshed the README keymaps and added a vhs demo recording
+
+## [0.1.1] — 2026-06-20
+
+### Added
+
+- `command_alias` config (default `nil`): a string or list of strings (e.g. `"D"` or `{ "D", "Df" }`) that registers extra ex-commands routing to the same dispatcher as `:Differ`, so `:D HEAD~1` or `:D log` work. Completion is name-agnostic (keyed off token position), so aliases get full subcommand and rev completion. An invalid name (Vim requires an uppercase-leading user-command name) warns via `vim.notify` rather than aborting setup
+
+## [0.1.0] — 2026-06-20
+
+Initial release. One renderer drives local diffs, file history, staging, PR review, and merge conflicts, so every surface behaves like the same tool.
+
+### Diff engine & rendering
+
+- Stacked dual-rail layout: one scroll surface with old and new lines interleaved per hunk and both line numbers in the gutter via `statuscolumn`
+- Side-by-side layout from the same hunk model, switchable at runtime as a pure re-render
+- Word-level intra-hunk highlighting rendered as a same-hue background block, with whitespace-only spans dropped and order-aware similarity pairing for word-diff lines
+- Treesitter syntax on by default, so a diff reads like source rather than a grey block
+- Real buffer lines for code, so search, yank, and motions work; the hunk model is canonical and the buffer is a projection of it
+- One diff engine (`vim.diff()`, histogram) shared by every source
+- Split rows aligned by similarity, so a mid-hunk insertion opens filler in place
+- A full-width cursor-line overlay painted above the diff backgrounds; configurable context expansion (more / less context)
+
+### Command grammar & sessions
+
+- `:Differ [revspec]` with a git-mirroring grammar: bare (`HEAD` vs worktree), `<rev>`, two-dot `<a>..<b>`, three-dot `<a>...<b>` (merge-base), `<a>...` (branch total vs worktree), and `<a> <b>`
+- `:Differ base` and `:Differ log base` shortcuts
+- `:Differ <rev>` is idempotent: re-opening reopens over a live session
+- HEAD re-read per source build, so a branch switch updates the statusline label
+- Sessions end when the diff, panel, or compose window is navigated away
+
+### File panel & staging
+
+- Persistent sidebar with the changed-file tree, status icons, +/- counts, and tree / name listing modes
+- Hunk-level and file-level staging, with the panel staging at file level and the diff view at hunk level
+- Readable at depth: pinned diffstat, name truncation, deep-prefix subtitle, and fold operations
+- Panel sidebar toggles in place instead of ending the session; the diffstat stays next to the tree on full-width top/bottom panels
+- The diff cursor holds near its hunk across an external refresh
+
+### Edit in review
+
+- Edit the diffed file in place and write it back, with the diff cursor's column carried to the real file on `de` / `df`
+- Editing in review is blocked on `<rev>` versus worktree opens (where there is no single writable file)
+
+### File history
+
+- File history for single files and branch ranges, walked commit-by-commit, each step a diff through the same engine
+- Concurrent blob fetches and pinned-sha fast paths (pinned shas skip PR refs)
+
+### PR review (Go sidecar)
+
+- A supervised Go sidecar owns the GitHub API: stdio framing, a hello handshake, and restart-backoff supervision, so opening a PR or posting a review doesn't block the editor and results are cached between calls
+- PR picker, typed client, and file navigation
+- Inline review-thread overlay with thread/comment gestures: `gc` collapse, `]t` / `[t` thread nav, `gr` resolve, and a split-layout peek float showing comment times; the resolved tag sits on the footer rule in green and the peek float hides when focus leaves the diff columns
+- Review-authoring loop: pending-review drafts, commenting, submit / discard, delete-comment, and immediate posting that honours the one-pending-review rule; the active draft state shows in the diff winbar
+- Per-file viewed-state: `<Tab>` toggle, `]u` / `[u` nav, and neighbour prefetch
+- CI checks view and PR lifecycle verbs (merge, checkout, ready / draft, close), grouped by what they act on
+- An ISO-8601 timestamp parser for the timeline; a minimal PR overview page and timeline
+
+### 3-way merge tool
+
+- Reads merge-conflict stages and parses conflict markers into a 3-way model, carrying the `|||||||` / `=======` lines and ref labels through the parse
+- Lays out the base / ours / theirs columns through the n-column renderer with conflict navigation, locating each side's slab and folding the unchanged spans
+- Resolves conflicts in place and writes / stages on save; per-side colour, input sync, and raw editable markers
+- Bare `:Differ` routes to the merge tool mid-conflict; result-buffer diagnostics are cleared rather than merely hidden
+
+### Security
+
+- Server-side `expected_head` TOCTOU guard on mutating PR actions
+
+### Tooling & release
+
+- Prefix-driven auto-tagging and release notes, a PR-title check, and version stamping via ldflags
+- Build-on-install sidecar via the `make go-build` build hook (no prebuilt binaries)

--- a/lua/differ/history/init.lua
+++ b/lua/differ/history/init.lua
@@ -448,24 +448,28 @@ end
 
 -- ]f / [f. file mode: step to the next/previous commit. range mode: step file rows,
 -- crossing into the adjacent commit (auto-expanded) at a boundary. `keep_focus`
--- keeps focus in the diff window (in-view stepping)
+-- keeps focus in the diff window (in-view stepping). returns whether it actually
+-- stepped (false at the first/last commit or file row)
 ---@param direction "next"|"prev"
 ---@param keep_focus boolean|nil
+---@return boolean moved
 function History:step(direction, keep_focus)
     local fwd = direction == "next"
     if self.mode == "file" then
         local i = self.index + (fwd and 1 or -1)
         if i < 1 or i > #self.commits then
-            return
+            return false
         end
         self:_move_cursor(commit_line(i))
-        return self:_open(i, keep_focus)
+        self:_open(i, keep_focus)
+        return true
     end
 
     local ci = self.index
     local fi = (self.file_index or 1) + (fwd and 1 or -1)
     if fi >= 1 and fi <= #self:_files(ci) then
-        return self:_open_file(ci, fi, keep_focus)
+        self:_open_file(ci, fi, keep_focus)
+        return true
     end
     -- crossed the commit boundary: find the adjacent commit that has files
     local step = fwd and 1 or -1
@@ -473,10 +477,12 @@ function History:step(direction, keep_focus)
     while ti >= 1 and ti <= #self.commits do
         local files = self:_files(ti)
         if #files > 0 then
-            return self:_open_file(ti, fwd and 1 or #files, keep_focus)
+            self:_open_file(ti, fwd and 1 or #files, keep_focus)
+            return true
         end
         ti = ti + step
     end
+    return false
 end
 
 -- scroll the *diff view* a quarter page (the origin window), not the panel list,
@@ -495,7 +501,7 @@ end
 
 -- g?: a floating keymap cheatsheet, dismissed with <Esc> / q / g?
 function History:show_help()
-    local lines = { " differ file history", "" }
+    local lines = {}
     if self.mode == "range" then
         vim.list_extend(lines, {
             " <CR> / o   open file / toggle fold",
@@ -513,32 +519,7 @@ function History:show_help()
         " f / b      scroll diff down / up",
         " g?         this help",
     })
-    local width = 0
-    for _, l in ipairs(lines) do
-        width = math.max(width, #l)
-    end
-    local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-    vim.bo[buf].modifiable = false
-    vim.bo[buf].bufhidden = "wipe"
-    local win = vim.api.nvim_open_win(buf, true, {
-        relative = "editor",
-        width = width + 1,
-        height = #lines,
-        row = math.floor((vim.o.lines - #lines) / 2),
-        col = math.floor((vim.o.columns - width) / 2),
-        style = "minimal",
-        border = "rounded",
-        title = " Differ ",
-    })
-    local function close()
-        if vim.api.nvim_win_is_valid(win) then
-            pcall(vim.api.nvim_win_close, win, true)
-        end
-    end
-    for _, lhs in ipairs({ "q", "<Esc>", "g?" }) do
-        vim.keymap.set("n", lhs, close, { buffer = buf, nowait = true })
-    end
+    require("differ.ui.help").show(lines, { title = " Differ: history " })
 end
 
 -- window appearance + buffer-local keymaps

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -658,10 +658,12 @@ end
 
 -- ]f / [f: move to the next/prev file row and open it (lockstep file stepping).
 -- wraps at the ends by default; `wrap == false` (the staging review flow) stops at
--- them. `keep_focus` is threaded to `_open` so in-view stepping stays in the diff window
+-- them. `keep_focus` is threaded to `_open` so in-view stepping stays in the diff
+-- window. returns whether a file was actually opened (false at a no-wrap list end)
 ---@param direction "next"|"prev"
 ---@param keep_focus boolean|nil
 ---@param wrap? boolean  -- default true; false stops at the list ends
+---@return boolean moved
 function Panel:goto_file(direction, keep_focus, wrap)
     -- step from the live cursor when the sidebar is visible, else from the last
     -- opened row so ]f/[f keeps working with the panel hidden
@@ -670,7 +672,7 @@ function Panel:goto_file(direction, keep_focus, wrap)
         or self:_first_file_line()
     local i = self:_file_row(from, direction, wrap)
     if not i then
-        return
+        return false
     end
     -- the file being left, for an optional session step hook (the pr forward-auto-mark)
     local left = self.meta[from] and self.meta[from].kind == "file" and self.meta[from].entry or nil
@@ -682,6 +684,7 @@ function Panel:goto_file(direction, keep_focus, wrap)
     if self.on_step then
         self.on_step(direction, left, self.meta[i].entry)
     end
+    return true
 end
 
 -- a pure rename/copy (status R/C with no added/deleted lines) diffs to nothing, so
@@ -872,8 +875,6 @@ end
 -- g?: a floating keymap cheatsheet, dismissed with <Esc> / g?
 function Panel:show_help()
     local lines = {
-        " differ panel",
-        "",
         " <CR> / o   open file / toggle fold",
         " c          close node / parent",
         " C / O      close / open all nodes",
@@ -883,42 +884,19 @@ function Panel:show_help()
         " ]c / [c    next / previous hunk",
         " f / b      scroll diff down / up",
         " i          toggle listing (tree / name)",
+        " de         go to the real file",
     }
     if self.actions then
         vim.list_extend(lines, {
             " s / u      stage / unstage file",
             " S / U      stage / unstage all",
             " X          discard file (confirm)",
+            " df         edit the real file (in review)",
             " R          refresh",
         })
     end
     vim.list_extend(lines, { " g?         this help" })
-    local width = 0
-    for _, l in ipairs(lines) do
-        width = math.max(width, #l)
-    end
-    local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-    vim.bo[buf].modifiable = false
-    vim.bo[buf].bufhidden = "wipe"
-    local win = vim.api.nvim_open_win(buf, true, {
-        relative = "editor",
-        width = width + 1,
-        height = #lines,
-        row = math.floor((vim.o.lines - #lines) / 2),
-        col = math.floor((vim.o.columns - width) / 2),
-        style = "minimal",
-        border = "rounded",
-        title = " Differ ",
-    })
-    local function close()
-        if vim.api.nvim_win_is_valid(win) then
-            pcall(vim.api.nvim_win_close, win, true)
-        end
-    end
-    for _, lhs in ipairs({ "q", "<Esc>", "g?" }) do
-        vim.keymap.set("n", lhs, close, { buffer = buf, nowait = true })
-    end
+    require("differ.ui.help").show(lines, { title = " Differ: panel " })
 end
 
 -- window appearance + buffer-local keymaps
@@ -986,6 +964,20 @@ function Panel:_setup_window()
     local function map(spec, fn, desc)
         bind(self.bufnr, spec, fn, "differ panel: " .. desc)
     end
+    -- de / df: file-targeted diff verbs (go-to-file, edit-in-review). open the row
+    -- under the cursor first so they act on it, not the last-shown diff, then defer to
+    -- the shared entry points, which act on the driven view and self-guard by source
+    local function diff_file_verb(run)
+        local lnum = vim.api.nvim_win_get_cursor(self.winid)[1]
+        local m = self.meta[lnum]
+        if not (m and m.kind == "file") then
+            return vim.notify("differ: put the cursor on a file", vim.log.levels.WARN)
+        end
+        if lnum ~= self.selected_row then
+            self:select()
+        end
+        run()
+    end
     map(km.select, function()
         self:select()
     end, "open / toggle fold")
@@ -1015,6 +1007,11 @@ function Panel:_setup_window()
     map(km.prev_hunk, function()
         require("differ").goto_hunk("prev")
     end, "previous hunk")
+    map(km.goto_file, function()
+        diff_file_verb(function()
+            require("differ").jump_to_file()
+        end)
+    end, "go to the real file")
     map(km.help, function()
         self:show_help()
     end, "help")
@@ -1055,6 +1052,11 @@ function Panel:_setup_window()
         map(km.refresh, function()
             self:refresh()
         end, "refresh")
+        map(km.edit_file, function()
+            diff_file_verb(function()
+                require("differ").edit_file()
+            end)
+        end, "edit the real file")
     end
     -- session-supplied maps the generic panel doesn't own (e.g. the pr viewed nav)
     for _, m in ipairs(self.extra_keymaps or {}) do

--- a/lua/differ/ui/help.lua
+++ b/lua/differ/ui/help.lua
@@ -1,0 +1,44 @@
+-- floating keymap cheatsheet shared by the panel, history and diff surfaces.
+-- takes prebuilt lines (each " lhs   desc") and opens a centred minimal float,
+-- dismissed with q / <Esc> / g? (or the caller's own dismiss keys)
+
+local M = {}
+
+---@param lines string[]
+---@param opts? { title?: string, dismiss?: string[] }
+function M.show(lines, opts)
+    opts = opts or {}
+    local width = 0
+    for _, l in ipairs(lines) do
+        width = math.max(width, #l)
+    end
+    -- one blank row of breathing space above and below the keymap rows
+    local padded = { "" }
+    vim.list_extend(padded, lines)
+    padded[#padded + 1] = ""
+    lines = padded
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.bo[buf].modifiable = false
+    vim.bo[buf].bufhidden = "wipe"
+    local win = vim.api.nvim_open_win(buf, true, {
+        relative = "editor",
+        width = width + 1,
+        height = #lines,
+        row = math.floor((vim.o.lines - #lines) / 2),
+        col = math.floor((vim.o.columns - width) / 2),
+        style = "minimal",
+        border = "rounded",
+        title = opts.title or " Differ ",
+    })
+    local function close()
+        if vim.api.nvim_win_is_valid(win) then
+            pcall(vim.api.nvim_win_close, win, true)
+        end
+    end
+    for _, lhs in ipairs(opts.dismiss or { "q", "<Esc>", "g?" }) do
+        vim.keymap.set("n", lhs, close, { buffer = buf, nowait = true })
+    end
+end
+
+return M

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -534,6 +534,9 @@ function View:_setup_window(winid, bufnr)
     bind(bufnr, km.scroll_up, function()
         self:quarter_scroll("up")
     end, "differ: scroll up a quarter page")
+    bind(bufnr, km.help, function()
+        self:show_help()
+    end, "differ: keymap help")
     -- stage / unstage the hunk under the cursor, hunk-level here vs file-level
     -- in the panel. bound for the whole worktree-status session; the per-file
     -- direction is checked at call time (the buffer is read-only, so shadowing native
@@ -559,26 +562,28 @@ end
 
 -- step the file panel's selection (and re-source this view) without leaving the diff
 -- window, the in-view counterpart to the panel's own ]f / [f. `wrap` defaults on (for
--- ]f / [f); the staging review flow passes false so s/S/u/U stop at the list ends
+-- ]f / [f); the staging review flow passes false so s/S/u/U stop at the list ends.
+-- returns whether a file/commit was actually opened (false at a no-wrap list end),
+-- which the hunk-nav and review callers use to notify at the change-set boundary
 ---@param direction "next"|"prev"
 ---@param wrap? boolean
+---@return boolean moved
 function View:step_file(direction, wrap)
     local panel = require("differ.panel").current()
     if panel and panel:is_open() then
-        panel:goto_file(direction, true, wrap) -- keep focus in the diff window
-        return
+        return panel:goto_file(direction, true, wrap) -- keep focus in the diff window
     end
     -- file history: one file, so ]f / [f step commits instead
     local history = require("differ.history").current()
     if history and history:is_open() then
-        history:step(direction, true)
-        return
+        return history:step(direction, true)
     end
     -- sidebar hidden but the panel session is live: step from internal selection so
     -- ]f / [f still walk files with no panel window to read the cursor from
     if panel then
-        panel:goto_file(direction, true, wrap)
+        return panel:goto_file(direction, true, wrap)
     end
+    return false
 end
 
 -- scroll a quarter of the window height, cursor following (count-prefixed <C-d>/
@@ -587,6 +592,51 @@ end
 function View:quarter_scroll(direction)
     local n = math.max(1, math.floor(vim.api.nvim_win_get_height(0) / 4))
     vim.api.nvim_feedkeys(n .. (direction == "down" and CTRL_D or CTRL_U), "nx", false)
+end
+
+-- g?: a floating keymap cheatsheet for the diff window, mirroring the panel's.
+-- rows come from the live keymaps (so a configured lhs shows correctly) and list
+-- only the keys actually bound for this source: staging, edit-in-review, and the
+-- session's extra maps (the pr unviewed nav and thread/comment verbs)
+function View:show_help()
+    local km = self.keymaps
+    local function fmt(spec)
+        return type(spec) == "table" and table.concat(spec, " / ") or tostring(spec)
+    end
+    local function pair(a, b)
+        return fmt(a) .. " / " .. fmt(b)
+    end
+    local rows = {
+        { pair(km.next_hunk, km.prev_hunk), "next / previous hunk" },
+        { pair(km.next_file, km.prev_file), "next / previous file" },
+        { pair(km.scroll_down, km.scroll_up), "scroll down / up" },
+        { pair(km.more_context, km.less_context), "more / less context" },
+        { fmt(km.goto_file), "go to the real file" },
+    }
+    if self:_editable_source() then
+        rows[#rows + 1] = { fmt(km.edit_file), "edit the real file (in review)" }
+    end
+    if self.can_stage then
+        rows[#rows + 1] = { pair(km.stage, km.unstage), "stage / unstage hunk" }
+        rows[#rows + 1] = { pair(km.stage_all, km.unstage_all), "stage / unstage all" }
+    end
+    for _, m in ipairs(self.extra_keymaps or {}) do
+        rows[#rows + 1] = { fmt(m.spec), m.desc }
+    end
+    rows[#rows + 1] = { fmt(km.help), "this help" }
+
+    local keyw = 0
+    for _, r in ipairs(rows) do
+        keyw = math.max(keyw, #r[1])
+    end
+    local lines = {}
+    for _, r in ipairs(rows) do
+        lines[#lines + 1] = (" %-" .. keyw .. "s   %s"):format(r[1], r[2])
+    end
+    -- dismiss on the configured help key too, not just the hardcoded g?
+    local dismiss = { "q", "<Esc>" }
+    vim.list_extend(dismiss, type(km.help) == "table" and km.help or { km.help })
+    require("differ.ui.help").show(lines, { title = " Differ: diff ", dismiss = dismiss })
 end
 
 -- the column whose window is currently focused, defaulting to the first. split
@@ -620,13 +670,14 @@ function View:goto_hunk(direction)
     if target then
         vim.api.nvim_win_set_cursor(col.winid or win, { target, 0 })
     elseif direction == "next" then
-        self:step_file("next", false) -- past the last hunk: flow into the next file (no wrap)
-    else
-        local before = self.model.path
-        self:step_file("prev", false) -- before the first hunk: flow into the previous file
-        if self.model.path ~= before then
-            self:_focus_last_hunk() -- land on its last hunk, continuing the backward flow
+        -- past the last hunk: flow into the next file (no wrap), or notify at the last one
+        if not self:step_file("next", false) then
+            vim.notify("differ: no next hunk", vim.log.levels.INFO)
         end
+    elseif self:step_file("prev", false) then
+        self:_focus_last_hunk() -- landed on the previous file: continue the backward flow
+    else
+        vim.notify("differ: no previous hunk", vim.log.levels.INFO)
     end
 end
 
@@ -650,14 +701,20 @@ end
 
 -- move the primary window's cursor to the first unstaged hunk (or first hunk). run
 -- on open and on every file switch so ]f / [f and selecting a file drop you on the
--- first thing to review rather than wherever the cursor happened to be
-function View:_focus_first_hunk()
+-- first thing to review rather than wherever the cursor happened to be. `above` lands
+-- one line up (the context line) so the first change is visible with a line above it,
+-- used on the initial open; file switches land directly on the hunk
+---@param above? boolean
+function View:_focus_first_hunk(above)
     local col = self.columns[1]
     if not (col and col.winid and vim.api.nvim_win_is_valid(col.winid)) then
         return
     end
     local lnum = self:_first_review_line(col)
     if lnum then
+        if above then
+            lnum = math.max(1, lnum - 1)
+        end
         pcall(vim.api.nvim_win_set_cursor, col.winid, { lnum, 0 })
     end
 end
@@ -812,8 +869,8 @@ function View:_advance_review()
     local target = nav.next_hunk(col.map, vim.api.nvim_win_get_cursor(win)[1])
     if target then
         vim.api.nvim_win_set_cursor(win, { target, 0 })
-    else
-        self:step_file("next", false) -- review flow: stop at the last file, don't wrap
+    elseif not self:step_file("next", false) then -- review flow: stop at the last file, don't wrap
+        vim.notify("differ: no more hunks to stage", vim.log.levels.INFO)
     end
 end
 
@@ -841,12 +898,10 @@ function View:_retreat_review()
     local target = nav.prev_hunk(col.map, vim.api.nvim_win_get_cursor(win)[1])
     if target then
         vim.api.nvim_win_set_cursor(win, { target, 0 })
+    elseif self:step_file("prev", false) then -- review flow: stop at the first file, don't wrap
+        self:_focus_last_hunk() -- only when a previous file actually opened
     else
-        local before = self.model.path
-        self:step_file("prev", false) -- review flow: stop at the first file, don't wrap
-        if self.model.path ~= before then -- only when a previous file actually opened
-            self:_focus_last_hunk()
-        end
+        vim.notify("differ: no more hunks to unstage", vim.log.levels.INFO)
     end
 end
 
@@ -875,7 +930,9 @@ end
 -- to do), step to the next file, the file-level echo of s advancing past the last hunk
 function View:stage_all()
     if not self:_toggle_all(true) and self.can_stage and self.staging then
-        self:step_file("next", false) -- stop at the last file, don't wrap
+        if not self:step_file("next", false) then -- stop at the last file, don't wrap
+            vim.notify("differ: no more files to stage", vim.log.levels.INFO)
+        end
     end
 end
 
@@ -883,10 +940,10 @@ end
 -- landing on its last hunk, the file-level echo of u retreating past the first hunk
 function View:unstage_all()
     if not self:_toggle_all(false) and self.can_stage and self.staging then
-        local before = self.model.path
-        self:step_file("prev", false) -- stop at the first file, don't wrap
-        if self.model.path ~= before then -- only when a previous file actually opened
-            self:_focus_last_hunk()
+        if self:step_file("prev", false) then -- stop at the first file, don't wrap
+            self:_focus_last_hunk() -- only when a previous file actually opened
+        else
+            vim.notify("differ: no more files to unstage", vim.log.levels.INFO)
         end
     end
 end
@@ -1068,6 +1125,11 @@ function View:_open_edit_window(abs, target, tcol, anchor_win)
     if target then
         place_cursor(target, tcol)
     end
+    -- bind g? on the real-file buffer too, so the cheatsheet is reachable from the
+    -- edit window (shadows native g?/rot13, inert in this review flow)
+    bind(vim.api.nvim_get_current_buf(), self.keymaps.help, function()
+        self:show_help()
+    end, "differ: keymap help")
 end
 
 -- drop the edit window without losing work: a window holding unsaved edits is left
@@ -1190,7 +1252,7 @@ end
 ---@return differ.View
 function View:open()
     self:_relayout()
-    self:_focus_first_hunk() -- start on the first unstaged hunk, not line 1
+    self:_focus_first_hunk(true) -- start one line above the first hunk so it's visible with context
     self:_paint_cursorline() -- repaint after the cursor moved off line 1
     return self
 end


### PR DESCRIPTION
## Summary

Adds a `g?` keymap cheatsheet to the diff and in-review edit windows, file-targeted verbs from the panel, and boundary feedback during staging-review navigation.

## Changes

- **Diff-window cheatsheet (`g?`)**: a floating cheatsheet on the diff and in-review edit windows, mirroring the panel and history surfaces. Rows come from the live keymaps, so a configured `lhs` shows correctly, and it lists only the keys bound for the active source (staging, edit-in-review, and the session's extra maps).
- **Shared help renderer**: the float renderer is extracted to `differ.ui.help`, reused by the panel, history, and diff surfaces, with a configurable title and a blank row of padding above and below the keymap rows.
- **Panel file verbs**: `de` (go to the real file) and `df` (edit the real file in review) act on the file row under the cursor, opening it first so they operate on it rather than the last-shown diff.
- **Nav boundary feedback**: `s`/`u` past the last/first hunk and `S`/`U` past the last/first file now notify (`no more hunks/files to stage/unstage`) instead of stopping silently. `step`, `goto_file`, and `step_file` now return whether they actually moved, replacing the old before/after path comparison.
- **First-hunk framing**: the diff view opens one line above the first hunk so it's visible with a line of context.
- Adds `CHANGELOG.md`.
