### PR TITLE
feat: merge-tool fixes and diff cursor-line tint

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ require("differ").diff({
 require("differ").setup({
   layout = "stacked",            -- "stacked" | "split", toggleable per-view
   context = 10,                  -- context lines (math.huge = full file)
+  cursorline_tint = true,        -- tint the cursor line by add/remove so the change
+                                 -- kind reads under the cursor; false = plain neutral
   deep_diff = {
     enabled = true,
     granularity = "word",        -- "word" | "char"

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Buffer-local, scoped to each surface. All configurable via `keymaps` in `setup()
 | `q` | Close the merge tool |
 | `g?` | Help |
 
+The result buffer is the real worktree file, so `:w` writes it and stages it once the markers are gone. Because it's a real file, a format-on-save would otherwise run over the conflict markers; the merge tool sets `vim.b.disable_autoformat` (conform's opt-out) for the session, so honour that flag in your `format_on_save` gate if you format on save.
+
 ### Launchers (a starting point)
 
 differ ships no global launchers — only the in-view buffer maps above and the optional `command_alias`. These are the `<leader>` launchers I drive it with, as a lazy.nvim spec you can lift wholesale or trim to taste.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Buffer-local, scoped to each surface. All configurable via `keymaps` in `setup()
 | `<leader>co` / `ct` / `cb` | Take ours / theirs / base |
 | `<leader>ca` | Take both (ours then theirs) |
 | `dx` | Drop the conflict region |
+| `q` | Close the merge tool |
+| `g?` | Help |
 
 ### Launchers (a starting point)
 

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -12,6 +12,7 @@
 ---@field context integer
 ---@field wrap boolean
 ---@field diff_counter boolean
+---@field cursorline_tint boolean
 ---@field deep_diff { enabled: boolean, granularity: "word"|"char", similarity_threshold: number }
 ---@field comments { inline: boolean, collapsed: boolean }
 ---@field panel differ.Config.Panel
@@ -34,6 +35,10 @@ M.defaults = {
     context = 10, -- generous default; tight context makes diffs hard to read
     wrap = true, -- soft-wrap long lines in the diff view
     diff_counter = true, -- "hunk K/N" counter in the diff window's winbar
+    -- tint the diff cursor line by the line's change kind (a stronger add/delete
+    -- shade) so the add/remove colour survives under the cursor; false falls back to
+    -- a plain neutral cursor line
+    cursorline_tint = true,
     deep_diff = {
         enabled = true,
         granularity = "word",

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -80,6 +80,7 @@ function M.diff_model(model, opts)
             context = opts.context or cfg.context,
             wrap = cfg.wrap,
             counter = cfg.diff_counter,
+            cursorline_tint = cfg.cursorline_tint,
             deep_diff = cfg.deep_diff,
             keymaps = cfg.keymaps.diff,
             staging = opts.staging,

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -59,6 +59,7 @@ local INPUT_HL = {
 ---@field return_tab integer
 ---@field session_tab integer
 ---@field keymaps table                   -- resolved merge keymaps (for the g? cheatsheet)
+---@field saved_autoformat any            -- the result buffer's prior disable_autoformat, restored on close
 ---@field diag_aug integer|nil            -- the DiagnosticChanged hook that hushes the result
 
 ---@type differ.MergeSession|nil
@@ -518,6 +519,9 @@ function M.close()
     local s = session
     session = nil
     restore_timeout() -- net in case the tab teardown didn't fire BufLeave on the result buf
+    if vim.api.nvim_buf_is_valid(s.result_buf) then
+        vim.b[s.result_buf].disable_autoformat = s.saved_autoformat -- give autoformat back
+    end
     -- drop the diagnostics hook; the producers re-lint the now-resolved file on their own
     if s.diag_aug then
         pcall(vim.api.nvim_del_augroup_by_id, s.diag_aug)
@@ -679,6 +683,11 @@ local function lay_out(root, relpath, model, layout)
     local cfg = require("differ").get_config()
     local km = cfg.keymaps.merge or require("differ.config").defaults.keymaps
     session.keymaps = km -- for the g? cheatsheet
+    -- the result is the real file, so a format-on-save would run on :w and choke on (or
+    -- mangle) the conflict markers. set conform's buffer-local opt-out for the session,
+    -- restored on close; honoured by any format_on_save gate that checks the flag
+    session.saved_autoformat = vim.b[result_buf].disable_autoformat
+    vim.b[result_buf].disable_autoformat = true
     local function rb(action, fn, desc)
         bind(result_buf, km[action], fn, desc)
     end

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -58,6 +58,7 @@ local INPUT_HL = {
 ---@field win_side table<integer, string> -- window id -> side (for the winbar)
 ---@field return_tab integer
 ---@field session_tab integer
+---@field keymaps table                   -- resolved merge keymaps (for the g? cheatsheet)
 ---@field diag_aug integer|nil            -- the DiagnosticChanged hook that hushes the result
 
 ---@type differ.MergeSession|nil
@@ -537,6 +538,44 @@ function M.close()
     end
 end
 
+-- g?: a floating keymap cheatsheet for the merge result buffer, mirroring the diff
+-- view's. rows read the session's resolved keymaps so a configured lhs shows correctly
+local function show_help()
+    if not session then
+        return
+    end
+    local km = session.keymaps
+    local function fmt(spec)
+        return type(spec) == "table" and table.concat(spec, " / ") or tostring(spec)
+    end
+    local function pair(a, b)
+        return fmt(a) .. " / " .. fmt(b)
+    end
+    local rows = {
+        { pair(km.next_conflict, km.prev_conflict), "next / previous conflict" },
+        { fmt(km.choose_ours), "take ours" },
+        { fmt(km.choose_theirs), "take theirs" },
+        { fmt(km.choose_base), "take base" },
+        { fmt(km.choose_all), "take both (ours then theirs)" },
+        { fmt(km.choose_none), "drop the conflict" },
+        { ":w", "write the file (auto-stages once resolved)" },
+        { "q", "close the merge tool" },
+        { fmt(km.help), "this help" },
+    }
+    local keyw = 0
+    for _, r in ipairs(rows) do
+        keyw = math.max(keyw, #r[1])
+    end
+    local lines = {}
+    for _, r in ipairs(rows) do
+        lines[#lines + 1] = (" %-" .. keyw .. "s   %s"):format(r[1], r[2])
+    end
+    -- dismiss on the configured help key too, not just the hardcoded q/<Esc>
+    local dismiss = { "q", "<Esc>" }
+    vim.list_extend(dismiss, type(km.help) == "table" and km.help or { km.help })
+    require("differ.ui.help").show(lines, { title = " Differ: merge ", dismiss = dismiss })
+end
+
 -- lay out the render in a fresh session tab and wire navigation
 ---@param root string
 ---@param relpath string
@@ -639,6 +678,7 @@ local function lay_out(root, relpath, model, layout)
     -- wasn't called, like the diff view does
     local cfg = require("differ").get_config()
     local km = cfg.keymaps.merge or require("differ.config").defaults.keymaps
+    session.keymaps = km -- for the g? cheatsheet
     local function rb(action, fn, desc)
         bind(result_buf, km[action], fn, desc)
     end
@@ -663,6 +703,7 @@ local function lay_out(root, relpath, model, layout)
     rb("choose_none", function()
         resolve_choice("none")
     end, "differ: drop the conflict")
+    rb("help", show_help, "differ: keymap help")
     -- q closes the tool (conventional, no config action)
     vim.keymap.set(
         "n",

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -63,6 +63,28 @@ local INPUT_HL = {
 ---@type differ.MergeSession|nil
 local session = nil
 
+-- the result-buffer conflict chords (<leader>co/ct/cb/ca, dx) are multi-key, so nvim waits
+-- timeoutlen for the completing key. a short global timeoutlen (which-key setups often run
+-- 200ms) drops them unless typed fast, so widen the window to a generous floor while the
+-- cursor sits in the result buffer and restore the user's value on leave/close. timeoutlen
+-- is global-only (no buffer scope), hence a save/restore rather than set_local; the nil
+-- guard keeps it re-entrant and never lowers an already-larger setting
+local saved_timeoutlen = nil
+
+local function bump_timeout()
+    if saved_timeoutlen == nil then
+        saved_timeoutlen = vim.o.timeoutlen
+        vim.o.timeoutlen = math.max(saved_timeoutlen, 1000)
+    end
+end
+
+local function restore_timeout()
+    if saved_timeoutlen ~= nil then
+        vim.o.timeoutlen = saved_timeoutlen
+        saved_timeoutlen = nil
+    end
+end
+
 ---@param msg string
 ---@param level integer|nil
 local function notify(msg, level)
@@ -494,6 +516,7 @@ function M.close()
     end
     local s = session
     session = nil
+    restore_timeout() -- net in case the tab teardown didn't fire BufLeave on the result buf
     -- drop the diagnostics hook; the producers re-lint the now-resolved file on their own
     if s.diag_aug then
         pcall(vim.api.nvim_del_augroup_by_id, s.diag_aug)
@@ -672,6 +695,18 @@ local function lay_out(root, relpath, model, layout)
         buffer = result_buf,
         group = aug,
         callback = on_cursor_moved,
+    })
+    -- widen the mapping timeout while focused in the result buffer so the multi-key
+    -- conflict chords land at any pace, not just under a short global timeoutlen
+    vim.api.nvim_create_autocmd("BufEnter", {
+        buffer = result_buf,
+        group = aug,
+        callback = bump_timeout,
+    })
+    vim.api.nvim_create_autocmd("BufLeave", {
+        buffer = result_buf,
+        group = aug,
+        callback = restore_timeout,
     })
     -- a hand-edit shifts the marker lines: re-parse + repaint so the regions, colour, and
     -- nav stay aligned to the live buffer (not just on splice/:w). InsertLeave covers a run

--- a/lua/differ/ui/highlights.lua
+++ b/lua/differ/ui/highlights.lua
@@ -205,10 +205,15 @@ end
 ---@return table<string, vim.api.keyset.highlight>
 local function diff_bg_groups(p)
     local base = bg_of({ "Normal" }, 0x14161b)
-    local line, word = 0.16, 0.42 -- blend weights toward the vivid colour; tune to taste
+    local line, cursor, word = 0.16, 0.28, 0.42 -- blend weights toward the vivid colour; tune to taste
     return {
         differLineAdd = { bg = blend(p.green, base, line) },
         differLineDelete = { bg = blend(p.red, base, line) },
+        -- the cursor line over an add/delete line: the same hue a notch stronger than the
+        -- line tint, so it reads as the current line yet still as added/removed (word
+        -- spans at 0.42 still show through). sit between the line and word weights
+        differCursorLineAdd = { bg = blend(p.green, base, cursor) },
+        differCursorLineDelete = { bg = blend(p.red, base, cursor) },
         differWordAdd = { bg = blend(p.green, base, word) },
         differWordDelete = { bg = blend(p.red, base, word) },
     }

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -72,6 +72,7 @@ local armed_view = nil
 ---@field context integer
 ---@field wrap boolean  -- soft-wrap long lines in the diff windows
 ---@field counter boolean  -- hunk-counter winbar on the diff windows
+---@field cursorline_tint boolean  -- tint the cursor line by add/delete kind
 ---@field deep_diff table
 ---@field keymaps table
 ---@field can_stage boolean  -- session-level: bind s/u (worktree-status panels)
@@ -94,6 +95,7 @@ View.__index = View
 ---@field context integer
 ---@field wrap? boolean
 ---@field counter? boolean
+---@field cursorline_tint? boolean
 ---@field deep_diff table
 ---@field keymaps? table
 ---@field staging? differ.view.Staging
@@ -116,6 +118,7 @@ function View.new(model, opts)
         context = opts.context,
         wrap = opts.wrap ~= false, -- default on; only an explicit false disables it
         counter = opts.counter ~= false, -- default on; only an explicit false disables it
+        cursorline_tint = opts.cursorline_tint ~= false, -- default on; explicit false disables
         deep_diff = opts.deep_diff,
         -- the diff surface's resolved action -> lhs map; default to the shared
         -- defaults so a directly-constructed View still binds (merge keeps partials)
@@ -314,9 +317,10 @@ end
 -- CursorLine is low-priority and gets buried by them. mirrors the diff line bg
 -- (a char-level fill with hl_eol so it spans the whole row past EOL) but at a higher
 -- priority so it wins; bg-only, so syntax foreground and word spans still show
--- through. cleared from every column and painted only in the focused one (the cursor
--- lives in one column), so the off-side column shows none. driven by CursorMoved /
--- WinEnter and after each render
+-- through. with cursorline_tint on, the fill takes the row's add/delete shade so the
+-- change kind reads under the cursor instead of a neutral wash. cleared from every
+-- column and painted only in the focused one (the cursor lives in one column), so the
+-- off-side column shows none. driven by CursorMoved / WinEnter and after each render
 function View:_paint_cursorline()
     for _, col in ipairs(self.columns) do
         if col.bufnr and vim.api.nvim_buf_is_valid(col.bufnr) then
@@ -329,10 +333,22 @@ function View:_paint_cursorline()
         return
     end
     local row = vim.api.nvim_win_get_cursor(win)[1] - 1
+    -- tint the cursor line by the row's change kind so the add/remove colour survives
+    -- under the cursor (a neutral overlay would bury it); plain neutral when off
+    local hl = "differCursorLine"
+    if self.cursorline_tint then
+        local line = col.map.lines[row + 1]
+        local kind = line and line.kind
+        if kind == "new" then
+            hl = "differCursorLineAdd"
+        elseif kind == "old" then
+            hl = "differCursorLineDelete"
+        end
+    end
     vim.api.nvim_buf_set_extmark(col.bufnr, cursor_ns, row, 0, {
         end_row = row + 1,
         end_col = 0,
-        hl_group = "differCursorLine",
+        hl_group = hl,
         hl_eol = true, -- fill past EOL so the whole row is covered, like the diff bg
         priority = 160, -- above the add/delete bg (100); word spans (200) show through
     })

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -717,20 +717,14 @@ end
 
 -- move the primary window's cursor to the first unstaged hunk (or first hunk). run
 -- on open and on every file switch so ]f / [f and selecting a file drop you on the
--- first thing to review rather than wherever the cursor happened to be. `above` lands
--- one line up (the context line) so the first change is visible with a line above it,
--- used on the initial open; file switches land directly on the hunk
----@param above? boolean
-function View:_focus_first_hunk(above)
+-- first thing to review rather than wherever the cursor happened to be
+function View:_focus_first_hunk()
     local col = self.columns[1]
     if not (col and col.winid and vim.api.nvim_win_is_valid(col.winid)) then
         return
     end
     local lnum = self:_first_review_line(col)
     if lnum then
-        if above then
-            lnum = math.max(1, lnum - 1)
-        end
         pcall(vim.api.nvim_win_set_cursor, col.winid, { lnum, 0 })
     end
 end
@@ -1268,8 +1262,8 @@ end
 ---@return differ.View
 function View:open()
     self:_relayout()
-    self:_focus_first_hunk(true) -- start one line above the first hunk so it's visible with context
-    self:_paint_cursorline() -- repaint after the cursor moved off line 1
+    self:_focus_first_hunk() -- land on the first hunk; the tinted cursor line shows its kind
+    self:_paint_cursorline()
     return self
 end
 

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -197,6 +197,37 @@ describe(":Differ mergetool", function()
         assert.are.equal(1500, vim.o.timeoutlen)
         vim.o.timeoutlen = saved
     end)
+
+    it("opens a g? keymap cheatsheet listing the conflict verbs", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = merge.current()
+
+        local cb
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(s.result_buf, "n")) do
+            if m.desc == "differ: keymap help" then
+                cb = m.callback
+            end
+        end
+        assert.is_not_nil(cb)
+
+        cb() -- opens the floating cheatsheet
+        local float
+        for _, w in ipairs(vim.api.nvim_list_wins()) do
+            if vim.api.nvim_win_get_config(w).relative ~= "" then
+                float = w
+            end
+        end
+        assert.is_not_nil(float)
+        local txt = table.concat(
+            vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(float), 0, -1, false),
+            "\n"
+        )
+        assert.is_true(txt:find("take ours", 1, true) ~= nil)
+        assert.is_true(txt:find("next / previous conflict", 1, true) ~= nil)
+        vim.api.nvim_win_close(float, true)
+    end)
 end)
 
 -- fire a buffer-local keymap by its description, so the test doesn't depend on <leader>

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -173,6 +173,30 @@ describe(":Differ mergetool", function()
         merge.close()
         assert.is_nil(merge.current())
     end)
+
+    it("widens a short timeoutlen in the result buffer and restores it on close", function()
+        local root = conflict_repo()
+        local saved = vim.o.timeoutlen
+        vim.o.timeoutlen = 200 -- a short which-key-style window the chords can't land in
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({}) -- lands in the result buffer, firing the bump
+        assert.is_true(vim.o.timeoutlen >= 1000)
+        merge.close()
+        assert.are.equal(200, vim.o.timeoutlen)
+        vim.o.timeoutlen = saved
+    end)
+
+    it("never lowers an already-generous timeoutlen", function()
+        local root = conflict_repo()
+        local saved = vim.o.timeoutlen
+        vim.o.timeoutlen = 1500
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        assert.are.equal(1500, vim.o.timeoutlen)
+        merge.close()
+        assert.are.equal(1500, vim.o.timeoutlen)
+        vim.o.timeoutlen = saved
+    end)
 end)
 
 -- fire a buffer-local keymap by its description, so the test doesn't depend on <leader>

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -228,6 +228,17 @@ describe(":Differ mergetool", function()
         assert.is_true(txt:find("next / previous conflict", 1, true) ~= nil)
         vim.api.nvim_win_close(float, true)
     end)
+
+    it("opts the result buffer out of format-on-save and restores it on close", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = merge.current()
+        assert.is_true(vim.b[s.result_buf].disable_autoformat)
+        local buf = s.result_buf
+        merge.close()
+        assert.is_nil(vim.b[buf].disable_autoformat) -- restored to its prior (unset) value
+    end)
 end)
 
 -- fire a buffer-local keymap by its description, so the test doesn't depend on <leader>

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -705,14 +705,29 @@ end)
 describe("view cursor-line overlay", function()
     local cursor_ns = vim.api.nvim_create_namespace("differ.cursorline")
 
+    local CURSORLINE = {
+        differCursorLine = true,
+        differCursorLineAdd = true,
+        differCursorLineDelete = true,
+    }
+
     local function overlay_rows(buf)
         local rows = {}
         for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, cursor_ns, 0, -1, { details = true })) do
-            if m[4].hl_group == "differCursorLine" then
+            if CURSORLINE[m[4].hl_group] then
                 rows[#rows + 1] = m[2]
             end
         end
         return rows
+    end
+
+    -- the cursorline hl_group at 0-based `row`, or nil
+    local function overlay_hl(buf, row)
+        for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, cursor_ns, 0, -1, { details = true })) do
+            if CURSORLINE[m[4].hl_group] and m[2] == row then
+                return m[4].hl_group
+            end
+        end
     end
 
     it("paints one overlay on the cursor row and follows the cursor", function()
@@ -746,6 +761,67 @@ describe("view cursor-line overlay", function()
         -- focus opens on the first column; the off-side column carries no overlay
         assert.are.equal(1, #overlay_rows(left.bufnr))
         assert.are.equal(0, #overlay_rows(right.bufnr))
+        v:close()
+    end)
+
+    it("tints the cursor overlay by the row's add/delete kind", function()
+        vim.cmd("silent! only")
+        local v = View.new(model("a\nb\nc\n", "a\nB\nc\n"), {
+            layout = "stacked",
+            context = math.huge,
+            deep_diff = { enabled = true },
+        })
+        v:open()
+        local buf, win = v.columns[1].bufnr, v.columns[1].winid
+        local line_hl = extmarks(buf)
+        local add_row, del_row, ctx_row
+        for row = 0, vim.api.nvim_buf_line_count(buf) - 1 do
+            if line_hl[row] == "differLineAdd" then
+                add_row = add_row or row
+            elseif line_hl[row] == "differLineDelete" then
+                del_row = del_row or row
+            elseif line_hl[row] == nil then
+                ctx_row = ctx_row or row
+            end
+        end
+        assert.is_not_nil(add_row)
+        assert.is_not_nil(del_row)
+
+        local function hl_at(row)
+            vim.api.nvim_win_set_cursor(win, { row + 1, 0 })
+            vim.api.nvim_exec_autocmds("CursorMoved", { buffer = buf })
+            return overlay_hl(buf, row)
+        end
+        assert.are.equal("differCursorLineAdd", hl_at(add_row))
+        assert.are.equal("differCursorLineDelete", hl_at(del_row))
+        if ctx_row then
+            assert.are.equal("differCursorLine", hl_at(ctx_row)) -- neutral off the change
+        end
+        v:close()
+    end)
+
+    it("falls back to a neutral overlay when cursorline_tint is false", function()
+        vim.cmd("silent! only")
+        local v = View.new(model("a\nb\nc\n", "a\nB\nc\n"), {
+            layout = "stacked",
+            context = math.huge,
+            deep_diff = { enabled = true },
+            cursorline_tint = false,
+        })
+        v:open()
+        local buf, win = v.columns[1].bufnr, v.columns[1].winid
+        local line_hl = extmarks(buf)
+        local chg_row
+        for row = 0, vim.api.nvim_buf_line_count(buf) - 1 do
+            if line_hl[row] == "differLineAdd" or line_hl[row] == "differLineDelete" then
+                chg_row = row
+                break
+            end
+        end
+        assert.is_not_nil(chg_row)
+        vim.api.nvim_win_set_cursor(win, { chg_row + 1, 0 })
+        vim.api.nvim_exec_autocmds("CursorMoved", { buffer = buf })
+        assert.are.equal("differCursorLine", overlay_hl(buf, chg_row)) -- no tint
         v:close()
     end)
 end)


### PR DESCRIPTION
Five changes across the merge tool and the diff view.

## Merge tool
**1. Conflict chords only fired when typed quickly** (`3ccdccb`)
The take-this chords (`<leader>co`/`ct`/`cb`/`ca`) and `dx` are multi-key, so nvim waits `timeoutlen` for the completing key. Under a short global `timeoutlen` (which-key setups commonly run 200ms) they drop unless typed fast. Widen `timeoutlen` to a 1s floor while focused in the result buffer (`BufEnter`), restoring the user's value on `BufLeave`/close. Never lowers an already-larger setting; `timeoutlen` is global-only so it's a guarded save/restore.

**2. `g?` cheatsheet was unreachable from the merge buffer** (`ad52c81`)
The merge tool was the only surface without the floating cheatsheet the panel, history and diff views bind. Wire the `help` action (`g?`) on the result buffer to a float listing the conflict nav/take verbs, `:w` and `q`, reading the session's resolved keymaps so configured lhs values show correctly.

**3. Format-on-save ran over conflict markers** (`4a9afba`)
The result buffer is the real worktree file, so a conform-style format-on-save runs on `:w` and would choke on (or mangle) the markers while they remain. Set conform's buffer-local opt-out (`vim.b.disable_autoformat`) for the session and restore the prior value on close; gates that honour the flag then skip the buffer.

## Diff view
**4. Cursor line buried the add/remove colour** (`825cadb`)
The cursor-line overlay sat above the add/delete backgrounds at a neutral shade, so you couldn't tell an added line from a removed one under the cursor. Paint it in a stronger shade of the row's own add/delete colour instead (neutral on context lines). New `cursorline_tint` config option (default on) falls back to the plain neutral overlay.

**5. Open directly on the first hunk** (`2f6310f`)
The view landed one line above the first hunk to dodge the neutral cursor line burying its colour. With the tint in place that's no longer needed, so land on the hunk itself.

## Tests
New coverage for the timeout widen/restore (+ never-lower), the `g?` cheatsheet, the autoformat opt-out/restore, and the kind-aware cursor line (add/delete/context + the `cursorline_tint = false` fallback). Full suite green (276 unit + 214 headless), lint and format clean.