### PR TITLE
feat: dim staged hunks and land diffs on the cursor's line

### DIFF
--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -887,7 +887,10 @@ function M.panel(opts)
         end
         panel:select(true)
         if on_origin and view then
-            view:focus_new_line(origin_line)
+            -- hold the exact origin line when it's a changed line, so opening deep in a
+            -- hunk stays put rather than snapping to the hunk's top; a cursor on
+            -- unchanged context still falls back to the nearest hunk to review
+            view:focus_new_line(origin_line, true)
         end
     end
     return panel
@@ -909,6 +912,11 @@ function M.history(opts)
         return nil
     end
 
+    -- the cursor line :Differ log was invoked from, to open the first commit's diff at
+    -- that line when history is for the file we're sitting in (resolved below)
+    local origin_line = vim.api.nvim_win_get_cursor(0)[1]
+    local origin_buf = vim.fn.resolve(vim.api.nvim_buf_get_name(0))
+
     local file = opts.path and vim.fn.fnamemodify(opts.path, ":p") or vim.api.nvim_buf_get_name(0)
     if file == "" or vim.fn.filereadable(file) == 0 then
         return notify("no file to show history for", vim.log.levels.WARN)
@@ -921,6 +929,10 @@ function M.history(opts)
         return notify("not inside a git repository", vim.log.levels.WARN)
     end
     local relpath = file:sub(#root + 2) -- strip "<root>/"; file is under root
+
+    -- carry the cursor line into the first commit's diff only when history targets the
+    -- file we're in; a `:Differ log <other>` has no meaningful origin line
+    local origin = (origin_buf ~= "" and origin_buf == file) and origin_line or nil
 
     local commits = M.log_commits(root, { path = relpath })
     if #commits == 0 then
@@ -942,6 +954,7 @@ function M.history(opts)
     end
 
     local view ---@type differ.View|nil -- the single diff view the panel drives
+    local opened_origin = false -- the first commit shown holds the origin line, then stop
     local cfg = require("differ").get_config()
     local return_tab, session_tab = open_session_tab()
     local history = History.new({
@@ -956,6 +969,13 @@ function M.history(opts)
                 view:set_source(model)
             else
                 view = require("differ").diff_model(model)
+            end
+            -- on the first commit shown, hold the origin line: a line changed by that
+            -- commit lands exactly, otherwise it falls back to the first hunk. later
+            -- commit steps land on the first hunk like before
+            if origin and not opened_origin then
+                opened_origin = true
+                view:focus_new_line(origin, true)
             end
         end,
         on_close = function()

--- a/lua/differ/ui/highlights.lua
+++ b/lua/differ/ui/highlights.lua
@@ -16,10 +16,10 @@ local LINKS = {
     -- meta, body) ride the palette + theme bg in thread_groups
     -- our own cursor-line overlay: CursorLine is low-priority when it has no
     -- foreground (`:h hl-CursorLine`), so it loses to the diff line backgrounds; we
-    -- repaint it as a line_hl_group above them. links to CursorLine to track the theme
+    -- repaint it as a char-level extmark above them. links to CursorLine to track the theme
     differCursorLine = { link = "CursorLine" },
-    -- staged-hunk overlay: a muted full-line bg replacing the vivid
-    -- add/delete so a staged hunk reads as set-aside rather than a live change
+    -- neutral fallback for a staged line with no add/delete kind; kinded staged lines
+    -- use the dimmed deep-diff groups (differStagedLine{Add,Delete}/Word*) instead
     differStagedLine = { link = "CursorLine" },
     -- file panel chrome
     differPanelHeader = { link = "Title" },
@@ -205,17 +205,26 @@ end
 ---@return table<string, vim.api.keyset.highlight>
 local function diff_bg_groups(p)
     local base = bg_of({ "Normal" }, 0x14161b)
-    local line, cursor, word = 0.16, 0.28, 0.42 -- blend weights toward the vivid colour; tune to taste
+    local line, cursor, word = 0.22, 0.36, 0.52 -- blend weights toward the vivid colour; tune to taste
+    -- staged hunks keep the same-hue deep diff but quieter, so they read as set-aside
+    -- yet still show what changed; well under the live weights so staged reads distinctly
+    -- dimmer; line/word stay paired so the word patch still pops
+    local staged_line, staged_word = 0.12, 0.34
     return {
         differLineAdd = { bg = blend(p.green, base, line) },
         differLineDelete = { bg = blend(p.red, base, line) },
-        -- the cursor line over an add/delete line: the same hue a notch stronger than the
-        -- line tint, so it reads as the current line yet still as added/removed (word
-        -- spans at 0.42 still show through). sit between the line and word weights
+        -- the cursor line over an add/delete line: the same hue, well clear of the line
+        -- tint so it reads as the current line over text (not just past EOL) yet still as
+        -- added/removed; word spans stay a notch above so they show through
         differCursorLineAdd = { bg = blend(p.green, base, cursor) },
         differCursorLineDelete = { bg = blend(p.red, base, cursor) },
         differWordAdd = { bg = blend(p.green, base, word) },
         differWordDelete = { bg = blend(p.red, base, word) },
+        -- dimmed deep diff for staged hunks (same hue, quieter than the live tints)
+        differStagedLineAdd = { bg = blend(p.green, base, staged_line) },
+        differStagedLineDelete = { bg = blend(p.red, base, staged_line) },
+        differStagedWordAdd = { bg = blend(p.green, base, staged_word) },
+        differStagedWordDelete = { bg = blend(p.red, base, staged_word) },
     }
 end
 

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -14,6 +14,9 @@ local bind = require("differ.util.keymap").bind
 local ns = vim.api.nvim_create_namespace("differ")
 local staged_ns = vim.api.nvim_create_namespace("differ.staging")
 local cursor_ns = vim.api.nvim_create_namespace("differ.cursorline")
+-- dimmed deep-diff groups for staged hunks, keyed by rail kind (mirrors ui.paint)
+local STAGED_LINE_HL = { old = "differStagedLineDelete", new = "differStagedLineAdd" }
+local STAGED_WORD_HL = { old = "differStagedWordDelete", new = "differStagedWordAdd" }
 local STATUSCOLUMN_EXPR = '%!v:lua.require("differ.ui.statuscolumn").render()'
 local FOLDTEXT_EXPR = 'v:lua.require("differ.ui.foldtext").render()'
 local CTRL_D = vim.api.nvim_replace_termcodes("<C-d>", true, false, true)
@@ -289,10 +292,12 @@ function View:rerender(opts)
     -- on open / layout toggle), so rerender doesn't, avoiding a double-apply
 end
 
--- overlay the staged-hunk marks: a muted full-line bg over every line of a
--- staged hunk plus the gutter glyph. repainted on every render and on each toggle;
--- buffer content is untouched (the diff stays frozen). a no-op off a staging view,
--- which leaves the gutter at its normal width
+-- overlay the staged-hunk marks: a dimmed deep diff over every line of a staged hunk
+-- plus the gutter glyph. repaints the line in the quieter staged add/delete shade and
+-- its word spans in the staged word shade, above the live diff bg + word spans, so a
+-- staged hunk reads as set-aside yet still shows what changed. repainted on every
+-- render and on each toggle; buffer content is untouched (the diff stays frozen).
+-- a no-op off a staging view, which leaves the gutter at its normal width
 function View:_paint_staged()
     if not self.can_stage then
         return
@@ -302,10 +307,30 @@ function View:_paint_staged()
         local staged_lines = {}
         for i, line in ipairs(col.map.lines) do
             if line.hunk and self.staged_hunks[line.hunk] then
-                vim.api.nvim_buf_set_extmark(col.bufnr, staged_ns, i - 1, 0, {
-                    line_hl_group = "differStagedLine",
-                    priority = 150, -- above the add/delete bg (100), under word spans (200)
+                local row = i - 1
+                -- char-level fill with hl_eol, not line_hl_group: a line_hl_group covers
+                -- the text but loses the past-EOL tail to the diff bg's own hl_eol (it
+                -- can't be raised above it), leaking the vivid colour into the tail. as a
+                -- char fill it spans the whole row and, above the live add/delete bg AND
+                -- word spans, recolours the line in the quieter staged shade
+                vim.api.nvim_buf_set_extmark(col.bufnr, staged_ns, row, 0, {
+                    end_row = i,
+                    end_col = 0,
+                    hl_group = STAGED_LINE_HL[line.kind] or "differStagedLine",
+                    hl_eol = true,
+                    priority = 210, -- above the live add/delete bg (100) and word spans (200)
                 })
+                -- the changed words a notch above the staged line so the deep diff still reads
+                local word_hl = STAGED_WORD_HL[line.kind]
+                if word_hl and line.spans then
+                    for _, span in ipairs(line.spans) do
+                        vim.api.nvim_buf_set_extmark(col.bufnr, staged_ns, row, span.col_start, {
+                            end_col = span.col_end,
+                            hl_group = word_hl,
+                            priority = 215,
+                        })
+                    end
+                end
                 staged_lines[i] = true
             end
         end
@@ -333,11 +358,11 @@ function View:_paint_cursorline()
         return
     end
     local row = vim.api.nvim_win_get_cursor(win)[1] - 1
+    local line = col.map.lines[row + 1]
     -- tint the cursor line by the row's change kind so the add/remove colour survives
     -- under the cursor (a neutral overlay would bury it); plain neutral when off
     local hl = "differCursorLine"
     if self.cursorline_tint then
-        local line = col.map.lines[row + 1]
         local kind = line and line.kind
         if kind == "new" then
             hl = "differCursorLineAdd"
@@ -345,12 +370,16 @@ function View:_paint_cursorline()
             hl = "differCursorLineDelete"
         end
     end
+    -- a staged line is recoloured above the live word spans (210/215); lift the cursor
+    -- tint over that so the focused line still lights up in its kind. on a normal line
+    -- stay under the word spans (200) so changed words show through under the cursor
+    local staged = self.can_stage and line and line.hunk and self.staged_hunks[line.hunk]
     vim.api.nvim_buf_set_extmark(col.bufnr, cursor_ns, row, 0, {
         end_row = row + 1,
         end_col = 0,
         hl_group = hl,
         hl_eol = true, -- fill past EOL so the whole row is covered, like the diff bg
-        priority = 160, -- above the add/delete bg (100); word spans (200) show through
+        priority = staged and 220 or 160,
     })
 end
 
@@ -933,6 +962,7 @@ function View:_toggle_hunk(want_staged)
     if self:_apply_hunk(idx, want_staged) then
         self.staging.refresh()
         self:_paint_staged()
+        self:_paint_cursorline() -- re-lift the cursor tint above the fresh staged fill
     end
 end
 
@@ -978,6 +1008,7 @@ function View:_toggle_all(want_staged)
     if changed then
         self.staging.refresh()
         self:_paint_staged()
+        self:_paint_cursorline() -- re-lift the cursor tint above the fresh staged fill
     end
     return changed
 end

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -779,11 +779,12 @@ function View:cursor_new_line()
 end
 
 -- position the new side near `new_lnum` (where the cursor was, or the line just
--- edited) across an in-place re-source. with `exact` (a re-source holding the precise
--- line), when that line maps to a rendered *changed* line, land on it and centre it so
--- an edit deep in a hunk shows the edit, not the hunk's top. otherwise (or an
--- unchanged/context line) fall back to the nearest hunk's start, landing on the change
--- you were by (this is what open-on-origin wants)
+-- edited) across an in-place re-source. with `exact` (open-on-origin, or a re-source
+-- holding the precise line), when that line maps to a rendered *changed* line, land on
+-- it and centre it so an edit deep in a hunk shows the edit, not the hunk's top. a
+-- cursor parked on an unchanged/context line (e.g. opening from the top of the file)
+-- falls back to the nearest hunk's start, landing on the change you were by, not on the
+-- leading context (this is what open-on-origin wants)
 ---@param new_lnum integer
 ---@param exact? boolean
 function View:focus_new_line(new_lnum, exact)
@@ -791,7 +792,8 @@ function View:focus_new_line(new_lnum, exact)
     if not (col and col.winid and vim.api.nvim_win_is_valid(col.winid)) then
         return
     end
-    -- the line maps straight to a rendered changed line (e.g. the line just edited)
+    -- the line maps straight to a rendered changed line (the line just edited, or the
+    -- origin line :Differ was run from); hold it exactly rather than snapping to the hunk
     local at = col.map.from_new[new_lnum]
     if exact and at and col.map.lines[at] and col.map.lines[at].hunk then
         pcall(vim.api.nvim_win_set_cursor, col.winid, { at, 0 })

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1045,11 +1045,13 @@ describe(":Differ diff hunk staging", function()
         local p = Panel.current()
         local v = view_in_origin(p)
         assert.are.equal("a.lua", v.model.path)
-        assert.are.equal(1, vim.api.nvim_win_get_cursor(p.origin_win)[1]) -- on hunk 1
+        -- opened from new-file line 1 (the "1" -> "1x" change), so it lands on that
+        -- line's new-side row (row 2, under the deleted old "1"), not the hunk's top
+        assert.are.equal(2, vim.api.nvim_win_get_cursor(p.origin_win)[1]) -- on hunk 1
 
         v:stage_hunk() -- stage hunk 1; cursor stays put, marked
         assert.is_true(v.staged_hunks[1])
-        assert.are.equal(1, vim.api.nvim_win_get_cursor(p.origin_win)[1])
+        assert.are.equal(2, vim.api.nvim_win_get_cursor(p.origin_win)[1])
 
         v:stage_hunk() -- second s: advance to hunk 2 (buffer line 9)
         assert.are.equal(9, vim.api.nvim_win_get_cursor(p.origin_win)[1])

--- a/test/nvim/history_spec.lua
+++ b/test/nvim/history_spec.lua
@@ -42,6 +42,20 @@ local function repo_with_history()
     return root
 end
 
+-- a repo whose newest commit changes two well-separated lines (2 and 9), so the
+-- origin-line landing is distinguishable from the first hunk
+local function repo_two_hunks()
+    local root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+    git(root, "init", "-q")
+    write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+    git(root, "add", "a.lua")
+    git(root, "commit", "-q", "-m", "seed")
+    write(root .. "/a.lua", "1\n2x\n3\n4\n5\n6\n7\n8\n9x\n10\n")
+    git(root, "commit", "-q", "-am", "two edits")
+    return root
+end
+
 -- the History panel returns focus to the diff by default, so the View lives in the
 -- origin window (View.current keys off the focused buffer)
 local function view_in_origin(h)
@@ -119,6 +133,58 @@ describe(":Differ log (single-file history)", function()
         assert.is_truthy(h.lines[3]:find("%d%d%d%d%-%d%d%-%d%d")) -- back to absolute
         h:close()
         require("differ").setup({}) -- restore defaults for the rest of the suite
+    end)
+
+    it("opens the newest commit's diff at the origin line, not the first hunk", function()
+        local root = repo_two_hunks()
+        vim.cmd.edit(root .. "/a.lua")
+        vim.api.nvim_win_set_cursor(0, { 9, 0 }) -- park on the lower change
+
+        git_src.history({})
+        local h = History.current()
+        local v = view_in_origin(h)
+        local col = v.columns[1]
+        local cur = vim.api.nvim_win_get_cursor(h.origin_win)[1]
+        assert.are.equal(col.map.from_new[9], cur) -- held line 9's row, not the line-2 hunk
+        assert.is_not_nil(col.map.lines[cur].hunk) -- and it's a real changed line
+        h:close()
+    end)
+
+    it(
+        "holds the origin line only on the first commit; later steps land on the first hunk",
+        function()
+            local root = repo_two_hunks()
+            vim.cmd.edit(root .. "/a.lua")
+            vim.api.nvim_win_set_cursor(0, { 9, 0 })
+
+            git_src.history({})
+            local h = History.current()
+            h:step("next") -- step to an older commit
+            local v = view_in_origin(h)
+            local col = v.columns[1]
+            local cur = vim.api.nvim_win_get_cursor(h.origin_win)[1]
+            assert.are.equal(v:_first_review_line(col), cur) -- first hunk, origin not re-applied
+            h:close()
+        end
+    )
+
+    it("ignores the origin line for `:Differ log <other-file>`", function()
+        local root = repo_two_hunks()
+        write(root .. "/b.lua", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+        git(root, "add", "b.lua")
+        git(root, "commit", "-q", "-m", "add b")
+        write(root .. "/b.lua", "1\n2\n3\n4\n5\n6\n7\n8\n9x\n10\n")
+        git(root, "commit", "-q", "-am", "edit b line 9")
+        vim.cmd.edit(root .. "/a.lua") -- sitting in a.lua, cursor at line 1
+        vim.api.nvim_win_set_cursor(0, { 9, 0 })
+
+        git_src.history({ path = root .. "/b.lua" }) -- history for a different file
+        local h = History.current()
+        local v = view_in_origin(h)
+        local col = v.columns[1]
+        local cur = vim.api.nvim_win_get_cursor(h.origin_win)[1]
+        assert.are.equal(v:_first_review_line(col), cur) -- first hunk, origin ignored
+        h:close()
     end)
 
     it("steps to an older commit and re-sources the same view in place", function()

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -464,6 +464,23 @@ describe("view re-source", function()
         assert.is_true(cur > col.map.from_new[2]) -- below the top of the new block
         v:close()
     end)
+
+    it("snaps an unchanged origin line to the nearest hunk, not the context row", function()
+        -- the change is at lines 2-4 (B,C,D); line 5 ("e") is an unchanged context line
+        local old, new = "a\nb\nc\nd\ne\n", "a\nB\nC\nD\ne\n"
+        local v = View.new(model(old, new), {
+            layout = "stacked",
+            context = math.huge,
+            deep_diff = { enabled = true },
+        })
+        v:open()
+        local col = v.columns[1]
+        v:focus_new_line(5, true) -- parked on the "e" context line below the hunk
+        local cur = vim.api.nvim_win_get_cursor(col.winid)[1]
+        assert.is_not_nil(col.map.lines[cur].hunk) -- landed on the hunk, not the context row
+        assert.are_not.equal(col.map.from_new[5], cur)
+        v:close()
+    end)
 end)
 
 describe("view jump-to-file", function()


### PR DESCRIPTION
Two related diff-view improvements.

## Staged-hunk dimmed tint
Paint staged hunks as a dimmed deep diff (same-hue add/delete line + word spans, well under the live weights) instead of a flat muted line background, so a staged hunk reads as set-aside yet still shows what changed. Uses a char-level `hl_eol` fill so the tail past EOL no longer leaks the vivid colour, and lifts the cursor-line tint above the staged fill so the focused line still lights up. The cursor line repaints after a stage/unstage toggle.

## Open-on-origin exact-line landing
Opening `:Differ <rev>` (or single-file `:Differ log`) on the file you're in snapped the cursor to the nearest hunk's top, even when you were parked on a changed line deep inside it. The origin line is now passed through to `focus_new_line`, so a changed line is held exactly; a cursor on unchanged context still falls back to the first hunk to review.

For `:Differ log`, only the first commit shown holds the line (later commit steps land on the first hunk, since older content no longer maps cleanly), and only when history targets the file you're sitting in. Range history is unchanged.

## Tests
Added coverage for the exact-line landing on both the diff and log openers, the context-line fallback, the first-commit-only behaviour, and the cross-file `:Differ log <other>` case. Full suite green (218 nvim, 276 unit), lint and fmt clean.
