### PR TITLE
feat: add goto_hunk fallback option

### DIFF
--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -210,12 +210,13 @@ end
 -- (in the diff window already bound buffer-locally). a no-op with a notice when no
 -- diff is active
 ---@param direction "next"|"prev"
-function M.goto_hunk(direction)
+---@param opts? { fallback?: fun(direction: "next"|"prev"): boolean|nil }
+function M.goto_hunk(direction, opts)
     local view = M.active_view()
     if not view then
         return vim.notify("differ: no diff view here", vim.log.levels.WARN)
     end
-    view:goto_hunk(direction)
+    view:goto_hunk(direction, opts)
 end
 
 return M

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -701,12 +701,17 @@ function View:_focused_column()
     return self.columns[1]
 end
 
+local function run_hunk_fallback(direction, opts)
+    return opts and opts.fallback and opts.fallback(direction)
+end
+
 -- move the cursor to the next/prev hunk in the focused column. at a change-set
 -- boundary it flows into the adjacent file (no wrap); a log/history session is the
 -- exception: hunk nav stays within the current commit's diff (commits step via ]f/[f),
 -- so it stops at the first/last hunk rather than crossing into the next commit
 ---@param direction "next"|"prev"
-function View:goto_hunk(direction)
+---@param opts? { fallback?: fun(direction: "next"|"prev"): boolean|nil }
+function View:goto_hunk(direction, opts)
     local col = self:_focused_column()
     local win = col.winid or vim.api.nvim_get_current_win()
     local lnum = vim.api.nvim_win_get_cursor(col.winid or win)[1]
@@ -728,12 +733,16 @@ function View:goto_hunk(direction)
     if direction == "next" then
         -- past the last hunk: flow into the next file (no wrap), or notify at the last one
         if in_history or not self:step_file("next", false) then
-            vim.notify("differ: no next hunk", vim.log.levels.INFO)
+            if not run_hunk_fallback(direction, opts) then
+                vim.notify("differ: no next hunk", vim.log.levels.INFO)
+            end
         end
     elseif not in_history and self:step_file("prev", false) then
         self:_focus_last_hunk() -- landed on the previous file: continue the backward flow
     else
-        vim.notify("differ: no previous hunk", vim.log.levels.INFO)
+        if not run_hunk_fallback(direction, opts) then
+            vim.notify("differ: no previous hunk", vim.log.levels.INFO)
+        end
     end
 end
 

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -182,6 +182,39 @@ describe("view hunk navigation", function()
         assert.is_true(lhs["[c"])
         v:close()
     end)
+
+    it("uses goto_hunk fallback at hunk boundaries", function()
+        local v = two_hunk_view()
+        v:open()
+        local win = v.columns[1].winid
+        vim.api.nvim_win_set_cursor(win, { 9, 0 })
+        local called
+        _G.notifs = {}
+        v:goto_hunk("next", {
+            fallback = function(direction)
+                called = direction
+                return true
+            end,
+        })
+        assert.are.equal("next", called)
+        assert.are.equal(0, #_G.notifs)
+        v:close()
+    end)
+
+    it("notifies when goto_hunk fallback does not handle the boundary", function()
+        local v = two_hunk_view()
+        v:open()
+        local win = v.columns[1].winid
+        vim.api.nvim_win_set_cursor(win, { 1, 0 })
+        _G.notifs = {}
+        v:goto_hunk("prev", {
+            fallback = function()
+                return nil
+            end,
+        })
+        assert.are.equal("differ: no previous hunk", _G.notifs[1].msg)
+        v:close()
+    end)
 end)
 
 describe("view in-view keymaps", function()


### PR DESCRIPTION
# feat: add goto_hunk fallback option

Thanks for this package! Do you want contributions?

## Summary

- Add `opts.fallback` to public `require("differ").goto_hunk(direction, opts)`.
- Run the fallback when goto_hunk fails (at first/last hunk boundaries) before showing the existing info notification.

## Why

I want to jump to next file when next hunk is called on last hunk.  Example config:

```lua

    opts = {
      keymaps = {
        diff = {
          next_hunk = false,
          prev_hunk = false,
        },
      },
    },
    config = function(_, opts)
      require("differ").setup(opts)
      local function step_file(direction)
        local view = require("differ").active_view()
        return view and view:step_file(direction)
      end
      vim.api.nvim_create_autocmd("FileType", {
        pattern = "differdiff",
        callback = function(ev)
          vim.keymap.set("n", "]c", function()
            require("differ").goto_hunk("next", { fallback = step_file })
          end, { buffer = ev.buf, desc = "differ: next hunk" })
          vim.keymap.set("n", "[c", function()
            require("differ").goto_hunk("prev", { fallback = step_file })
          end, { buffer = ev.buf, desc = "differ: previous hunk" })
        end,
      })
    end

```

But this approach is also very versatile if someone wants to do something else.