### PR TITLE
fix: eol-safe staging and worktree reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .luarc.local.json
 docs/overview.md
 /.plans
+/.DS_Store
+/.tools/
 
 # generated demo fixtures (rebuilt by .demo/setup.sh); the gif/mp4 are committed
 /.demo/fixture/

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -89,7 +89,9 @@ local function close_session_tab(tab)
     if #vim.api.nvim_list_tabpages() == 1 then
         vim.cmd("tabnew")
     end
-    pcall(vim.cmd, "tabclose " .. vim.api.nvim_tabpage_get_number(tab))
+    pcall(function()
+        vim.cmd("tabclose " .. vim.api.nvim_tabpage_get_number(tab))
+    end)
 end
 
 -- repo root containing `path` (a file or directory), or nil if not in a repo
@@ -722,12 +724,13 @@ function M.panel(opts)
             origin_rel = resolved:sub(#root + 2)
         end
     end
-    -- normalise the rev spec to an arg list (explicit branches so the type narrows)
+    -- normalise the rev spec to an arg list (bind to a local so type() narrows it)
+    local rev_opt = opts.rev
     local args ---@type string[]
-    if type(opts.rev) == "table" then
-        args = opts.rev
-    elseif opts.rev then
-        args = { opts.rev }
+    if type(rev_opt) == "table" then
+        args = rev_opt
+    elseif rev_opt then
+        args = { rev_opt }
     else
         args = {}
     end

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -29,7 +29,10 @@ local function notify(msg, level)
     vim.notify("differ: " .. msg, level or vim.log.levels.INFO)
 end
 
--- run git in `cwd`. returns stdout on success, or nil + stderr on failure
+-- run git in `cwd`. returns stdout on success, or nil + stderr on failure.
+-- `text = true` normalises `\r\n` to `\n` in stdout, which is right for plumbing
+-- output (status/numstat/rev-parse/name-status/...) but would corrupt file
+-- content read via `git show`; content reads use git_raw instead
 ---@param args string[]
 ---@param cwd string
 ---@return string|nil stdout, string|nil stderr
@@ -37,6 +40,22 @@ local function git(args, cwd)
     local cmd = { "git" }
     vim.list_extend(cmd, args)
     local res = vim.system(cmd, { cwd = cwd, text = true }):wait()
+    if res.code ~= 0 then
+        return nil, res.stderr
+    end
+    return res.stdout
+end
+
+-- like `git`, but without `text = true`: stdout comes back byte-true (CRLF kept
+-- intact) instead of newline-normalised. use for content-bearing reads (`git
+-- show` on the index/a rev/a conflict stage), never for plumbing output
+---@param args string[]
+---@param cwd string
+---@return string|nil stdout, string|nil stderr
+local function git_raw(args, cwd)
+    local cmd = { "git" }
+    vim.list_extend(cmd, args)
+    local res = vim.system(cmd, { cwd = cwd }):wait()
     if res.code ~= 0 then
         return nil, res.stderr
     end
@@ -195,7 +214,7 @@ function M.read(ref, root, relpath)
     end
     -- index (stage 0) is `:path`; a rev is `<rev>:path`
     local spec = (ref.kind == "index" and ":" or (ref.rev .. ":")) .. relpath
-    return git({ "show", spec }, root) -- nil if the path is absent in that tree
+    return git_raw({ "show", spec }, root) -- nil if the path is absent in that tree
 end
 
 -- one conflict stage's full content for `relpath`: 1=base, 2=ours, 3=theirs.
@@ -206,7 +225,7 @@ end
 ---@param stage 1|2|3
 ---@return string
 function M.read_stage(root, relpath, stage)
-    return git({ "show", (":%d:"):format(stage) .. relpath }, root) or ""
+    return git_raw({ "show", (":%d:"):format(stage) .. relpath }, root) or ""
 end
 
 -- repo-relative paths of the unmerged (conflicted) files, in git's order

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -43,6 +43,7 @@ local function git(args, cwd)
     return res.stdout
 end
 
+-- strip trailing whitespace from a git output line (e.g. rev-parse, show, log)
 local function chomp(s)
     return (s:gsub("%s+$", ""))
 end
@@ -117,9 +118,63 @@ local function resolve_ref(ref, root)
     return { kind = "rev", rev = chomp(out), label = ref.label }
 end
 
+-- worktree bytes as `git add` would store them (the clean filter: eol
+-- conversion, text attrs, custom filters), so worktree-side diffs compare in
+-- the repo domain, like `git diff`, and the hunk patches built from the model
+-- stage the same blob a `git add` of the file would write. runs the real
+-- `git add` against a throwaway copy of the index and reads the entry back, so
+-- every conversion rule (safe-crlf stickiness included) is git's own, not a
+-- reimplementation. gated on a CR byte in non-binary content: LF-only content
+-- can't convert differently, so the common case pays nothing. any failure
+-- falls back to the raw bytes (the old behaviour)
+---@param root string
+---@param relpath string
+---@param data string
+---@return string
+local function as_staged(root, relpath, data)
+    if not data:find("\r", 1, true) or text_util.is_binary(data) then
+        return data
+    end
+    local index = git({ "rev-parse", "--git-path", "index" }, root)
+    if not index then
+        return data
+    end
+    index = chomp(index)
+    if index:sub(1, 1) ~= "/" then
+        index = root .. "/" .. index -- --git-path can print relative to the cwd
+    end
+    local tmp = vim.fn.tempname()
+    local src = io.open(index, "rb") -- absent in a fresh repo: git add creates tmp
+    if src then
+        local blob = src:read("*a")
+        src:close()
+        local dst = io.open(tmp, "wb")
+        if not dst then
+            return data
+        end
+        dst:write(blob)
+        dst:close()
+    end
+    local env = { GIT_INDEX_FILE = tmp }
+    local add = vim.system({ "git", "add", "--", relpath }, { cwd = root, env = env }):wait()
+    if add.code ~= 0 then
+        os.remove(tmp)
+        return data
+    end
+    -- raw read, no text=true: that would strip the CRs git chose to keep
+    local show = vim.system({ "git", "show", ":" .. relpath }, { cwd = root, env = env }):wait()
+    os.remove(tmp)
+    if show.code ~= 0 or not show.stdout then
+        return data
+    end
+    return show.stdout
+end
+
 -- read a side's content for `relpath` (repo-root-relative). returns the content
 -- (possibly ""), or nil when the file is absent on that side (added/deleted);
--- callers treat nil as an empty file so the diff renders an add/delete
+-- callers treat nil as an empty file so the diff renders an add/delete.
+-- the worktree side reads through the clean filter (as_staged) so it lands in
+-- the same domain as the index/rev sides
 ---@param ref differ.git.Ref
 ---@param root string
 ---@param relpath string
@@ -136,7 +191,7 @@ function M.read(ref, root, relpath)
         end
         local data = fd:read("*a")
         fd:close()
-        return data
+        return as_staged(root, relpath, data)
     end
     -- index (stage 0) is `:path`; a rev is `<rev>:path`
     local spec = (ref.kind == "index" and ":" or (ref.rev .. ":")) .. relpath

--- a/lua/differ/git/watch.lua
+++ b/lua/differ/git/watch.lua
@@ -17,6 +17,8 @@ Watcher.__index = Watcher
 ---@field handles table<string, userdata> -- fs_event handles keyed by "git"/"file"
 ---@field file_dir string|nil
 ---@field timer userdata|nil
+---@field watch_file fun(self: differ.git.Watcher, path: string|nil)
+---@field stop fun(self: differ.git.Watcher)
 
 -- start watching `git_dir`; the file watch is attached later via watch_file
 ---@param opts { git_dir: string, on_change: fun() }

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -266,12 +266,13 @@ end
 -- splice both recompute from one source
 ---@param active integer|nil  -- the live index of the conflict under the cursor
 local function paint_result(active)
-    vim.api.nvim_buf_clear_namespace(session.result_buf, merge_ns, 0, -1)
-    for _, r in ipairs(session.regions) do
+    local s = assert(session)
+    vim.api.nvim_buf_clear_namespace(s.result_buf, merge_ns, 0, -1)
+    for _, r in ipairs(s.regions) do
         local on = r.index == active
         local function fill(side, first, last)
             local pair = SECTION_HL[side]
-            paint_lines(session.result_buf, first, last, on and pair.active or pair.normal)
+            paint_lines(s.result_buf, first, last, on and pair.active or pair.normal)
         end
         fill("ours", r.result_start, (r.mark_base or r.mark_sep) - 1)
         if r.mark_base then
@@ -310,18 +311,20 @@ end
 -- keymap splices stay consistent), plus the buffer's current lines
 ---@return differ.merge.Region[], string[]
 local function live_regions()
-    local lines = vim.api.nvim_buf_get_lines(session.result_buf, 0, -1, false)
+    local s = assert(session)
+    local lines = vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false)
     return require("differ.git.conflict").parse(lines), lines
 end
 
 -- the live index of the conflict under the result cursor, else nil
 ---@return integer|nil
 local function active_index()
-    if not vim.api.nvim_win_is_valid(session.result_win) then
+    local s = assert(session)
+    if not vim.api.nvim_win_is_valid(s.result_win) then
         return nil
     end
-    local cur = vim.api.nvim_win_get_cursor(session.result_win)[1]
-    for _, r in ipairs(session.regions) do
+    local cur = vim.api.nvim_win_get_cursor(s.result_win)[1]
+    for _, r in ipairs(s.regions) do
         if cur >= r.result_start and cur <= r.result_end then
             return r.index
         end
@@ -334,16 +337,17 @@ end
 -- maintains it itself (so this no-ops), but an arbitrary hand-edit + write rebuilds it to
 -- the identity so the pane sync stays consistent (degrading to live-index = original-index)
 local function repaint_result()
+    local s = assert(session)
     local regions = live_regions()
-    session.regions = regions
-    if not session.order or #session.order ~= #regions then
-        session.order = {}
+    s.regions = regions
+    if not s.order or #s.order ~= #regions then
+        s.order = {}
         for i = 1, #regions do
-            session.order[i] = i
+            s.order[i] = i
         end
     end
-    session.active_index = active_index()
-    paint_result(session.active_index)
+    s.active_index = active_index()
+    paint_result(s.active_index)
 end
 
 -- run fn with scrollbind off on every merge window, then restore it. the panes are
@@ -352,15 +356,16 @@ end
 -- cursor off the conflict, stalling ]x), so centring happens with the bind lifted
 ---@param fn fun()
 local function without_scrollbind(fn)
+    local s = assert(session)
     local saved = {}
     local function each(f)
-        for _, inp in ipairs(session.inputs) do
+        for _, inp in ipairs(s.inputs) do
             if vim.api.nvim_win_is_valid(inp.win) then
                 f(inp.win)
             end
         end
-        if vim.api.nvim_win_is_valid(session.result_win) then
-            f(session.result_win)
+        if vim.api.nvim_win_is_valid(s.result_win) then
+            f(s.result_win)
         end
     end
     each(function(w)
@@ -604,7 +609,9 @@ function M.close()
         if #vim.api.nvim_list_tabpages() == 1 then
             vim.cmd("tabnew")
         end
-        pcall(vim.cmd, "tabclose " .. vim.api.nvim_tabpage_get_number(s.session_tab))
+        pcall(function()
+            vim.cmd("tabclose " .. vim.api.nvim_tabpage_get_number(s.session_tab))
+        end)
     end
     if vim.api.nvim_tabpage_is_valid(s.return_tab) then
         vim.api.nvim_set_current_tabpage(s.return_tab)
@@ -727,12 +734,22 @@ function lay_out(root, relpath, model, layout)
         end
     end
 
+    -- the render layer always yields a result column; assert so the buf type narrows
+    -- (and a broken render fails loudly here rather than nil-derefing later)
+    assert(result_buf, "merge: render produced no result column")
+
     local win_side = { [result_win] = "result" }
     for _, win in ipairs(input_wins) do
         dress(win)
         set_local(win, "signcolumn", "yes:1") -- room for the ▌ slab sign
     end
     dress(result_win)
+
+    -- nav + take-this resolution live on the result buffer (the working surface), from
+    -- the configurable merge keymaps; falls back to the flat defaults when setup
+    -- wasn't called, like the diff view does
+    local cfg = require("differ").get_config()
+    local km = cfg.keymaps.merge or require("differ.config").defaults.keymaps
 
     local first = model.regions[1]
     session = {
@@ -756,6 +773,7 @@ function lay_out(root, relpath, model, layout)
         win_side = win_side,
         return_tab = return_tab,
         session_tab = session_tab,
+        keymaps = km, -- for the g? cheatsheet
         diag_aug = suppress_diagnostics(result_buf), -- the markers aren't valid source
         saved_markdown_render = quiet_markdown_render(result_buf), -- don't conceal the markers
     }
@@ -772,12 +790,6 @@ function lay_out(root, relpath, model, layout)
     apply_folds(result_win, result_col and result_col.folds)
     paint_result(nil)
 
-    -- nav + take-this resolution live on the result buffer (the working surface), from
-    -- the configurable merge keymaps; falls back to the flat defaults when setup
-    -- wasn't called, like the diff view does
-    local cfg = require("differ").get_config()
-    local km = cfg.keymaps.merge or require("differ.config").defaults.keymaps
-    session.keymaps = km -- for the g? cheatsheet
     -- the result is the real file, so a format-on-save would run on :w and choke on (or
     -- mangle) the conflict markers. set conform's buffer-local opt-out for the session,
     -- restored on close; honoured by any format_on_save gate that checks the flag

--- a/lua/differ/pr/checks.lua
+++ b/lua/differ/pr/checks.lua
@@ -98,7 +98,11 @@ local function render(checks)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
     local ns = vim.api.nvim_create_namespace("differ.checks")
     for i, hl in ipairs(hls) do
-        vim.api.nvim_buf_add_highlight(buf, ns, hl, i - 1, 0, -1)
+        vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, {
+            end_row = i,
+            end_col = 0,
+            hl_group = hl,
+        })
     end
     vim.bo[buf].modifiable = false
     vim.bo[buf].bufhidden = "wipe"

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -59,6 +59,46 @@ describe("git.read / changed_files", function()
         local files = git_src.changed_files(rev.source({}), root)
         assert.are.same({ { status = "M", path = "a.lua" } }, files)
     end)
+
+    it("keeps CRLF bytes intact for a rev read and an index read", function()
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git(root, "init", "-q")
+        write(root .. "/f.txt", "a\r\nb\r\nc\r\n")
+        git(root, "add", "f.txt")
+        git(root, "commit", "-q", "-m", "base")
+        write(root .. "/f.txt", "a\r\nB\r\nc\r\n")
+        git(root, "add", "f.txt") -- stage the CRLF edit into the index, worktree untouched
+
+        local head = { kind = "rev", rev = "HEAD", label = "HEAD" }
+        local index = { kind = "index", label = "INDEX" }
+        assert.are.equal("a\r\nb\r\nc\r\n", git_src.read(head, root, "f.txt"))
+        assert.are.equal("a\r\nB\r\nc\r\n", git_src.read(index, root, "f.txt"))
+    end)
+end)
+
+describe("git.read_stage", function()
+    it("keeps CRLF bytes intact for each conflict stage (base/ours/theirs)", function()
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git(root, "init", "-q")
+        write(root .. "/f.txt", "a\r\nb\r\nc\r\n")
+        git(root, "add", "f.txt")
+        git(root, "commit", "-q", "-m", "base")
+        git(root, "checkout", "-q", "-b", "feature")
+        write(root .. "/f.txt", "a\r\nTHEIRS\r\nc\r\n")
+        git(root, "commit", "-q", "-am", "theirs")
+        git(root, "checkout", "-q", "main")
+        write(root .. "/f.txt", "a\r\nOURS\r\nc\r\n")
+        git(root, "commit", "-q", "-am", "ours")
+        -- merging conflicts (non-zero exit), which is expected here: use raw
+        -- vim.system directly rather than the asserting `git` helper above
+        vim.system({ "git", "merge", "feature" }, { cwd = root, text = true }):wait()
+
+        assert.are.equal("a\r\nb\r\nc\r\n", git_src.read_stage(root, "f.txt", 1)) -- base
+        assert.are.equal("a\r\nOURS\r\nc\r\n", git_src.read_stage(root, "f.txt", 2)) -- ours
+        assert.are.equal("a\r\nTHEIRS\r\nc\r\n", git_src.read_stage(root, "f.txt", 3)) -- theirs
+    end)
 end)
 
 describe("git.read (worktree clean filter)", function()

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -92,8 +92,18 @@ describe("git.read_stage", function()
         write(root .. "/f.txt", "a\r\nOURS\r\nc\r\n")
         git(root, "commit", "-q", "-am", "ours")
         -- merging conflicts (non-zero exit), which is expected here: use raw
-        -- vim.system directly rather than the asserting `git` helper above
-        vim.system({ "git", "merge", "feature" }, { cwd = root, text = true }):wait()
+        -- vim.system directly rather than the asserting `git` helper above, but still
+        -- pin identity so the merge doesn't abort before conflicting on runners with no
+        -- global gitconfig
+        vim.system({
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "merge",
+            "feature",
+        }, { cwd = root, text = true }):wait()
 
         assert.are.equal("a\r\nb\r\nc\r\n", git_src.read_stage(root, "f.txt", 1)) -- base
         assert.are.equal("a\r\nOURS\r\nc\r\n", git_src.read_stage(root, "f.txt", 2)) -- ours

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -61,6 +61,63 @@ describe("git.read / changed_files", function()
     end)
 end)
 
+describe("git.read (worktree clean filter)", function()
+    local wt = { kind = "worktree", label = "WORKTREE" }
+
+    -- raw git stdout: the spec-level git() uses text=true, which collapses \r\n,
+    -- so byte-exact blob assertions read through vim.system directly
+    local function raw_indexed(root, path)
+        local res = vim.system({ "git", "show", ":" .. path }, { cwd = root }):wait()
+        assert(res.code == 0, res.stderr)
+        return res.stdout
+    end
+
+    it("cleans CRLF worktree content the way git add would (autocrlf=input)", function()
+        local root = fresh_repo()
+        git(root, "config", "core.autocrlf", "input")
+        -- a tool rewrote the tracked (LF-blob) file with CRLF endings
+        write(root .. "/a.lua", "local x = 1\r\nNEW LINE\r\nreturn x\r\n")
+        assert.are.equal("local x = 1\nNEW LINE\nreturn x\n", git_src.read(wt, root, "a.lua"))
+    end)
+
+    it("keeps CRLF when the index blob already has CRLF (safe-crlf stickiness)", function()
+        local root = fresh_repo()
+        git(root, "config", "core.autocrlf", "false")
+        write(root .. "/c.txt", "one\r\ntwo\r\n")
+        git(root, "add", "c.txt")
+        git(root, "commit", "-q", "-m", "crlf blob")
+        git(root, "config", "core.autocrlf", "input")
+        write(root .. "/c.txt", "one\r\ntwo\r\nthree\r\n")
+        -- git add wouldn't renormalise a file whose index blob has CRLF; nor do we
+        assert.are.equal("one\r\ntwo\r\nthree\r\n", git_src.read(wt, root, "c.txt"))
+    end)
+
+    it("passes CRLF through untouched when no conversion is configured", function()
+        local root = fresh_repo()
+        git(root, "config", "core.autocrlf", "false")
+        write(root .. "/c.txt", "one\r\ntwo\r\n")
+        assert.are.equal("one\r\ntwo\r\n", git_src.read(wt, root, "c.txt"))
+    end)
+
+    it("hunk staging stores the same blob a git add would (no CRLF leak)", function()
+        local root = fresh_repo()
+        git(root, "config", "core.autocrlf", "input")
+        write(root .. "/a.lua", "local x = 1\r\nNEW LINE\r\nreturn x\r\n")
+
+        local source = {
+            old = { kind = "index", label = "INDEX" },
+            new = { kind = "worktree", label = "WORKTREE" },
+        }
+        local model = git_src.model(source, root, { path = "a.lua" })
+        assert.are.equal(1, #model.hunks) -- the insert only, no phantom eol hunks
+        local patch = require("differ.git.patch")
+        local p = patch.hunk("a.lua", model.hunks[1], model.old_text, model.new_text, 0, false)
+        assert.is_true(git_src.apply_patch(root, p, false))
+        -- the staged blob is byte-identical to what `git add` would have written
+        assert.are.equal("local x = 1\nNEW LINE\nreturn x\n", raw_indexed(root, "a.lua"))
+    end)
+end)
+
 describe("git.file_entries (rev-pair sources)", function()
     it("unions in untracked files for a worktree new-side, but not a rev new-side", function()
         local root = fresh_repo()

--- a/test/nvim/sidecar_spec.lua
+++ b/test/nvim/sidecar_spec.lua
@@ -28,6 +28,9 @@ end
 
 describe("sidecar client", function()
     if not has_binary() then
+        -- one-arg pending(name) is valid busted;
+        -- the type stub only declares pending(name, block)
+        ---@diagnostic disable-next-line: missing-parameter
         pending("bin/differ-sidecar not built (run `make go-build`)")
         return
     end


### PR DESCRIPTION
## Summary
- read git content byte-true instead of newline-normalised, so CRLF files stage and diff correctly
- clean-filter worktree reads so hunk staging matches what `git add` would write
- narrow nilable session/rev/pcall types for lua_ls
- replace deprecated `nvim_buf_add_highlight` in the checks panel
- gitignore local lua_ls tooling dir and `.DS_Store`

## Test plan
- [x] `make test` / lua unit tests (see `test/nvim/git_spec.lua`, `test/nvim/sidecar_spec.lua`)
- [x] lua_ls / luacheck clean