### PR TITLE
fix: align notify wording/level for PR checks and threads

### DIFF
--- a/lua/differ/pr/checks.lua
+++ b/lua/differ/pr/checks.lua
@@ -132,7 +132,7 @@ local function render(checks)
             close()
             vim.ui.open(url)
         else
-            notify("this check has no url")
+            notify("this check has no url", vim.log.levels.WARN)
         end
     end
     vim.keymap.set("n", "<CR>", open_under_cursor, { buffer = buf, nowait = true })

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -315,7 +315,7 @@ end
 function M.toggle_thread()
     local anchor = cursor_anchor()
     if not anchor then
-        return notify("no review thread on this line")
+        return notify("no thread on this line")
     end
     local threads = require("differ.pr.threads")
     threads.toggle_group(session, anchor)
@@ -359,7 +359,7 @@ end
 function M.resolve()
     local anchor = cursor_anchor()
     if not anchor then
-        return notify("no review thread on this line")
+        return notify("no thread on this line")
     end
     local target
     for _, t in ipairs(anchor.threads) do
@@ -610,8 +610,8 @@ local function open_session(pr, detail, opts)
             end,
             desc = "previous unviewed file",
         },
-        { spec = diff_km.next_thread, fn = M.next_thread, desc = "next review thread" },
-        { spec = diff_km.prev_thread, fn = M.prev_thread, desc = "previous review thread" },
+        { spec = diff_km.next_thread, fn = M.next_thread, desc = "next thread" },
+        { spec = diff_km.prev_thread, fn = M.prev_thread, desc = "previous thread" },
         { spec = diff_km.toggle_thread, fn = M.toggle_thread, desc = "toggle thread" },
         { spec = diff_km.resolve_thread, fn = M.resolve, desc = "resolve thread" },
         -- commenting: ga single (normal) / range (visual), gp reply to a thread

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -904,6 +904,39 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
+    it("notifies rather than re-applying when a hunk is already in the target state", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")
+        git(root, "commit", "-q", "-am", "8 lines")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8x\n") -- two far-apart edits
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        v:stage_hunk()
+        assert.is_true(v.staged_hunks[1])
+
+        -- s/u on a hunk already in the target state re-enter the review flow instead
+        -- (stage_hunk/unstage_hunk step past it), so _toggle_hunk itself is called
+        -- directly here to exercise its own already-staged/already-unstaged guard
+        _G.notifs = {}
+        v:_toggle_hunk(true)
+        assert.are.equal("differ: hunk already staged", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.INFO, _G.notifs[1].level)
+        assert.is_true(v.staged_hunks[1]) -- state untouched
+
+        v:_toggle_hunk(false) -- actually unstage it, so the mirror check below is real
+        assert.is_false(v.staged_hunks[1])
+        _G.notifs = {}
+        v:_toggle_hunk(false)
+        assert.are.equal("differ: hunk already unstaged", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.INFO, _G.notifs[1].level)
+        assert.is_false(v.staged_hunks[1]) -- state untouched
+        p:close()
+    end)
+
     it("stages an untracked file as one whole-file hunk instead of warning", function()
         local root = fresh_repo()
         write(root .. "/new.lua", "alpha\nbeta\n") -- untracked, the only change
@@ -1255,12 +1288,21 @@ describe(":Differ diff hunk staging", function()
         v:unstage_all()
         assert.are.equal("a.lua", v.model.path)
 
+        _G.notifs = {}
         v:step_file("next") -- ]f to z.lua (the last file)
         assert.are.equal("z.lua", v.model.path)
+        assert.are.equal(0, #_G.notifs) -- a plain step, not a wrap
+
+        _G.notifs = {}
         v:step_file("next", false) -- review-style step: no wrap off the last file
         assert.are.equal("z.lua", v.model.path)
+        assert.are.equal(0, #_G.notifs) -- wrap disabled, so no wrap notify either
+
+        _G.notifs = {}
         v:step_file("next") -- ]f / [f: wraps to the first
         assert.are.equal("a.lua", v.model.path)
+        assert.are.equal("differ: wrapped to the first file", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.INFO, _G.notifs[1].level)
         p:close()
     end)
 
@@ -1601,10 +1643,17 @@ describe(":Differ (open_first)", function()
         local v = require("differ.view").current()
         assert.are.equal("a.lua", v.model.path)
 
+        _G.notifs = {}
         v:step_file("next") -- ]f past the last file wraps to the first
         assert.are.equal("z.lua", require("differ.view").current().model.path)
+        assert.are.equal("differ: wrapped to the first file", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.INFO, _G.notifs[1].level)
+
+        _G.notifs = {}
         v:step_file("prev") -- [f past the first wraps back to the last
         assert.are.equal("a.lua", require("differ.view").current().model.path)
+        assert.are.equal("differ: wrapped to the last file", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.INFO, _G.notifs[1].level)
         p:close()
     end)
 

--- a/test/nvim/history_spec.lua
+++ b/test/nvim/history_spec.lua
@@ -63,6 +63,17 @@ local function view_in_origin(h)
     return require("differ.view").current()
 end
 
+-- fire a buffer's ]c / [c keymap by lhs, so the test exercises the real bound
+-- callback (and its opts.fallback), not a hand-rolled call to View:goto_hunk
+local function goto_hunk(bufnr, lhs)
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+        if m.lhs == lhs and m.callback then
+            return m.callback()
+        end
+    end
+    error("no " .. lhs .. " keymap bound on buffer " .. bufnr)
+end
+
 describe("git.log_commits", function()
     it("lists a file's commits newest first with parsed fields", function()
         local root = repo_with_history()
@@ -161,12 +172,22 @@ describe(":Differ log (single-file history)", function()
         git_src.history({})
         local h = History.current()
         local v = view_in_origin(h)
+        local diff_buf = v.columns[1].bufnr
+        -- park exactly on the commit's only hunk so ]c / [c hit the boundary on the
+        -- very first press, regardless of where the origin buffer's cursor started
+        local hunk_start = require("differ.nav").next_hunk(v.columns[1].map, 0)
+        vim.api.nvim_win_set_cursor(h.origin_win, { hunk_start, 0 })
+
         -- the newest commit's diff is a single hunk; stepping past it must NOT flow into
         -- the next/previous commit (that's ]f/[f) — the selected commit stays put
-        v:goto_hunk("next")
+        _G.notifs = {}
+        goto_hunk(diff_buf, "]c")
         assert.are.equal(1, h.index)
-        v:goto_hunk("prev")
+        assert.are.equal("differ: no more hunks in this commit", _G.notifs[1].msg)
+        _G.notifs = {}
+        goto_hunk(diff_buf, "[c")
         assert.are.equal(1, h.index)
+        assert.are.equal("differ: no previous hunks in this commit", _G.notifs[1].msg)
         h:close()
     end)
 

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -141,6 +141,21 @@ describe(":Differ mergetool", function()
         end
     end)
 
+    it("notifies rather than opening when invoked outside a git repository", function()
+        require("differ.git") -- warm the require cache before chdir makes it unresolvable
+        local outside = vim.fn.tempname()
+        vim.fn.mkdir(outside, "p")
+        local cwd = vim.fn.getcwd()
+        vim.cmd("enew") -- an unnamed scratch buffer, so M.open falls back to cwd
+        vim.fn.chdir(outside)
+        _G.notifs = {}
+        merge.open({})
+        vim.fn.chdir(cwd)
+        assert.is_nil(merge.current())
+        assert.are.equal("differ: not inside a git repository", _G.notifs[1].msg)
+        assert.are.equal(vim.log.levels.WARN, _G.notifs[1].level)
+    end)
+
     it("opens a session over the conflicted current file", function()
         local root = conflict_repo()
         vim.cmd.edit(root .. "/f.txt")

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -1,0 +1,173 @@
+-- runs under headless nvim: exercises the pr session frontend against a stubbed
+-- sidecar. every pr/*.lua module only ever reaches the outside world through
+-- differ.sidecar.request (see pr/client.lua), so stubbing that one seam is enough to
+-- drive a real session (get_pr -> open_session -> panel + diff) without a Go subprocess
+
+require("differ").setup({})
+
+local sidecar = require("differ.sidecar")
+local pr = require("differ.pr")
+
+-- replace differ.sidecar.request for the duration of a test, dispatching by method
+-- name to a canned `{result, err}` per method (missing method -> empty result), and
+-- scheduling the callback like the real client does. returns a restore() to undo it
+---@param responses table<string, { result: any, err: table|nil }>
+local function stub_sidecar(responses)
+    local real = sidecar.request
+    sidecar.request = function(method, _params, cb)
+        local r = responses[method]
+        vim.schedule(function()
+            if r then
+                cb(r.err, r.result)
+            else
+                cb(nil, {})
+            end
+        end)
+    end
+    return function()
+        sidecar.request = real
+    end
+end
+
+local PR = { owner = "acme", repo = "widget", number = 7 }
+
+---@param overrides table|nil
+local function get_pr_result(overrides)
+    return vim.tbl_extend("force", {
+        title = "add widget",
+        body = "",
+        author = "octocat",
+        base_sha = "aaa1111",
+        head_sha = "bbb2222",
+        head_ref = "feature",
+        url = "https://example.test/acme/widget/pull/7",
+        state = "open",
+        draft = false,
+        mergeable = true,
+        files = {
+            {
+                path = "a.txt",
+                status = "modified",
+                additions = 1,
+                deletions = 1,
+                viewed_state = "UNVIEWED",
+            },
+        },
+    }, overrides or {})
+end
+
+-- fire a buffer-local keymap by its description, so a test doesn't depend on <leader>
+-- (same pattern as mergetool_spec.lua)
+local function fire(buf, desc)
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+        if m.desc == desc and m.callback then
+            m.callback()
+            return true
+        end
+    end
+    return false
+end
+
+-- fire a buffer-local keymap by its lhs (the checks float sets no desc on <CR>/o)
+local function fire_lhs(buf, lhs)
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+        if m.lhs == lhs and m.callback then
+            m.callback()
+            return true
+        end
+    end
+    return false
+end
+
+describe("pr session notifies", function()
+    after_each(function()
+        if pr.current_session() then
+            pr.end_session()
+        end
+    end)
+
+    it("warns when opening a check with no url from the checks float", function()
+        local restore = stub_sidecar({
+            get_pr = { result = get_pr_result() },
+            get_file_versions = {
+                result = { base = { content = "a\n" }, head = { content = "b\n" } },
+            },
+            get_checks = {
+                result = {
+                    rollup = "FAILURE",
+                    checks = { { name = "build", status = "COMPLETED", conclusion = "FAILURE" } },
+                },
+            },
+        })
+
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            return pr.current_session() ~= nil
+        end))
+
+        pr.checks()
+        assert.is_true(vim.wait(1000, function()
+            return vim.api.nvim_win_get_config(0).relative ~= ""
+        end))
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        _G.notifs = {}
+        assert.is_true(fire_lhs(vim.api.nvim_get_current_buf(), "o"))
+        assert.are.equal("differ: this check has no url", _G.notifs[#_G.notifs].msg)
+        assert.are.equal(vim.log.levels.WARN, _G.notifs[#_G.notifs].level)
+
+        restore()
+    end)
+
+    it("notifies 'no thread on this line' toggling a thread off a plain diff line", function()
+        local restore = stub_sidecar({
+            get_pr = { result = get_pr_result() },
+            get_file_versions = {
+                result = { base = { content = "a\nb\nc\n" }, head = { content = "a\nB\nc\n" } },
+            },
+            get_threads = { result = {} },
+        })
+
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            local s = pr.current_session()
+            return s and s.view and s.view:is_open()
+        end))
+        assert.is_true(vim.wait(1000, function()
+            return pr.current_session().threads ~= nil
+        end))
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        _G.notifs = {}
+        assert.is_true(fire(vim.api.nvim_get_current_buf(), "toggle thread"))
+        assert.are.equal("differ: no thread on this line", _G.notifs[#_G.notifs].msg)
+
+        restore()
+    end)
+
+    it("notifies 'no thread on this line' resolving off a plain diff line", function()
+        local restore = stub_sidecar({
+            get_pr = { result = get_pr_result() },
+            get_file_versions = {
+                result = { base = { content = "a\nb\nc\n" }, head = { content = "a\nB\nc\n" } },
+            },
+            get_threads = { result = {} },
+        })
+
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            local s = pr.current_session()
+            return s and s.view and s.view:is_open()
+        end))
+        assert.is_true(vim.wait(1000, function()
+            return pr.current_session().threads ~= nil
+        end))
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        _G.notifs = {}
+        assert.is_true(fire(vim.api.nvim_get_current_buf(), "resolve thread"))
+        assert.are.equal("differ: no thread on this line", _G.notifs[#_G.notifs].msg)
+
+        restore()
+    end)
+end)

--- a/test/nvim/range_history_spec.lua
+++ b/test/nvim/range_history_spec.lua
@@ -176,24 +176,32 @@ describe(":Differ log <range> (branch-range history)", function()
         local diff_buf = view_in_origin(h).columns[1].bufnr
         assert.are.equal("a.lua", view_in_origin(h).model.path)
 
+        _G.notifs = {}
         goto_hunk(diff_buf, "]c") -- past a.lua's only hunk: overflow into c3's second file
         assert.are.equal(2, h.index)
         assert.are.equal(2, h.file_index)
         assert.are.equal("c.lua", view_in_origin(h).model.path)
+        assert.are.equal(0, #_G.notifs) -- a plain step within the commit, not a boundary
 
+        _G.notifs = {}
         goto_hunk(diff_buf, "]c") -- past c.lua's only hunk too: c3 has no more files.
         -- must NOT flow into c4 (that's ]f/[f's job)
         assert.are.equal(2, h.index)
         assert.are.equal(2, h.file_index)
+        assert.are.equal("differ: no more hunks in this commit", _G.notifs[1].msg)
 
+        _G.notifs = {}
         goto_hunk(diff_buf, "[c") -- back over c3's own file boundary to a.lua, landing
         -- on its last (only) hunk
         assert.are.equal(1, h.file_index)
         assert.are.equal("a.lua", view_in_origin(h).model.path)
+        assert.are.equal(0, #_G.notifs) -- a plain step within the commit, not a boundary
 
+        _G.notifs = {}
         goto_hunk(diff_buf, "[c") -- a.lua's first file, first hunk: stop here
         assert.are.equal(2, h.index) -- still c3, not crossed back into c4
         assert.are.equal(1, h.file_index)
+        assert.are.equal("differ: no previous hunks in this commit", _G.notifs[1].msg)
         h:close()
     end)
 


### PR DESCRIPTION
## Summary
- checks.lua's "this check has no url" guard now uses WARN (matching every other "no url" guard elsewhere)
- both "no review thread on this line" notifies shortened to "no thread on this line", matching the rest of the file's thread terminology
- next_thread/prev_thread keymap descs shortened to match ("next thread"/"previous thread")
- adds test coverage for the notify changes from this branch and the prior boundary-notify fixes (]c/[c commit-boundary text, ]f/[f wrap notify, hunk-restage guard, merge repo-guard wording, PR checks/thread guards via a new sidecar-request stub)

## Test plan
- [x] `make lua-test-nvim` (270 passing)
- [x] `make lua-test-unit` (289 passing)
- [x] `make lua-lint` (clean)