### PR TITLE
fix: guard binary files from the diff word pass

### DIFF
--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -756,10 +756,11 @@ function M.panel(opts)
     ---@return boolean shown
     local function show_entry(entry, focus_line)
         local model = model_for(entry)
-        if #model.hunks == 0 then
+        if #model.hunks == 0 and not model.binary then
             -- a pure rename or copy has identical content on both sides, so it diffs
             -- to zero hunks but is still a real change worth opening (the file just
-            -- moved). any other zero-hunk entry is stale: committed, staged away, or
+            -- moved). a binary file also has no hunks but renders a placeholder, so it
+            -- opens too. any other zero-hunk entry is stale: committed, staged away, or
             -- reverted outside differ
             local is_move = (entry.status == "R" or entry.status == "C")
                 and entry.previous_path ~= nil

--- a/lua/differ/model/diff.lua
+++ b/lua/differ/model/diff.lua
@@ -18,10 +18,12 @@
 ---@field new_text string
 ---@field head string|nil  -- git branch, for the synthetic buffer's statusline (set by the frontend)
 ---@field root string|nil  -- repo root (absolute), so jump-to-file can resolve the real file (set by the frontend)
+---@field binary boolean|nil  -- either side is binary: no hunks, renderers show a placeholder
 
 local text_util = require("differ.util.text")
 local to_lines = text_util.to_lines
 local ensure_trailing_nl = text_util.ensure_trailing_nl
+local is_binary = text_util.is_binary
 
 local M = {}
 
@@ -51,6 +53,24 @@ end
 ---@param opts differ.model.BuildOpts
 ---@return differ.DiffModel
 function M.build(opts)
+    -- binary content has no line structure: stray 0x0a bytes would split it into
+    -- pathological pseudo-lines and drive the word-diff pairing into O(n*m) over
+    -- megabytes (an OOM that takes the editor down). detect it up front, skip the
+    -- diff entirely, and let the renderers show a placeholder
+    if is_binary(opts.old_text) or is_binary(opts.new_text) then
+        return {
+            path = opts.path,
+            old_rev = opts.old_rev,
+            new_rev = opts.new_rev,
+            hunks = {},
+            old_text = opts.old_text,
+            new_text = opts.new_text,
+            head = opts.head,
+            root = opts.root,
+            binary = true,
+        }
+    end
+
     local old_lines = to_lines(opts.old_text)
     local new_lines = to_lines(opts.new_text)
 

--- a/lua/differ/render/split.lua
+++ b/lua/differ/render/split.lua
@@ -16,6 +16,8 @@ local walk = require("differ.render.walk")
 
 local M = {}
 
+local BINARY_NOTICE = "Binary file not shown"
+
 -- render a model into two index-aligned columns ("old" left, "new" right). both
 -- columns share the same fold ranges since their rows are aligned
 ---@param model differ.DiffModel
@@ -57,6 +59,13 @@ function M.render(model, opts)
             },
             rows = #old_lines,
         }
+    end
+
+    -- a binary file isn't diffed (it would blow up the word pass); show a placeholder
+    -- on both sides so the columns stay row-aligned
+    if model.binary then
+        push_row(BINARY_NOTICE, { kind = "meta" }, BINARY_NOTICE, { kind = "meta" })
+        return result()
     end
 
     if #model.hunks == 0 then

--- a/lua/differ/render/stacked.lua
+++ b/lua/differ/render/stacked.lua
@@ -10,6 +10,8 @@ local walk = require("differ.render.walk")
 
 local M = {}
 
+local BINARY_NOTICE = "Binary file not shown"
+
 -- render a model into a single "unified" column: interleaved buffer lines plus
 -- a populated line map and the fold ranges (buffer coords) the view collapses
 ---@param model differ.DiffModel
@@ -30,6 +32,15 @@ function M.render(model, opts)
             folds[#folds + 1] = { first = fold_start, last = #lines - 1 }
             fold_start = nil
         end
+    end
+
+    -- a binary file isn't diffed (it would blow up the word pass); show a placeholder
+    if model.binary then
+        map:push({ kind = "meta" })
+        return {
+            columns = { { lines = { BINARY_NOTICE }, map = map, side = "unified", folds = folds } },
+            rows = 1,
+        }
     end
 
     -- identical content produces no hunks; nothing to show

--- a/lua/differ/ui/winbar.lua
+++ b/lua/differ/ui/winbar.lua
@@ -59,6 +59,9 @@ function M.diff()
     if not map then
         return ""
     end
+    if view.model.binary then
+        return (" %s %%=binary "):format(esc(vim.fn.fnamemodify(view.model.path, ":t")))
+    end
     local total = #view.model.hunks
     local lnum = vim.api.nvim_win_get_cursor(win)[1]
     local k = math.max(hunk_at(map, lnum), total > 0 and 1 or 0)

--- a/lua/differ/util/text.lua
+++ b/lua/differ/util/text.lua
@@ -29,6 +29,17 @@ function M.to_lines(text)
     return lines
 end
 
+-- a NUL byte in the first 8kb marks the content as binary, mirroring git's own
+-- heuristic. binary blobs have no line structure, so the line/word diff would split
+-- them on stray 0x0a bytes into pathological pseudo-lines and blow up; callers skip
+-- diffing them. pure, so it stays testable without nvim
+---@param text string
+---@return boolean
+function M.is_binary(text)
+    local head = #text > 8000 and text:sub(1, 8000) or text
+    return head:find("\0", 1, true) ~= nil
+end
+
 -- right-truncate `s` to at most `max` columns, keeping the front (the part that
 -- distinguishes one filename from another) with a trailing "…". byte-based, so it
 -- approximates for multibyte (filenames are ASCII in practice). returns `s`

--- a/test/nvim/diff_spec.lua
+++ b/test/nvim/diff_spec.lua
@@ -37,4 +37,18 @@ describe("model.diff.build", function()
         assert.are.equal(1, #m.hunks)
         assert.are.same({ "b" }, m.hunks[1].new_lines)
     end)
+
+    it("flags binary content and skips diffing it", function()
+        -- a modified binary file (NUL bytes both sides) must not be diffed: the word
+        -- pass over megabyte pseudo-lines is an OOM. it carries no hunks, just a flag
+        local m = diff.build({
+            path = "demo.gif",
+            old_rev = "HEAD",
+            new_rev = "WORKTREE",
+            old_text = "GIF89a\0\1\2\3",
+            new_text = "GIF89a\0\4\5\6",
+        })
+        assert.is_true(m.binary)
+        assert.are.equal(0, #m.hunks)
+    end)
 end)

--- a/test/nvim/split_spec.lua
+++ b/test/nvim/split_spec.lua
@@ -69,4 +69,11 @@ describe("render.split end-to-end round-trip", function()
     it("multiple separated hunks", function()
         assert_roundtrip("1\n2\n3\n4\n5\n6\n7\n8\n9\n", "1\nX\n3\n4\n5\n6\n7\nY\n9\n")
     end)
+
+    it("renders an aligned placeholder for a binary file", function()
+        local r = render(build("a\0b", "c\0d"), { context = math.huge })
+        assert.are.same({ "Binary file not shown" }, r.old_lines)
+        assert.are.same({ "Binary file not shown" }, r.new_lines)
+        assert.are.equal(#r.old_lines, #r.new_lines) -- columns stay row-aligned
+    end)
 end)

--- a/test/nvim/stacked_spec.lua
+++ b/test/nvim/stacked_spec.lua
@@ -83,4 +83,11 @@ describe("render.stacked end-to-end content", function()
         assert.are.equal(11, #r.lines) -- nothing dropped (9 unchanged + X + Y)
         assert.are.same({ { first = 5, last = 7 } }, r.folds) -- the 4,5,6 middle folds
     end)
+
+    it("renders a placeholder for a binary file, never the raw bytes", function()
+        local model = build("a\0b", "c\0d")
+        local r = render(model, { context = math.huge })
+        assert.are.same({ "Binary file not shown" }, r.lines)
+        assert.are.equal("meta", r.map.lines[1].kind)
+    end)
 end)

--- a/test/unit/text_spec.lua
+++ b/test/unit/text_spec.lua
@@ -20,3 +20,22 @@ describe("util.text.truncate_end", function()
         assert.are.equal("abcdef", text.truncate_end("abcdef", 1))
     end)
 end)
+
+describe("util.text.is_binary", function()
+    it("treats plain text as non-binary", function()
+        assert.is_false(text.is_binary(""))
+        assert.is_false(text.is_binary("a\nb\nc\n"))
+        assert.is_false(text.is_binary(("line\n"):rep(5000)))
+    end)
+
+    it("flags content with a NUL byte", function()
+        assert.is_true(text.is_binary("abc\0def"))
+        assert.is_true(text.is_binary("\0"))
+    end)
+
+    it("only scans the first 8kb", function()
+        -- a NUL past the window is missed, mirroring git's heuristic
+        assert.is_false(text.is_binary(("x"):rep(8000) .. "\0"))
+        assert.is_true(text.is_binary(("x"):rep(7999) .. "\0"))
+    end)
+end)


### PR DESCRIPTION
## Problem

Opening a **modified** binary file (e.g. a changed `gif`/`mp4`) crashed the entire nvim instance. The worktree side was read as raw bytes, split on stray `0x0a` into pathological pseudo-lines, then fed through the `O(n*m)` word-diff pairing (`worddiff/pair.lua` + `spans.lua`). That exhausted memory until the process was OOM-killed — a true crash, not a catchable Lua error. Reproduced by stepping (`]f`/`]c`) onto a binary file in the changes panel.

## Fix

- `util/text.lua` — `is_binary(text)`: NUL byte in the first 8 KB (git's heuristic).
- `model/diff.lua` — detect binary up front, skip `vim.text.diff` and the word pass, flag `model.binary`.
- `render/stacked.lua` / `render/split.lua` — show a `Binary file not shown` placeholder instead of diffing.
- `git/init.lua` — open binary entries despite their zero hunks (previously bailed as stale). Also covers the PR diff path, which had no zero-hunk guard.
- `ui/winbar.lua` — reads `binary` instead of `hunk 0/0`.

## Notes

- The trigger is a *modified* binary; a newly-added binary has an empty old side and never hit the pairing. The fix covers both.
- The merge tool (`render/merge.lua`) is a separate model and is out of scope here.

## Tests

Unit + headless specs for `is_binary` (incl. the 8 KB boundary), binary model build, and the placeholder render in both layouts. `make lua-test` (282 unit + 246 nvim), lint, and fmt-check all clean.