### PR TITLE
chore: pin, clean and gate a lua_ls type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,21 @@ jobs:
         with:
           args: lua
 
+  lua-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # the Makefile fetches a version-pinned lua_ls into .tools; cache it on
+      # the pin (keying on the Makefile line that declares it)
+      - uses: actions/cache@v4
+        with:
+          path: .tools/lua-language-server-*
+          key: luals-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
+      - name: Type-check
+        run: make lua-typecheck
+
   lua-test:
     runs-on: ubuntu-latest
     strategy:

--- a/.luarc.json
+++ b/.luarc.json
@@ -6,9 +6,10 @@
         "${3rd}/busted/library",
         "${3rd}/luassert/library"
     ],
-    "workspace.ignoreDir": [".luacheckrc"],
+    "workspace.ignoreDir": [".luacheckrc", ".tools"],
     "diagnostics.globals": ["vim"],
     "diagnostics.disable": [
-        "redundant-parameter"
+        "redundant-parameter",
+        "need-check-nil"
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,17 +11,20 @@ Thanks for considering a contribution to differ.nvim.
 ## Before opening a PR
 
 ```sh
-make check       # lint + vet + full test suite (Lua + Go)
+make check       # lint + type-check + vet + full test suite (Lua + Go)
 ```
 
 Or run pieces individually:
 
 ```sh
-make test        # Lua (unit + headless-nvim) + Go tests
-make lint        # luacheck + stylua --check + golangci-lint
-make fmt         # format Lua and Go sources
-make help        # full target list
+make test           # Lua (unit + headless-nvim) + Go tests
+make lint           # luacheck + stylua --check + golangci-lint
+make lua-typecheck  # lua_ls type-check over lua/ (pinned; fetched on first run)
+make fmt            # format Lua and Go sources
+make help           # full target list
 ```
+
+The Lua type-check runs a version-pinned lua-language-server, downloaded into gitignored `.tools/` on first use (needs `curl` and network access, once). It covers `lua/` only and must be clean; CI enforces it. luacheck and lua_ls are independent and can disagree: a fix that satisfies one can trip the other, so run both before pushing.
 
 Modules under `test/unit` must not touch any Neovim or `vim` API, at load or in the functions they test — that's what keeps them fast and dependency-free. Neovim-only behaviour (windows, extmarks, treesitter) belongs in `test/nvim` instead. See `docs/manual-testing.md` for the manual checklist covering what the automated suites don't reach.
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,15 @@ GO_BIN  := bin/differ-sidecar
 GO_VERSION := $(shell git describe --tags --always 2>/dev/null | sed 's/^v//' || echo dev)
 GO_LDFLAGS := -X github.com/undont/differ.nvim/internal/protocol.Binary=$(GO_VERSION)
 
+# pinned lua-language-server: its diagnostics shift between releases (a version bump
+# alone can turn a clean tree red), so the version is fixed here and fetched into
+# .tools rather than taken from PATH/Mason. bump deliberately
+LUALS_VERSION := 3.18.2
+LUALS_DIR     := .tools/lua-language-server-$(LUALS_VERSION)
+LUALS_BIN     := $(LUALS_DIR)/bin/lua-language-server
+
 .PHONY: help \
-	lua-test lua-test-unit lua-test-nvim lua-lint lua-fmt lua-fmt-check \
+	lua-test lua-test-unit lua-test-nvim lua-lint lua-typecheck lua-fmt lua-fmt-check \
 	go-build go-test go-vet go-lint go-fmt go-fmt-check \
 	test lint fmt fmt-check check clean \
 	demo demo-fixtures
@@ -53,6 +60,22 @@ lua-fmt: ## Format Lua sources with stylua
 
 lua-fmt-check: ## Verify Lua formatting without writing
 	@stylua --check lua plugin test
+
+lua-typecheck: $(LUALS_BIN) ## Type-check Lua with pinned lua_ls (informational; not in `check` yet)
+	@$(INFO) "Type-checking Lua (lua_ls $(LUALS_VERSION))"
+	@$(LUALS_BIN) --check . --checklevel=Warning --logpath=.tools/luals-report
+	@$(OK) "Lua type-check clean"
+
+# fetch the pinned lua_ls into .tools on first use; the whole tree is gitignored
+$(LUALS_BIN):
+	@$(INFO) "Fetching lua-language-server $(LUALS_VERSION)"
+	@mkdir -p $(LUALS_DIR)
+	@os=$$(uname -s | tr 'A-Z' 'a-z'); \
+	arch=$$(uname -m); \
+	case "$$arch" in x86_64) arch=x64;; aarch64|arm64) arch=arm64;; esac; \
+	case "$$os" in darwin|linux) ;; *) printf "$(RED)unsupported OS: $$os$(NC)\n"; exit 1;; esac; \
+	url="https://github.com/LuaLS/lua-language-server/releases/download/$(LUALS_VERSION)/lua-language-server-$(LUALS_VERSION)-$$os-$$arch.tar.gz"; \
+	curl -fsSL "$$url" | tar -xz -C $(LUALS_DIR) && $(OK) "Installed lua_ls $(LUALS_VERSION)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 ##@ Go sidecar

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,11 @@ lua-fmt: ## Format Lua sources with stylua
 lua-fmt-check: ## Verify Lua formatting without writing
 	@stylua --check lua plugin test
 
+# checks lua/ only; test specs deliberately pass invalid inputs. lua_ls config
+# discovery is path-sensitive, so point at the repo-root .luarc.json explicitly
 lua-typecheck: $(LUALS_BIN) ## Type-check Lua with pinned lua_ls (informational; not in `check` yet)
 	@$(INFO) "Type-checking Lua (lua_ls $(LUALS_VERSION))"
-	@$(LUALS_BIN) --check . --checklevel=Warning --logpath=.tools/luals-report
+	@$(LUALS_BIN) --check lua --configpath=$(CURDIR)/.luarc.json --checklevel=Warning --logpath=.tools/luals-report
 	@$(OK) "Lua type-check clean"
 
 # fetch the pinned lua_ls into .tools on first use; the whole tree is gitignored

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ lua-fmt-check: ## Verify Lua formatting without writing
 
 # checks lua/ only; test specs deliberately pass invalid inputs. lua_ls config
 # discovery is path-sensitive, so point at the repo-root .luarc.json explicitly
-lua-typecheck: $(LUALS_BIN) ## Type-check Lua with pinned lua_ls (informational; not in `check` yet)
+lua-typecheck: $(LUALS_BIN) ## Type-check Lua with pinned lua_ls
 	@$(INFO) "Type-checking Lua (lua_ls $(LUALS_VERSION))"
 	@$(LUALS_BIN) --check lua --configpath=$(CURDIR)/.luarc.json --checklevel=Warning --logpath=.tools/luals-report
 	@$(OK) "Lua type-check clean"
@@ -122,7 +122,7 @@ fmt: lua-fmt go-fmt ## Format the whole codebase (Lua + Go)
 
 fmt-check: lua-fmt-check go-fmt-check ## Verify formatting across the codebase
 
-check: lint go-vet test ## Run the full quality gate
+check: lint lua-typecheck go-vet test ## Run the full quality gate
 
 clean: ## Remove build artefacts
 	@rm -rf bin differ-sidecar

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -12,6 +12,10 @@
 ---@field height integer  -- used for top/bottom
 ---@field width integer   -- used for left/right
 
+-- a resolved per-surface keymap table: action -> lhs (a string, a multi-lhs list,
+-- or false to disable). the shape `resolve_keymaps` produces per surface
+---@alias differ.KeymapSet table<string, string|string[]|false>
+
 ---@class differ.Config
 ---@field layout differ.Layout
 ---@field context integer

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -1012,7 +1012,7 @@ function M.panel(opts)
         footer = footer_label(args, root),
         actions = actions,
         on_external_change = refresh_external,
-        keymaps = cfg.keymaps.panel,
+        keymaps = cfg.keymaps.panel --[[@as differ.KeymapSet]],
         listing = opts.listing or panel_cfg.listing,
         position = opts.position or panel_cfg.position,
         height = opts.height or panel_cfg.height,
@@ -1123,7 +1123,7 @@ function M.history(opts)
     local history = History.new({
         commits = commits,
         path = vim.fn.fnamemodify(file, ":~"),
-        keymaps = cfg.keymaps.history,
+        keymaps = cfg.keymaps.history --[[@as differ.KeymapSet]],
         relative_dates = cfg.relative_dates,
         position = opts.position or hist_cfg.position,
         height = hist_cfg.height,
@@ -1196,7 +1196,7 @@ function M.range_history(opts)
         commits = commits,
         mode = "range",
         path = range, -- the header shows the range in place of a file path
-        keymaps = cfg.keymaps.history,
+        keymaps = cfg.keymaps.history --[[@as differ.KeymapSet]],
         relative_dates = cfg.relative_dates,
         position = opts.position or hist_cfg.position,
         height = hist_cfg.height,

--- a/lua/differ/history/init.lua
+++ b/lua/differ/history/init.lua
@@ -738,7 +738,7 @@ end
 
 -- window appearance + buffer-local keymaps
 function History:_setup_window()
-    local win = self.winid
+    local win = assert(self.winid)
     set_wo(win, "number", false)
     set_wo(win, "relativenumber", false)
     set_wo(win, "signcolumn", "no")

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -210,7 +210,7 @@ end
 -- (in the diff window already bound buffer-locally). a no-op with a notice when no
 -- diff is active
 ---@param direction "next"|"prev"
----@param opts? { fallback?: fun(direction: "next"|"prev"): boolean|nil }
+---@param opts? differ.HunkNavOpts
 function M.goto_hunk(direction, opts)
     local view = M.active_view()
     if not view then

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -82,7 +82,7 @@ function M.diff_model(model, opts)
             counter = cfg.diff_counter,
             cursorline_tint = cfg.cursorline_tint,
             deep_diff = cfg.deep_diff,
-            keymaps = cfg.keymaps.diff,
+            keymaps = cfg.keymaps.diff --[[@as table]],
             staging = opts.staging,
             can_stage = opts.can_stage,
             on_edit_unstage = opts.on_edit_unstage,

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -749,7 +749,7 @@ function lay_out(root, relpath, model, layout)
     -- the configurable merge keymaps; falls back to the flat defaults when setup
     -- wasn't called, like the diff view does
     local cfg = require("differ").get_config()
-    local km = cfg.keymaps.merge or require("differ.config").defaults.keymaps
+    local km = (cfg.keymaps.merge or require("differ.config").defaults.keymaps) --[[@as differ.KeymapSet]]
 
     local first = model.regions[1]
     session = {

--- a/lua/differ/merge/model.lua
+++ b/lua/differ/merge/model.lua
@@ -26,7 +26,7 @@ local M = {}
 ---@return differ.MergeModel|nil, string|nil err
 function M.build(root, relpath, head)
     local git = require("differ.git")
-    local result_text = git.read({ kind = "worktree" }, root, relpath)
+    local result_text = git.read({ kind = "worktree", label = "WORKTREE" }, root, relpath)
     if not result_text then
         return nil, "file is not in the working tree"
     end

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -832,7 +832,7 @@ function Panel:focus_first_unstaged()
     local i = self:_file_row(0, "next", false)
     while i do
         local e = self.meta[i].entry
-        if not e.staged and not is_blank_rename(e) then
+        if e and not e.staged and not is_blank_rename(e) then
             pcall(vim.api.nvim_win_set_cursor, self.winid, { i, 0 })
             return
         end

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -106,18 +106,18 @@ Panel.__index = Panel
 ---@field keymaps? table<string, string|string[]|false> -- resolved panel action -> lhs
 ---@field extra_keymaps? differ.panel.ExtraMap[] -- session maps (pr viewed nav)
 ---@field on_step? fun(direction: "next"|"prev", left: differ.FileEntry|nil, new: differ.FileEntry)
-
----@class differ.panel.ExtraMap
----@field spec string|string[]|false  -- resolved lhs (a keymaps value)
----@field fn fun()
----@field desc string
----@field mode? string|string[] -- keymap mode (default normal; pr range-comment uses "x")
 ---@field icons? boolean -- filetype devicons (default true when available)
 ---@field listing? "tree"|"name"
 ---@field position? "bottom"|"top"|"left"|"right"
 ---@field height? integer
 ---@field width? integer
 ---@field progress? boolean -- file-position meter in the panel winbar (default on)
+
+---@class differ.panel.ExtraMap
+---@field spec string|string[]|false  -- resolved lhs (a keymaps value)
+---@field fn fun()
+---@field desc string
+---@field mode? string|string[] -- keymap mode (default normal; pr range-comment uses "x")
 
 -- build a panel (buffer only; the window is created on :open, so it's headless-
 -- constructible for tests)
@@ -1023,7 +1023,7 @@ end
 
 -- window appearance + buffer-local keymaps
 function Panel:_setup_window()
-    local win = self.winid
+    local win = assert(self.winid)
     -- window-local only: a plain vim.wo[win] write also sets the global default
     -- (omits scope), leaking the panel's chrome onto every other window
     set_wo(win, "number", false)

--- a/lua/differ/panel/tree.lua
+++ b/lua/differ/panel/tree.lua
@@ -12,7 +12,7 @@ local M = {}
 ---@field deletions integer
 ---@field staged boolean|nil       -- which local section it belongs to
 ---@field previous_path string|nil -- renames/copies
----@Field viewed boolean|nil       -- PR only
+---@field viewed boolean|nil       -- PR only
 
 ---@class differ.panel.Node
 ---@field kind "dir"|"file"

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -109,7 +109,7 @@ function M.comment(session)
     local row = vim.api.nvim_win_get_cursor(win)[1]
     local anchor, err = M.row_anchor(col.map, row, col.side)
     if not anchor then
-        return notify(err)
+        return notify(err or "no commentable line here")
     end
     M.compose(session, { anchor = anchor, anchor_win = win })
 end
@@ -127,7 +127,7 @@ function M.comment_range(session)
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
     local anchor, err = M.range_anchor(col.map, r1, r2, col.side)
     if not anchor then
-        return notify(err)
+        return notify(err or "no commentable line here")
     end
     M.compose(session, { anchor = anchor, anchor_win = win })
 end
@@ -194,7 +194,7 @@ end
 -- active, "posts immediately" otherwise. opts.initial pre-fills the body (the
 -- conflict re-prompt), opts.stale flags the head moved
 ---@param session table
----@param opts { anchor?: table, in_reply_to?: string, initial?: string, stale?: boolean }
+---@param opts { anchor?: table, anchor_win?: integer, in_reply_to?: string, initial?: string, stale?: boolean }
 function M.compose(session, opts)
     local base = opts.in_reply_to and "Reply"
         or (session.review_id and "Comment (draft)" or "Comment (posts immediately)")

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -161,6 +161,10 @@ end
 ---@param entry differ.FileEntry
 ---@param focus_line integer|nil
 local function show_file(entry, focus_line)
+    local s = session
+    if not s then
+        return
+    end
     local function render(vers)
         local base, head = vers.base or {}, vers.head or {}
         local model = require("differ.model.diff").build({
@@ -181,15 +185,15 @@ local function show_file(entry, focus_line)
                 -- re-apply the thread overlay after a layout/context re-render, and
                 -- expand the thread under the cursor as it moves
                 on_rerender = function()
-                    require("differ.pr.threads").apply(session)
+                    require("differ.pr.threads").apply(s)
                 end,
                 on_cursor = function()
-                    require("differ.pr.threads").on_cursor(session)
+                    require("differ.pr.threads").on_cursor(s)
                 end,
             })
         end
         prefetch_around(entry) -- warm the neighbours so the next step is instant
-        require("differ.pr.threads").refresh(session) -- (re)paint inline comment threads
+        require("differ.pr.threads").refresh(s) -- (re)paint inline comment threads
         -- resume position restore: once the target file is rendered, drop the
         -- cursor on the pending comment's mapped row, then clear the one-shot focus
         local pf = session.pending_focus
@@ -313,14 +317,15 @@ end
 -- overrides the cursor-peek default until toggled back; re-apply swaps the boxes in
 -- place (stacked) or shows/hides the float (split), and a no-op off a thread row
 function M.toggle_thread()
+    local s = session
     local anchor = cursor_anchor()
-    if not anchor then
+    if not s or not anchor then
         return notify("no thread on this line")
     end
     local threads = require("differ.pr.threads")
-    threads.toggle_group(session, anchor)
-    threads.apply(session)
-    threads.on_cursor(session) -- reopen/close the split float to match the new state
+    threads.toggle_group(s, anchor)
+    threads.apply(s)
+    threads.on_cursor(s) -- reopen/close the split float to match the new state
 end
 
 -- ]t/[t: move the cursor to the next/prev thread anchor in the current diff column,
@@ -357,8 +362,9 @@ end
 -- several threads, so it acts on the first open one (else the first, to unresolve);
 -- the sidecar flushes its thread cache after the mutation
 function M.resolve()
+    local s = session
     local anchor = cursor_anchor()
-    if not anchor then
+    if not s or not anchor then
         return notify("no thread on this line")
     end
     local target
@@ -375,8 +381,8 @@ function M.resolve()
     local threads = require("differ.pr.threads")
     local new_state = not target.resolved
     target.resolved = new_state
-    threads.apply(session)
-    client.resolve_thread(session.pr, target.thread_id, new_state, function(err, res)
+    threads.apply(s)
+    client.resolve_thread(s.pr, target.thread_id, new_state, function(err, res)
         if not (session and session.view and session.view:is_open()) then
             return -- session torn down while the mutation was in flight
         end
@@ -568,7 +574,9 @@ local function open_session(pr, detail, opts)
         pending_focus = nil, -- one-shot { path, side, line } for resume position-restore
         session_tab = session_tab, -- the tab hosting both the overview page and the review
         overview_win = vim.api.nvim_get_current_win(), -- the page window (pre-panel)
+        ---@type differ.View|nil
         view = nil,
+        ---@type differ.Panel|nil
         panel = nil, -- nil until the user enters the files (build_panel below)
     }
 
@@ -767,9 +775,12 @@ function M.open(opts)
     if opts.land == "files" and session_matches(opts) then
         return enter_files(opts.review)
     end
-    repo.resolve(opts, function(err, coords)
+    repo.resolve(opts --[[@as { coords?: { owner: string, repo: string } }]], function(err, coords)
         if err then
             return notify_err(err)
+        end
+        if not coords then
+            return
         end
         if opts.number then
             return M.show(
@@ -1050,7 +1061,9 @@ function M.resume(arg)
     local function open_then_reattach(pr)
         M.show(pr, {
             after = function()
-                require("differ.pr.review").reattach(session)
+                if session then
+                    require("differ.pr.review").reattach(session)
+                end
             end,
         })
     end

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -179,8 +179,8 @@ local function show_file(entry, focus_line)
             session.view:set_source(model, nil, focus_line and { focus_line = focus_line } or nil)
         else
             session.view = require("differ").diff_model(model, {
-                staging = false,
-                can_stage = false,
+                can_stage = false, -- read-only pr diff, no hunk staging
+
                 extra_keymaps = session.diff_extra_keymaps, -- ]u/[u on the diff surface
                 -- re-apply the thread overlay after a layout/context re-render, and
                 -- expand the thread under the cursor as it moves
@@ -639,7 +639,7 @@ local function open_session(pr, detail, opts)
             sections = { { title = ("#%d %s"):format(pr.number, title), entries = entries } },
             root = ("%s/%s"):format(pr.owner, pr.repo),
             footer = detail.url or detail.head_ref,
-            keymaps = cfg.keymaps.panel,
+            keymaps = cfg.keymaps.panel --[[@as differ.KeymapSet]],
             extra_keymaps = panel_extra,
             on_step = on_step,
             listing = panel_cfg.listing,

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -222,10 +222,10 @@ local function show_file(entry, focus_line)
         if err then
             return notify_err(err)
         end
-        if not (session and session.panel and session.panel:is_open()) then
-            return -- session torn down while the blob was in flight
+        if session ~= s or not (s.panel and s.panel:is_open()) then
+            return -- session torn down (or replaced) while the blob was in flight
         end
-        session.versions[entry.path] = vers
+        s.versions[entry.path] = vers
         render(vers)
     end)
 end

--- a/lua/differ/sidecar/init.lua
+++ b/lua/differ/sidecar/init.lua
@@ -14,6 +14,7 @@ local MAX_ATTEMPTS = 5
 local M = {}
 
 ---@class differ.sidecar.Client
+---@diagnostic disable-next-line: undefined-doc-name
 ---@field proc vim.SystemObj|nil
 ---@field running boolean
 ---@field ready boolean        -- hello handshake completed
@@ -76,6 +77,7 @@ end
 
 local function send(obj)
     if client and client.proc then
+        ---@diagnostic disable-next-line: undefined-field
         client.proc:write(vim.json.encode(obj) .. "\n")
     end
 end
@@ -296,6 +298,7 @@ function M.stop()
     client.running = false
     if client.proc then
         pcall(function()
+            ---@diagnostic disable-next-line: undefined-field
             client.proc:kill(15)
         end)
     end

--- a/lua/differ/ui/highlights.lua
+++ b/lua/differ/ui/highlights.lua
@@ -10,6 +10,7 @@
 local M = {}
 
 -- static links: body diff layers and structural panel chrome
+---@diagnostic disable-next-line: undefined-doc-name
 ---@type table<string, vim.api.keyset.highlight>
 local LINKS = {
     -- thread overlay: all thread groups (range background, panel-tinted chrome,
@@ -106,6 +107,7 @@ end
 -- map the panel's status/count groups onto the palette (status letters,
 -- "Status presentation", and the right-aligned +N -M counts)
 ---@param p table<string, integer>
+---@diagnostic disable-next-line: undefined-doc-name
 ---@return table<string, vim.api.keyset.highlight>
 local function status_groups(p)
     return {
@@ -128,6 +130,7 @@ end
 -- resolved receded (grey), pending draft (orange); meta is dim; body keeps the normal
 -- fg. all share the one panel bg blended off Normal
 ---@param p table<string, integer>
+---@diagnostic disable-next-line: undefined-doc-name
 ---@return table<string, vim.api.keyset.highlight>
 local function thread_groups(p)
     local base = bg_of({ "Normal" }, 0x14161b)
@@ -152,6 +155,7 @@ end
 -- verdict + author groups ride the palette (approved green, requested-changes orange,
 -- author blue) so a review verdict reads at a glance. the title links Title in LINKS
 ---@param p table<string, integer>
+---@diagnostic disable-next-line: undefined-doc-name
 ---@return table<string, vim.api.keyset.highlight>
 local function overview_groups(p)
     return {
@@ -170,6 +174,7 @@ end
 -- adds: active vs inactive intensities (the block under the cursor at full strength, the
 -- rest faint), the ▌ input-slab sign, a stronger input body tint, and the resolved flash
 ---@param p table<string, integer>
+---@diagnostic disable-next-line: undefined-doc-name
 ---@return table<string, vim.api.keyset.highlight>
 local function merge_groups(p)
     local base = bg_of({ "Normal" }, 0x14161b)
@@ -206,6 +211,7 @@ end
 -- on light ones, no per-theme branching. word spans are bg-only (no fg/bold) so the
 -- syntax foreground shows through. these replace the old DiffAdd/DiffDelete links
 ---@param p table<string, integer>
+---@diagnostic disable-next-line: undefined-doc-name
 ---@return table<string, vim.api.keyset.highlight>
 local function diff_bg_groups(p)
     local base = bg_of({ "Normal" }, 0x14161b)

--- a/lua/differ/util/date.lua
+++ b/lua/differ/util/date.lua
@@ -56,7 +56,7 @@ function M.format(epoch, opts)
     if opts.relative then
         return M.relative(epoch, opts.now)
     end
-    return os.date(opts.time and "%Y-%m-%d %H:%M" or "%Y-%m-%d", epoch)
+    return os.date(opts.time and "%Y-%m-%d %H:%M" or "%Y-%m-%d", epoch) --[[@as string]]
 end
 
 -- parse an RFC3339 / ISO-8601 timestamp to an epoch (local-time interpretation;
@@ -77,9 +77,9 @@ function M.parse_iso(ts)
         return nil
     end
     return os.time({
-        year = tonumber(y),
-        month = tonumber(mo),
-        day = tonumber(d),
+        year = tonumber(y) --[[@as integer]],
+        month = tonumber(mo) --[[@as integer]],
+        day = tonumber(d) --[[@as integer]],
         hour = tonumber(h),
         min = tonumber(mi),
         sec = tonumber(s),

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -55,6 +55,7 @@ local armed_view = nil
 ---@field winid integer|nil
 ---@field map differ.LineMap
 ---@field side differ.ColumnSide
+---@field folds? differ.FoldRange[]
 
 -- the hunk-staging capability the git frontend supplies per source. the
 -- view keeps its diff frozen and marks staged hunks in place rather than re-reading

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -241,7 +241,7 @@ end
 -- right buffer (the thread overlay). a stacked view's single "unified" column backs
 -- both sides; a split returns the matching old/new column
 ---@param side differ.ColumnSide
----@return { bufnr: integer, map: differ.LineMap, side: differ.ColumnSide }|nil
+---@return differ.ViewColumn|nil
 function View:column_for(side)
     for _, col in ipairs(self.columns) do
         if col.side == side or col.side == "unified" then
@@ -760,8 +760,12 @@ end
 -- boundary it flows into the adjacent file (no wrap); a log/history session is the
 -- exception: hunk nav stays within the current commit's diff (commits step via ]f/[f),
 -- so it stops at the first/last hunk rather than crossing into the next commit
+-- `fallback` runs past the first/last hunk (a history session steps within its commit)
+---@class differ.HunkNavOpts
+---@field fallback? fun(direction: "next"|"prev"): boolean|nil
+
 ---@param direction "next"|"prev"
----@param opts? { fallback?: fun(direction: "next"|"prev"): boolean|nil }
+---@param opts? differ.HunkNavOpts
 function View:goto_hunk(direction, opts)
     local col = self:_focused_column()
     local win = col.winid or vim.api.nvim_get_current_win()


### PR DESCRIPTION
## Summary
- add `make lua-typecheck`: version-pinned lua_ls 3.18.2 fetched into gitignored `.tools/`, checking `lua/` only (test specs deliberately pass invalid inputs); absolute `--configpath` because lua_ls config discovery silently misses the repo-root `.luarc.json` otherwise
- wire it into `make check` and a CI job (`.tools` cached on the pin); baseline driven 747 findings → 0
- fix `---@Field viewed` (capital F, silently ignored by lua_ls) so `FileEntry.viewed` is actually declared
- correct misplaced/incomplete annotations: panel opts fields were attached to the wrong class, `View:column_for` return type lacked `winid`, session `view`/`panel` handles untyped, `ViewColumn.folds` and compose `anchor_win` undeclared
- share a named `differ.HunkNavOpts` class between the two goto_hunk signatures (lua_ls treats identical anonymous types as incompatible); add a `differ.KeymapSet` alias with casts where one config field holds pre- and post-resolve shapes
- narrow real invariants: `assert(self.winid)` in `_setup_window`, session capture in pr flows, guard `show_file`'s blob fetch on session identity (not just liveness) so a torn-down-and-replaced session can't receive a stale render
- disable `need-check-nil` (module-state-under-invariant pattern) and suppress the nvim types the pinned meta can't resolve outside the editor (`vim.SystemObj`, `vim.api.keyset.highlight`, libuv handle methods)
- document the gate in CONTRIBUTING

supersedes #22

## Test plan
- [x] `make lua-typecheck` clean (0 problems)
- [x] `make check` (full gate incl. the new job's target)
- [x] lua unit 289/0, headless-nvim 276/0