### PR TITLE
chore: add informational lua_ls type-check target

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -6,9 +6,10 @@
         "${3rd}/busted/library",
         "${3rd}/luassert/library"
     ],
-    "workspace.ignoreDir": [".luacheckrc"],
+    "workspace.ignoreDir": [".luacheckrc", ".tools"],
     "diagnostics.globals": ["vim"],
     "diagnostics.disable": [
-        "redundant-parameter"
+        "redundant-parameter",
+        "need-check-nil"
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,15 @@ GO_BIN  := bin/differ-sidecar
 GO_VERSION := $(shell git describe --tags --always 2>/dev/null | sed 's/^v//' || echo dev)
 GO_LDFLAGS := -X github.com/undont/differ.nvim/internal/protocol.Binary=$(GO_VERSION)
 
+# pinned lua-language-server: its diagnostics shift between releases (a version bump
+# alone can turn a clean tree red), so the version is fixed here and fetched into
+# .tools rather than taken from PATH/Mason. bump deliberately
+LUALS_VERSION := 3.18.2
+LUALS_DIR     := .tools/lua-language-server-$(LUALS_VERSION)
+LUALS_BIN     := $(LUALS_DIR)/bin/lua-language-server
+
 .PHONY: help \
-	lua-test lua-test-unit lua-test-nvim lua-lint lua-fmt lua-fmt-check \
+	lua-test lua-test-unit lua-test-nvim lua-lint lua-typecheck lua-fmt lua-fmt-check \
 	go-build go-test go-vet go-lint go-fmt go-fmt-check \
 	test lint fmt fmt-check check clean \
 	demo demo-fixtures
@@ -53,6 +60,22 @@ lua-fmt: ## Format Lua sources with stylua
 
 lua-fmt-check: ## Verify Lua formatting without writing
 	@stylua --check lua plugin test
+
+lua-typecheck: $(LUALS_BIN) ## Type-check Lua with pinned lua_ls (informational; not in `check` yet)
+	@$(INFO) "Type-checking Lua (lua_ls $(LUALS_VERSION))"
+	@$(LUALS_BIN) --check . --checklevel=Warning --logpath=.tools/luals-report
+	@$(OK) "Lua type-check clean"
+
+# fetch the pinned lua_ls into .tools on first use; the whole tree is gitignored
+$(LUALS_BIN):
+	@$(INFO) "Fetching lua-language-server $(LUALS_VERSION)"
+	@mkdir -p $(LUALS_DIR)
+	@os=$$(uname -s | tr 'A-Z' 'a-z'); \
+	arch=$$(uname -m); \
+	case "$$arch" in x86_64) arch=x64;; aarch64|arm64) arch=arm64;; esac; \
+	case "$$os" in darwin|linux) ;; *) printf "$(RED)unsupported OS: $$os$(NC)\n"; exit 1;; esac; \
+	url="https://github.com/LuaLS/lua-language-server/releases/download/$(LUALS_VERSION)/lua-language-server-$(LUALS_VERSION)-$$os-$$arch.tar.gz"; \
+	curl -fsSL "$$url" | tar -xz -C $(LUALS_DIR) && $(OK) "Installed lua_ls $(LUALS_VERSION)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 ##@ Go sidecar

--- a/lua/differ/panel/tree.lua
+++ b/lua/differ/panel/tree.lua
@@ -12,7 +12,7 @@ local M = {}
 ---@field deletions integer
 ---@field staged boolean|nil       -- which local section it belongs to
 ---@field previous_path string|nil -- renames/copies
----@Field viewed boolean|nil       -- PR only
+---@field viewed boolean|nil       -- PR only
 
 ---@class differ.panel.Node
 ---@field kind "dir"|"file"


### PR DESCRIPTION
Adds a pinned lua-language-server type-check target and fixes the one genuine annotation bug it surfaced.

## What

- `make lua-typecheck`: fetches a pinned lua_ls 3.18.2 into gitignored `.tools/` and runs `--check . --checklevel=Warning`. Informational only, **not** wired into `make check`, `lint`, or CI.
- `.luarc.json`: ignore `.tools`, disable `need-check-nil` (module-state-under-invariant noise, ~623 findings, the `assert(session)` pattern).
- `fix`: `differ.FileEntry.viewed` was declared with `---@Field` (capital F), which lua_ls ignores, so every `entry.viewed` access tripped `undefined-field`/`inject-field`. Corrected to `---@field`; clears 10 findings.

## Why informational, not a gate

A sweep found no genuine runtime bugs. The remaining ~114 findings are benign: incomplete internal `---@class` annotations, libuv handle methods absent from the meta, stdlib return-type strictness, and real nvim types (`vim.SystemObj`, `vim.api.keyset.highlight`) the pinned meta can't resolve. Not worth contorting code to satisfy. The target is kept as an on-demand tool; revisit CI gating if contributors arrive.