### PR TITLE
test: cover hunk-at and hunk-landing edge cases

### DIFF
--- a/lua/differ/ui/winbar.lua
+++ b/lua/differ/ui/winbar.lua
@@ -23,7 +23,7 @@ end
 ---@param map differ.LineMap
 ---@param lnum integer
 ---@return integer
-local function hunk_at(map, lnum)
+function M.hunk_at(map, lnum)
     local k, prev = 0, nil
     for i = 1, math.min(lnum, #map.lines) do
         local h = map.lines[i].hunk
@@ -64,7 +64,7 @@ function M.diff()
     end
     local total = #view.model.hunks
     local lnum = vim.api.nvim_win_get_cursor(win)[1]
-    local k = math.max(hunk_at(map, lnum), total > 0 and 1 or 0)
+    local k = math.max(M.hunk_at(map, lnum), total > 0 and 1 or 0)
     -- a pending-review badge when this is a PR diff with an active draft, right-aligned
     -- next to the hunk counter in a bold warning colour so the draft state stands out
     -- while reviewing (not just in the compose window)

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1214,10 +1214,54 @@ describe(":Differ diff hunk staging", function()
 
         v:goto_hunk("next") -- past a.lua's only (last) hunk: flow into z.lua
         assert.are.equal("z.lua", v.model.path)
+        -- lands on a real hunk row in the file it stepped into, not just anywhere in it
+        assert.is_not_nil(v.columns[1].map.lines[vim.api.nvim_win_get_cursor(p.origin_win)[1]].hunk)
         v:goto_hunk("prev") -- before z.lua's only (first) hunk: flow back into a.lua
         assert.are.equal("a.lua", v.model.path)
-        -- and it lands on a real hunk row in the file it stepped into
         assert.is_not_nil(v.columns[1].map.lines[vim.api.nvim_win_get_cursor(p.origin_win)[1]].hunk)
+        p:close()
+    end)
+
+    it("]c flowing forward lands on the new file's first hunk, not line 1", function()
+        -- z.lua mirrors a file with a long header before its first real change: 30
+        -- lines of context, a small hunk, more context, then a second hunk near the
+        -- end. a hunk-at-line-1 fixture can't tell "landed on the first hunk" apart
+        -- from "cursor just carried over from wherever it was" -- this one can.
+        local root = fresh_repo()
+        local base = {}
+        for i = 1, 30 do
+            base[#base + 1] = "ctx" .. i
+        end
+        base[#base + 1] = "OLD_A"
+        for i = 31, 60 do
+            base[#base + 1] = "ctx" .. i
+        end
+        base[#base + 1] = "OLD_B"
+        write(root .. "/z.lua", table.concat(base, "\n") .. "\n")
+        git(root, "add", "z.lua")
+        git(root, "commit", "-q", "-am", "two files")
+
+        local changed = vim.deepcopy(base)
+        changed[31] = "NEW_A"
+        changed[#changed] = "NEW_B"
+        write(root .. "/a.lua", "1x\n2\n") -- a.lua: one hunk near the top
+        write(root .. "/z.lua", table.concat(changed, "\n") .. "\n") -- z.lua: two hunks
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("a.lua", v.model.path)
+
+        v:goto_hunk("next") -- past a.lua's only hunk: flow into z.lua
+        assert.are.equal("z.lua", v.model.path)
+        local first = v.columns[1].map.lines[vim.api.nvim_win_get_cursor(p.origin_win)[1]]
+        assert.are.equal(1, first and first.hunk) -- z.lua's first hunk, not a leftover cursor row
+
+        v:goto_hunk("next") -- z.lua's second hunk, not a skip out to a (nonexistent) next file
+        assert.are.equal("z.lua", v.model.path)
+        local second = v.columns[1].map.lines[vim.api.nvim_win_get_cursor(p.origin_win)[1]]
+        assert.are.equal(2, second and second.hunk)
         p:close()
     end)
 

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -487,6 +487,36 @@ describe("view re-source", function()
         assert.are_not.equal(col.map.from_new[5], cur)
         v:close()
     end)
+
+    it("origin-open can snap to a later hunk, not the file's first", function()
+        -- two far-apart changes; an origin line parked next to the second one must
+        -- snap to IT, not fall back to the first hunk in the file. this is the
+        -- open-on-origin path (`:Differ` invoked from inside a changed file): it
+        -- deliberately does not land on "the first hunk" the way a plain ]c-driven
+        -- file switch does, so a subsequent ]c can correctly find no hunk left in
+        -- this file and flow to the next one instead of appearing to skip a hunk
+        local old = "a\nOLD_A\nctx1\nctx2\nctx3\nctx4\nctx5\nOLD_B\nz\n"
+        local new = "a\nNEW_A\nctx1\nctx2\nctx3\nctx4\nctx5\nNEW_B\nz\n"
+        local v = View.new(model(old, new), {
+            layout = "stacked",
+            context = math.huge,
+            deep_diff = { enabled = true },
+        })
+        v:open()
+        local col = v.columns[1]
+        assert.are.equal(2, #v.model.hunks)
+
+        v:focus_new_line(7, true) -- "ctx5", the unchanged line right above NEW_B
+        local cur = vim.api.nvim_win_get_cursor(col.winid)[1]
+        assert.are.equal(2, col.map.lines[cur].hunk) -- snapped to the second hunk, not the first
+
+        -- from there, ]c must not wrap back to the first hunk: nothing left after
+        -- the second hunk in this file, so the cursor stays put (a real caller with
+        -- a panel/next file would flow out instead)
+        v:goto_hunk("next")
+        assert.are.equal(cur, vim.api.nvim_win_get_cursor(col.winid)[1])
+        v:close()
+    end)
 end)
 
 describe("view jump-to-file", function()

--- a/test/unit/winbar_spec.lua
+++ b/test/unit/winbar_spec.lua
@@ -1,0 +1,78 @@
+local stacked = require("differ.render.stacked")
+local winbar = require("differ.ui.winbar")
+
+-- two hunks far apart -> stacked (full context) buffer:
+--   1 ctx | 2 old"2" h1 | 3 new"X" h1 | 4-8 ctx | 9 old"8" h2 | 10 new"Y" h2 | 11 ctx
+local function two_hunk_map()
+    return stacked.render({
+        path = "x",
+        old_rev = "A",
+        new_rev = "B",
+        old_text = "1\n2\n3\n4\n5\n6\n7\n8\n9\n",
+        new_text = "1\nX\n3\n4\n5\n6\n7\nY\n9\n",
+        hunks = {
+            {
+                old_start = 2,
+                old_count = 1,
+                new_start = 2,
+                new_count = 1,
+                old_lines = { "2" },
+                new_lines = { "X" },
+            },
+            {
+                old_start = 8,
+                old_count = 1,
+                new_start = 8,
+                new_count = 1,
+                old_lines = { "8" },
+                new_lines = { "Y" },
+            },
+        },
+    }, { context = math.huge }).columns[1].map
+end
+
+describe("winbar.hunk_at", function()
+    local map = two_hunk_map()
+
+    it("is 0 before the first hunk starts", function()
+        assert.are.equal(0, winbar.hunk_at(map, 1))
+    end)
+
+    it("counts the first hunk from its start through its own lines", function()
+        assert.are.equal(1, winbar.hunk_at(map, 2))
+        assert.are.equal(1, winbar.hunk_at(map, 3))
+    end)
+
+    it("still reads as the first hunk on trailing context after it", function()
+        assert.are.equal(1, winbar.hunk_at(map, 5))
+        assert.are.equal(1, winbar.hunk_at(map, 8))
+    end)
+
+    it("counts the second hunk from its start onward", function()
+        assert.are.equal(2, winbar.hunk_at(map, 9))
+        assert.are.equal(2, winbar.hunk_at(map, 10))
+    end)
+
+    it("still reads as the second hunk on trailing context past it", function()
+        assert.are.equal(2, winbar.hunk_at(map, 11))
+    end)
+
+    it("clamps to the map's last line past the end", function()
+        assert.are.equal(2, winbar.hunk_at(map, 999))
+    end)
+end)
+
+describe("winbar.hunk_at with no hunks", function()
+    it("is always 0", function()
+        local map = stacked.render({
+            path = "x",
+            old_rev = "A",
+            new_rev = "B",
+            old_text = "a\nb\n",
+            new_text = "a\nb\n",
+            hunks = {},
+        }, { context = math.huge }).columns[1].map
+        assert.are.equal(0, winbar.hunk_at(map, 1))
+        assert.are.equal(0, winbar.hunk_at(map, 2))
+    end)
+end)


### PR DESCRIPTION
## Summary
- expose winbar's `hunk_at` as `M.hunk_at` so it's directly unit-testable
- add pure-lua unit coverage for `hunk_at` in `test/unit/winbar_spec.lua`
- add nvim-integration coverage for `goto_hunk`/`focus_new_line` landing on the correct hunk (not just the first) in `test/nvim/git_spec.lua` and `test/nvim/view_spec.lua`

## Test plan
- [x] `busted --run unit` — 289/289 passing
- [x] `busted --lua=nlua --run nvim` — 253/253 passing
- [x] `luacheck lua` — clean
- [x] `stylua --check lua plugin test` — clean