### PR TITLE
fix: count untracked files' real lines in the panel --stat totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Untracked files now count their real lines as additions in the panel's `--stat` totals and per-file `+N` counts, instead of a hardcoded `0/0`. An untracked file has no old side to diff against, so every line in it is genuinely an addition; binary content still counts as `0`, matching how binary tracked changes have always been reported
+
+## [0.1.11] — 2026-07-04
+
+### Fixed
+
 - Untracked files no longer silently drop out of rev-pair diffs against the worktree (branch total `<a>...`, `:Differ <rev>`). `git diff` never lists them regardless of the refs passed to it, so the panel now unions in `git ls-files --others --exclude-standard` alongside the diffed set, with `?` status and 0/0 counts, matching the default view's Untracked section
 
 ## [0.1.10] — 2026-06-30

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ differ's only install step is building the Go sidecar, so point your manager's b
 | `:Differ <a>...` | merge-base(`<a>`, `HEAD`) vs worktree (branch total) |
 | `:Differ <a> <b>` | `<a>` vs `<b>` |
 
-Any source with worktree on the new side (the first three rows above) also lists untracked files: `git diff` can't see them no matter what refs you pass it, so differ unions in `git ls-files --others --exclude-standard` to fill the gap. They show with a `?` status and 0/0 counts, same as the default panel's Untracked section.
+Any source with worktree on the new side (the first three rows above) also lists untracked files: `git diff` can't see them no matter what refs you pass it, so differ unions in `git ls-files --others --exclude-standard` to fill the gap. They show with a `?` status and their line count as the addition count (0 for binary content), same as the default panel's Untracked section.
 
 ### Runtime controls
 

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -8,6 +8,7 @@ local rev = require("differ.git.rev")
 local patch = require("differ.git.patch")
 local log = require("differ.git.log")
 local watch = require("differ.git.watch")
+local text_util = require("differ.util.text")
 
 local M = {}
 
@@ -167,6 +168,20 @@ end
 function M.untracked(root)
     local out = git({ "ls-files", "--others", "--exclude-standard", "-z" }, root)
     return out and rev.parse_paths(out) or {}
+end
+
+-- an untracked file has no diff to numstat, so every line reads as an addition;
+-- binary content counts as 0, matching how numstat's `-` markers already read
+-- binary tracked changes as 0/0
+---@param root string
+---@param relpath string
+---@return integer
+local function untracked_additions(root, relpath)
+    local content = M.read(WORKTREE, root, relpath)
+    if not content or text_util.is_binary(content) then
+        return 0
+    end
+    return #text_util.to_lines(content)
 end
 
 -- whether `relpath` is currently conflicted
@@ -339,10 +354,11 @@ end
 -- the change set as panel FileEntry records: one flat list with `+N -M` counts,
 -- used for rev-pair sources. working-tree sources use status_sections instead.
 -- `git diff` never lists untracked files regardless of the refs passed to it, so
--- a worktree new-side (branch total, `:Differ <rev>`, ...) unions them in here;
--- counts stay 0/0, matching the untracked entries status_sections produces for
--- the default view. no overlap to dedupe: untracked means absent from the index,
--- which `changed_files` always reads through, so the two lists are disjoint
+-- a worktree new-side (branch total, `:Differ <rev>`, ...) unions them in here,
+-- with a real line count (see untracked_additions) so they carry their weight in
+-- the panel's --stat totals. no overlap to dedupe: untracked means absent from
+-- the index, which `changed_files` always reads through, so the two lists are
+-- disjoint
 ---@param source differ.git.Source -- resolved
 ---@param root string
 ---@return differ.FileEntry[]
@@ -361,7 +377,12 @@ function M.file_entries(source, root)
     end
     if source.new.kind == "worktree" then
         for _, path in ipairs(M.untracked(root)) do
-            out[#out + 1] = { path = path, status = "?", additions = 0, deletions = 0 }
+            out[#out + 1] = {
+                path = path,
+                status = "?",
+                additions = untracked_additions(root, path),
+                deletions = 0,
+            }
         end
     end
     return out
@@ -382,8 +403,13 @@ function M.status_sections(root)
     local staged, unstaged, untracked = {}, {}, {}
     for _, s in ipairs(entries) do
         if s.x == "?" then
-            untracked[#untracked + 1] =
-                { path = s.path, status = "?", additions = 0, deletions = 0, staged = false }
+            untracked[#untracked + 1] = {
+                path = s.path,
+                status = "?",
+                additions = untracked_additions(root, s.path),
+                deletions = 0,
+                staged = false,
+            }
         else
             -- previous_path only belongs to whichever side carries the rename:
             -- an "RM" file is renamed HEAD↔index but plain-modified index↔worktree

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -73,7 +73,7 @@ describe("git.file_entries (rev-pair sources)", function()
         end)
         assert.are.same({
             { status = "M", path = "a.lua", additions = 1, deletions = 1 },
-            { status = "?", path = "u.lua", additions = 0, deletions = 0 },
+            { status = "?", path = "u.lua", additions = 1, deletions = 0 },
         }, wt_entries)
 
         -- a rev-vs-rev source (no worktree side) never gains untracked files
@@ -92,6 +92,39 @@ describe("git.file_entries (rev-pair sources)", function()
             { { status = "M", path = "a.lua", additions = 1, deletions = 1 } },
             rev_entries
         )
+    end)
+
+    it("counts an untracked file's real lines, but 0 for binary content", function()
+        local root = fresh_repo()
+        write(root .. "/multi.lua", "one\ntwo\nthree\n")
+        write(root .. "/bin.dat", "abc\0def")
+
+        local entries = git_src.file_entries(git_src.resolve(rev.source({}), root), root)
+        table.sort(entries, function(x, y)
+            return x.path < y.path
+        end)
+        assert.are.same({
+            { status = "?", path = "bin.dat", additions = 0, deletions = 0 },
+            { status = "?", path = "multi.lua", additions = 3, deletions = 0 },
+        }, entries)
+    end)
+end)
+
+describe("git.status_sections", function()
+    it("counts an untracked file's real lines, same as file_entries", function()
+        local root = fresh_repo()
+        write(root .. "/multi.lua", "one\ntwo\nthree\n")
+
+        local sections = git_src.status_sections(root)
+        local untracked
+        for _, sec in ipairs(sections) do
+            if sec.title == "Untracked" then
+                untracked = sec.entries
+            end
+        end
+        assert.are.same({
+            { path = "multi.lua", status = "?", additions = 3, deletions = 0, staged = false },
+        }, untracked)
     end)
 end)
 


### PR DESCRIPTION
## Summary
- untracked `file_entries`/`status_sections` entries hardcoded `0/0`, so the panel's `--stat` totals and per-file `+N` counts silently undercounted whenever an untracked file carried real content
- an untracked file has no old side to diff against, so every line in it is a genuine addition; binary content still counts as `0`, matching binary tracked changes
- adds the changelog entry, and cuts it into the 0.1.11 release alongside the untracked-diffs fix from #17

## Test plan
- [x] `make check` passes (Lua unit + headless-nvim tests, Lua/Go lint)
- [ ] manually verify an untracked file's `+N` count and the panel's `--stat` total in the default view and a rev-pair source (e.g. `:Differ HEAD~1...`)