### PR TITLE
docs: drop redundant HEAD arg from the <leader>do launcher example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ differ ships no global launchers - only the in-view buffer maps above and the op
   cmd = { "Differ", "D" }, -- "D" matches command_alias below; see note above
   keys = {
     -- local diff / history
-    { '<leader>do', '<cmd>Differ HEAD<CR>',                   desc = "Diff: open (vs index)" },
+    { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
     { "<leader>dc", "<cmd>Differ close<CR>",                  desc = "Diff: close" },
     { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
     { "<leader>de", "<cmd>Differ gofile<CR>",                 desc = "Diff: open the real file" },


### PR DESCRIPTION
## Summary
- `<leader>do`'s example launcher used `:Differ HEAD`, which resolves to the exact same source as bare `:Differ` (`HEAD` vs worktree in both cases). The only effect of the explicit arg was opting the command out of the merge-tool reroute for bare `:Differ` during a conflicted merge.
- Updated the README launcher example to `:Differ` so it matches the intended behaviour (and reflects the same fix applied to the author's own dotfiles keymap).

No source changes.