### PR TITLE
fix: include untracked files in worktree-side rev-pair diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Untracked files no longer silently drop out of rev-pair diffs against the worktree (branch total `<a>...`, `:Differ <rev>`). `git diff` never lists them regardless of the refs passed to it, so the panel now unions in `git ls-files --others --exclude-standard` alongside the diffed set, with `?` status and 0/0 counts, matching the default view's Untracked section
+
+## [0.1.10] — 2026-06-30
+
+### Added
+
+- A dashed filler row fills the empty side of a split-layout hunk (an inserted/deleted block with nothing on the opposite side), so it reads as "no line here" instead of a blank void, matching the native vimdiff look
+- Diff buffers now carry a private `differdiff` filetype instead of the source file's, so foreign `FileType <lang>` autocmds (LSP, linters, semantic tokens) never attach to a throwaway `differ://` buffer. The source filetype is stashed in `b:differ_filetype`; `differ.lualine` ships a drop-in for lualine's filetype component that reads it (with a devicon), falling back to the native filetype everywhere else
+
+### Fixed
+
+- Jumping to the real file (`de`) a second time no longer throws `E37` when that buffer is already current and has unsaved changes; it switches to the already-loaded buffer instead of forcing a disk reload
+
+## [0.1.9] — 2026-06-28
+
+### Fixed
+
+- Opening a modified binary file (e.g. a changed gif/mp4) no longer crashes the editor. Its content was read as raw bytes, split on stray `0x0a` bytes into pathological pseudo-lines, and fed through the O(n·m) word-diff pairing, exhausting memory until nvim was killed. Binary content is now detected (a NUL byte in the first 8kb, git's own heuristic) and the diff is skipped: the renderers show a "Binary file not shown" placeholder, the git frontend still opens the entry despite zero hunks, and the winbar reads "binary"
+
+## [0.1.8] — 2026-06-28
+
+### Added
+
+- The merge tool advances through conflicts on `:w`: once a file's markers are gone it stages and opens the next conflicted file, reporting done and closing (back on the invoking tab) once none remain. `:Differ close` stops after the current file
+- The merge result buffer disables in-buffer markdown rendering (render-markdown.nvim) for the session, since a `.md` result was otherwise read as prose and the conflict marker runs concealed as nested block-quotes; restored on close
+- Panel `gg`/`G` now just move the cursor to the first/last visitable file row without opening it (`<CR>`/`o` opens the row under the cursor)
+- Log panel commit-aware navigation: `]]`/`[[` step between commit headers, `gg`/`G` jump to the first/last commit, `O`/`C`/`c` expand/collapse commits, none of which open a diff on landing
+- Bare `:Differ log` with no real file in the current buffer now shows the full HEAD history instead of warning
+- `:Differ panel` toggles the sidebar in place; a bare `:Differ` re-opens it
+- The panel footer shows `diff --stat` totals and fits the file-name column to the longest name
+
+## [0.1.7] — 2026-06-24
+
+### Added
+
+- `:Differ panel <pos>` repositions a live `:Differ log` sidebar in place instead of spawning a second, overlapping session; a bare `:Differ panel` over a live log session is now a no-op + notify rather than opening a worktree diff on top of it
+- A dedicated `history` config table (`position`/`height`/`width`, defaulting to the bottom edge) that the log openers read
+- The hunk-counter marker in the diff winbar renders the nerd-font git-diff glyph when `nvim-web-devicons` is present, falling back to the plain diamond otherwise
+- `:Differ log` reworked: defaults to the bottom strip (the wide sha/date/author/subject row fits on one line there); left/right positions render two lines per commit instead, clipping at the window edge with no ellipsis. `K` floats the full commit message plus author/date/hash
+- `:Differ` (the worktree-status panel) now lands on the first unstaged file rather than the first changed file, skipping a Staged section with nothing left to review; falls back to the first visitable file when everything is staged
+
+### Fixed
+
+- Refuse to stage a file when a formatter has reindented its conflict markers: a `BufWritePost` check detects an indented `<<<<<<<`/`>>>>>>>` region and bails out of the `git add` with a one-time warning, guarding against the column-0 parser silently reading zero conflicts
+- Hunk staging no longer corrupts the patch when applied after an earlier staged deletion. `patch.hunk` shifted both `@@` starts by the staged-hunk offset; under `--unidiff-zero` git relocates a single zero-context hunk by content and reads only one side's start, so a net-negative offset could drive the unused side below zero and git would reject the patch as corrupt. Now only the located side shifts per direction, leaving the other at its frozen, always-non-negative line number
+
+## [0.1.6] — 2026-06-24
+
+### Added
+
+- Staged hunks now paint as a dimmed deep diff (same-hue add/delete line and word spans, well under the live weights) instead of a flat muted background, so a staged hunk still shows what changed while reading as set aside. The cursor-line tint stays lifted above the staged fill so the focused line still lights up, and repaints after a stage/unstage toggle
+
+### Fixed
+
+- Opening a diff (or single-file `:Differ log`) on the file you're already in now lands the cursor on the exact line you were on, instead of snapping to the nearest hunk's top. A cursor on unchanged context still falls back to the first hunk. For history, only the first commit shown holds the line; later commit steps land on the first hunk since older content no longer maps to it
+
+## [0.1.5] — 2026-06-23
+
+### Added
+
+- A `g?` keymap cheatsheet on the merge result buffer, matching the panel, history, and diff views
+- `cursorline_tint` config option (default on): the cursor line now paints in a stronger shade of its own add/delete colour instead of a neutral overlay, so the change kind reads under the cursor
+
+### Changed
+
+- The diff view now opens directly on the first hunk rather than one line above it, since the cursor-line tint keeps the hunk's colour visible under the cursor
+
+### Fixed
+
+- The merge result buffer widens `timeoutlen` to a 1s floor while focused (restored on leave/close) so the multi-key conflict chords (`<leader>co`/`ct`/`cb`/`ca`, `dx`) don't drop under a short global `timeoutlen`
+- The merge result buffer opts out of format-on-save (`vim.b.disable_autoformat`) for the session, since a formatter running on `:w` could choke on or mangle unresolved conflict markers
+
+## [0.1.4] — 2026-06-23
+
+### Fixed
+
+- Panel fold state is now scoped per section rather than shared globally by bare directory path, so a directory name present in two sections (e.g. an untracked `src/` and an unstaged `src/`) no longer collapses both from a single toggle. The cursor is also re-anchored to the toggled directory row after re-render instead of being restored by absolute line number, which could land it in the footer once rows above it disappeared
+
+## [0.1.3] — 2026-06-23
+
 ### Added
 
 - Floating keymap cheatsheet (`g?`) on the diff window and the in-review edit window, alongside the panel and history surfaces that already had it. The cheatsheet rows come from the live keymaps, so a configured `lhs` shows correctly, and it lists only the keys actually bound for the active source (staging, edit-in-review, and the session's extra maps such as the PR unviewed nav and thread/comment verbs)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ differ's only install step is building the Go sidecar, so point your manager's b
 | `:Differ <a>...` | merge-base(`<a>`, `HEAD`) vs worktree (branch total) |
 | `:Differ <a> <b>` | `<a>` vs `<b>` |
 
+Any source with worktree on the new side (the first three rows above) also lists untracked files: `git diff` can't see them no matter what refs you pass it, so differ unions in `git ls-files --others --exclude-standard` to fill the gap. They show with a `?` status and 0/0 counts, same as the default panel's Untracked section.
+
 ### Runtime controls
 
 These re-render the active view only. No refetch, no re-diff, and the state is local to that view.

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -161,6 +161,14 @@ function M.conflicted(root)
     return out and rev.parse_unmerged(out) or {}
 end
 
+-- repo-relative paths of untracked files, respecting .gitignore, in git's order
+---@param root string
+---@return string[]
+function M.untracked(root)
+    local out = git({ "ls-files", "--others", "--exclude-standard", "-z" }, root)
+    return out and rev.parse_paths(out) or {}
+end
+
 -- whether `relpath` is currently conflicted
 ---@param root string
 ---@param relpath string
@@ -329,7 +337,12 @@ local function numstat(args, root)
 end
 
 -- the change set as panel FileEntry records: one flat list with `+N -M` counts,
--- used for rev-pair sources. working-tree sources use status_sections instead
+-- used for rev-pair sources. working-tree sources use status_sections instead.
+-- `git diff` never lists untracked files regardless of the refs passed to it, so
+-- a worktree new-side (branch total, `:Differ <rev>`, ...) unions them in here;
+-- counts stay 0/0, matching the untracked entries status_sections produces for
+-- the default view. no overlap to dedupe: untracked means absent from the index,
+-- which `changed_files` always reads through, so the two lists are disjoint
 ---@param source differ.git.Source -- resolved
 ---@param root string
 ---@return differ.FileEntry[]
@@ -345,6 +358,11 @@ function M.file_entries(source, root)
             deletions = c.deletions or 0,
             previous_path = f.previous_path,
         }
+    end
+    if source.new.kind == "worktree" then
+        for _, path in ipairs(M.untracked(root)) do
+            out[#out + 1] = { path = path, status = "?", additions = 0, deletions = 0 }
+        end
     end
     return out
 end

--- a/lua/differ/git/rev.lua
+++ b/lua/differ/git/rev.lua
@@ -193,11 +193,12 @@ function M.parse_numstat(out)
     return counts
 end
 
--- parse `git diff --name-only --diff-filter=U -z` into the conflicted paths.
--- each path appears once; the trailing NUL leaves an empty field we drop
+-- parse a bare NUL-separated path list (`git diff --name-only -z`,
+-- `git ls-files -z`). each path appears once; the trailing NUL leaves an
+-- empty field we drop
 ---@param out string
 ---@return string[]
-function M.parse_unmerged(out)
+function M.parse_paths(out)
     local paths = {}
     for _, p in ipairs(nul_split(out)) do
         if p ~= "" then
@@ -205,6 +206,13 @@ function M.parse_unmerged(out)
         end
     end
     return paths
+end
+
+-- parse `git diff --name-only --diff-filter=U -z` into the conflicted paths
+---@param out string
+---@return string[]
+function M.parse_unmerged(out)
+    return M.parse_paths(out)
 end
 
 return M

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -61,6 +61,40 @@ describe("git.read / changed_files", function()
     end)
 end)
 
+describe("git.file_entries (rev-pair sources)", function()
+    it("unions in untracked files for a worktree new-side, but not a rev new-side", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n") -- tracked, modified
+        write(root .. "/u.lua", "untracked\n") -- untracked, no diff can ever see it
+
+        local wt_entries = git_src.file_entries(git_src.resolve(rev.source({}), root), root)
+        table.sort(wt_entries, function(x, y)
+            return x.path < y.path
+        end)
+        assert.are.same({
+            { status = "M", path = "a.lua", additions = 1, deletions = 1 },
+            { status = "?", path = "u.lua", additions = 0, deletions = 0 },
+        }, wt_entries)
+
+        -- a rev-vs-rev source (no worktree side) never gains untracked files
+        git(root, "checkout", "-q", "-b", "feature")
+        git(root, "commit", "-q", "-am", "feature change")
+        local rev_source = git_src.resolve({
+            old = { kind = "rev", rev = "main", label = "main" },
+            new = {
+                kind = "rev",
+                rev = "HEAD",
+                label = "HEAD",
+            },
+        }, root)
+        local rev_entries = git_src.file_entries(rev_source, root)
+        assert.are.same(
+            { { status = "M", path = "a.lua", additions = 1, deletions = 1 } },
+            rev_entries
+        )
+    end)
+end)
+
 describe("git.open_file", function()
     it("reads the rename's old side from previous_path", function()
         local root = fresh_repo()


### PR DESCRIPTION
## Summary
- branch total (`<a>...`) and `:Differ <rev>` never surfaced untracked files, since `git diff` can't see them regardless of refs; `file_entries` now unions in `git ls-files --others --exclude-standard` when the source's new side is the worktree
- reconciles CHANGELOG.md (backfills 0.1.4-0.1.10 from commit bodies) and documents the untracked-file behaviour in the README's revspec table

## Test plan
- [ ] `make test` passes
- [ ] manually verify `:Differ <rev>` and branch total diffs show untracked files with `?` status