### PR TITLE
feat: diff4 merge layout and grouping-agnostic base recovery

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,56 @@
+name: Changelog Check
+
+# a PR whose title prefix cuts a release (see release.yml) has to leave a mark on the
+# `## [Unreleased]` section of the hand-maintained CHANGELOG.md. label the PR
+# `no changelog` to opt a release-bound change out.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require an Unreleased entry
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          # the prefixes release.yml bumps a version from are the user-facing ones; docs,
+          # chore, refactor and test don't cut a release on their own, so they're exempt
+          if ! printf '%s' "$TITLE" | grep -qiE '^(breaking|add|update|feat|fix)(\(.+\))?:'; then
+            echo "No release-triggering prefix on: $TITLE — no changelog entry required"
+            exit 0
+          fi
+
+          if printf '%s' "$LABELS" | grep -qiE '(^|,)no changelog(,|$)'; then
+            echo "Skipped by the 'no changelog' label"
+            exit 0
+          fi
+
+          # the [Unreleased] section as it stands either side of the PR: comparing the
+          # section rather than the file catches an entry filed under a released version
+          section() {
+            git show "$1:CHANGELOG.md" 2>/dev/null |
+              awk '/^## \[Unreleased\]/ { inside = 1; next } /^## / { inside = 0 } inside'
+          }
+
+          if [ "$(section "$BASE_SHA")" = "$(section HEAD)" ]; then
+            echo "::error::CHANGELOG.md: add an entry under '## [Unreleased]' (or label the PR 'no changelog')"
+            exit 1
+          fi
+          echo "CHANGELOG.md [Unreleased] updated"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- A `diff4` merge layout (`merge.layout = "diff4"`), adding a base column with the common ancestor above the result. `<leader>cb` takes base in either layout, so the layout is about seeing what you're taking, not being able to take it
+- Base recovery under git's default `merge.conflictStyle`, which writes no base into the markers: differ re-merges the stages in diff3 style and maps those regions onto the worktree conflicts, so take-base works without `zdiff3`. Where the mapping can't be trusted the base pane says why (`no common ancestor` on add/add, `none for this conflict` otherwise) and take-base is refused rather than emptying the block
+
+### Changed
+
+- The merge tool's base column is a config preference (`merge.layout`) rather than a per-invocation argument: `:Differ mergetool diff3_mixed` is gone, and the sole argument to `mergetool` is always a path
+
+## [0.1.18] — 2026-07-13
+
+### Added
+
 - A PR overview page: the conversation timeline plus code threads rendered as boxed units (a left-spine box with a top-rule header, spine body rows, and a reply-count footer) that carry their diff hunk inline. The hunk tail is capped (keeping the `@@` header and an elision marker when trimmed), tinted with the diff's own +/- line colours, and treesitter-highlighted from the marker-stripped source rather than the page buffer. `]t`/`[t` hop between thread boxes
 - Enter the review straight from an overview thread: `<CR>`, `e`, or `r` on a thread row open the review at that comment's file and line, landing on the comment with no file-stepping
 - A review to overview round-trip: `go` pops from the review back to the overview, and `q` drops back into the review where you left off, restoring the stashed diff position and the overview's own cursor on the hop back

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ make demo                 # rebuilds fixtures, re-records .demo/demo.gif + .demo
 
 PR titles must start with one of `breaking`, `feat`, `add`, `update`, `fix`, `docs`, `chore`, `refactor`, `test` (enforced by CI). Match the existing `git log` style: lowercase after the prefix, imperative mood, no trailing full stop.
 
+## Changelog
+
+`CHANGELOG.md` is hand-maintained in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) style; the generated GitHub release notes come from commit messages and don't replace it. Land user-facing changes as terse bullets under `## [Unreleased]`, grouped into `### Added` / `### Changed` / `### Fixed`, and let the release rename that section to `## [x.y.z] — YYYY-MM-DD`.
+
+CI enforces it for any PR whose title prefix cuts a release (`breaking`, `add`, `update`, `feat`, `fix`); `docs`, `chore`, `refactor` and `test` don't cut one on their own, so they're exempt. They still ride along in whatever release lands next, so add an entry anyway if such a PR changes something a user would notice. A release-bound change that genuinely warrants no entry can be labelled `no changelog` to skip the check.
+
 ## Opening a PR
 
 `main` is protected, changes land via PR with CI green. Keep a PR scoped to one change; unrelated cleanup belongs in its own PR.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The GitHub side runs in a separate process rather than the editor, so opening a 
 - **PR review in the diff** with inline comment threads, pending-review drafts, thread resolve, per-file viewed-state, CI checks, and lifecycle actions (merge, checkout, ready/draft, close), backed by a Go sidecar that owns the GitHub API
 - **File panel and staging** in a persistent sidebar with the changed-file tree, status icons, +/- counts, and hunk- and file-level staging
 - **File history** for single files and branch ranges, walked commit-by-commit, each step a diff through the same engine
-- **3-way merge tool** running base/ours/theirs through the n-column renderer, resolved into the working-tree file
+- **3-way/4-way merge tool** running ours/theirs (and optionally base) through the n-column renderer, resolved into the working-tree file
 - **Word-level highlighting** and **Treesitter syntax** on by default, so the diff reads like source instead of a grey block
 - **Real buffer lines** for code, so search, yank, and motions all work; the hunk model is canonical and the buffer is a projection of it
 - **One diff engine** (`vim.diff()`, histogram) shared by every source
@@ -229,6 +229,10 @@ Code-comment threads render as a contained box (GitHub's outline, differ's left-
 | `q` | Close the merge tool |
 | `g?` | Help |
 
+`merge.layout` picks the panes: `default` shows ours and theirs over the result, `diff4` adds a base column with the common ancestor. `<leader>cb` takes base in either layout, so `diff4` is about seeing what you're taking, not being able to take it.
+
+You don't need `merge.conflictStyle = zdiff3` for that. Git's default style leaves no base in the conflict markers, so differ works it out from the merge stages instead. Where it can't, the base pane's winbar says so: `no common ancestor` when the file was added on both branches, `none for this conflict` when a conflict couldn't be matched up. Taking base is refused in those cases rather than emptying the block.
+
 The result buffer is the real worktree file, so `:w` writes it and stages it once the markers are gone, then opens the next conflicted file; when none remain the session reports done and closes. Use `:Differ close` to stop after the current file. Because it's a real file, a format-on-save would otherwise run over the conflict markers; the merge tool sets `vim.b.disable_autoformat` (conform's opt-out) for the session, so honour that flag in your `format_on_save` gate if you format on save. If a formatter reformats the markers anyway, differ notices on save, refuses to stage the file, and warns once that the flag isn't being honoured. The merge result also disables in-buffer markdown rendering (render-markdown.nvim) for the session so the conflict markers aren't concealed as block-quotes, restoring it on close.
 
 ### Launchers (a starting point)
@@ -391,6 +395,9 @@ require("differ").setup({
     position = "bottom",
     height = 10,                 -- top/bottom
     width = 40,                  -- left/right
+  },
+  merge = {                      -- merge tool pane layout; no per-invocation override
+    layout = "default",          -- "default" (ours | theirs) | "diff4" (adds base)
   },
   keymaps = {                    -- one flat action -> lhs table, shared across the diff,
     -- a value is a string, a list of strings, or false to disable. override globally

--- a/lua/differ/command.lua
+++ b/lua/differ/command.lua
@@ -212,14 +212,12 @@ function M.close()
     require("differ.git").close()
 end
 
--- :Differ mergetool [path|diff3_mixed]: 3-way conflict resolution. no arg targets
--- the current file (else the sole conflicted file, else a picker); `diff3_mixed` shows the
--- base column too. read-only navigation for now; resolution + write land in slice 3
+-- :Differ mergetool [path]: 3-way conflict resolution. no arg targets the current
+-- file (else the sole conflicted file, else a picker). the pane layout follows the
+-- configured merge.layout (`default` or `diff4`); there's no ad-hoc layout argument,
+-- so the sole arg is always a path
 ---@param arg string|nil
 function M.mergetool(arg)
-    if arg == "diff3_mixed" then
-        return require("differ.merge").open({ layout = "diff3_mixed" })
-    end
     require("differ.merge").open({ path = (arg ~= "" and arg) or nil })
 end
 
@@ -379,7 +377,6 @@ local VALUES = {
     sidecar = { "stop" },
     cache = { "clear" },
     log = { "base" },
-    mergetool = { "diff3_mixed" },
 }
 
 -- second-level completion under `pr <group>`: the review-draft actions, and the

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -81,8 +81,8 @@ M.defaults = {
         width = 40, -- left/right
     },
     -- the merge tool's pane layout: `default` is ours | theirs over the result,
-    -- `diff4` adds the base column (base/ours/theirs over the result). `:Differ
-    -- mergetool diff4` still overrides this per invocation
+    -- `diff4` adds the base column (base/ours/theirs over the result). base-pane
+    -- visibility is a stable preference, so there's no per-invocation argument
     merge = {
         layout = "default",
     },

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -12,6 +12,9 @@
 ---@field height integer  -- used for top/bottom
 ---@field width integer   -- used for left/right
 
+---@class differ.Config.Merge
+---@field layout "default"|"diff4"
+
 -- a resolved per-surface keymap table: action -> lhs (a string, a multi-lhs list,
 -- or false to disable). the shape `resolve_keymaps` produces per surface
 ---@alias differ.KeymapSet table<string, string|string[]|false>
@@ -26,6 +29,7 @@
 ---@field comments { inline: boolean, collapsed: boolean }
 ---@field panel differ.Config.Panel
 ---@field history differ.Config.History
+---@field merge differ.Config.Merge
 ---@field keymaps table<string, string|string[]|false|table>
 ---@field relative_dates boolean
 ---@field base string|nil
@@ -75,6 +79,12 @@ M.defaults = {
         position = "bottom",
         height = 10, -- top/bottom
         width = 40, -- left/right
+    },
+    -- the merge tool's pane layout: `default` is ours | theirs over the result,
+    -- `diff4` adds the base column (base/ours/theirs over the result). `:Differ
+    -- mergetool diff4` still overrides this per invocation
+    merge = {
+        layout = "default",
     },
     -- buffer-local maps, one flat table of action -> lhs shared across the diff,
     -- panel and history surfaces (each binds the actions it implements). a value is

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -238,6 +238,18 @@ function M.read_stage(root, relpath, stage)
     return git_raw({ "show", (":%d:"):format(stage) .. relpath }, root) or ""
 end
 
+-- whether `relpath` has a stage N entry at all. read_stage folds an absent stage into "",
+-- which a genuinely empty one also reads as, and the two want opposite handling: an add/add
+-- conflict has no `:1:` and so no base to take, while an empty ancestor has one to take
+---@param root string
+---@param relpath string
+---@param stage 1|2|3
+---@return boolean
+function M.has_stage(root, relpath, stage)
+    local spec = (":%d:"):format(stage) .. relpath
+    return vim.system({ "git", "cat-file", "-e", spec }, { cwd = root }):wait().code == 0
+end
+
 -- re-merge the three stage texts and return the result in diff3 conflict style (a base
 -- slab between ||||||| and =======), whatever the user's merge.conflictStyle is. used to
 -- recover base slabs when the worktree markers omit them (the default `merge` style).

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -238,6 +238,44 @@ function M.read_stage(root, relpath, stage)
     return git_raw({ "show", (":%d:"):format(stage) .. relpath }, root) or ""
 end
 
+-- re-merge the three stage texts and return the result in diff3 conflict style (a base
+-- slab between ||||||| and =======), whatever the user's merge.conflictStyle is. used to
+-- recover base slabs when the worktree markers omit them (the default `merge` style).
+-- git merge-file works on paths, so the stages go through temp files; a >0 exit is the
+-- conflict count (expected), only a 255 exit is real trouble and returns nil
+---@param ours_text string
+---@param base_text string
+---@param theirs_text string
+---@return string|nil
+function M.merge_file_diff3(ours_text, base_text, theirs_text)
+    local paths = {}
+    local function tmp(text)
+        local p = vim.fn.tempname()
+        local fd = io.open(p, "wb")
+        if not fd then
+            return nil
+        end
+        paths[#paths + 1] = p
+        fd:write(text)
+        fd:close()
+        return p
+    end
+    local ours, base, theirs = tmp(ours_text), tmp(base_text), tmp(theirs_text)
+    local out
+    if ours and base and theirs then
+        -- no text=true: it would strip the CRs git keeps, so a CRLF base slab would no
+        -- longer match the :1: stage the input column locates it against
+        local res = vim.system({ "git", "merge-file", "-p", "--diff3", ours, base, theirs }):wait()
+        if res.code ~= 255 then
+            out = res.stdout
+        end
+    end
+    for _, p in ipairs(paths) do
+        os.remove(p)
+    end
+    return out
+end
+
 -- repo-relative paths of the unmerged (conflicted) files, in git's order
 ---@param root string
 ---@return string[]

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -50,6 +50,7 @@ local INPUT_HL = {
 ---@field path string
 ---@field regions differ.merge.Region[]   -- re-derived from the live result buffer
 ---@field order integer[]                 -- live region position -> original conflict index
+---@field base_slabs table<integer, string[]> -- original conflict index -> recovered base slab
 ---@field total integer                   -- original conflict count (for the winbar N/M)
 ---@field active_index integer|nil        -- live index of the conflict under the cursor
 ---@field labels table<string, string>    -- side -> winbar pane label (OURS (HEAD), ...)
@@ -487,6 +488,11 @@ local function resolve_choice(choice)
     if not region then
         return notify("no conflict under the cursor")
     end
+    -- the live buffer parse carries no base under the default conflictStyle, so take-base
+    -- reads the slab recovered at build time, mapped live index -> original via `order`
+    if choice == "base" and not region.base then
+        region.base = session.base_slabs[session.order[region.index]]
+    end
     local new_lines, delta = require("differ.merge.resolve").splice(lines, region, choice)
     if not new_lines then
         return notify("no base version in this conflict", vim.log.levels.WARN)
@@ -757,6 +763,7 @@ function lay_out(root, relpath, model, layout)
         path = relpath,
         regions = model.regions,
         order = {},
+        base_slabs = {},
         total = #model.regions,
         active_index = nil,
         labels = {
@@ -779,6 +786,12 @@ function lay_out(root, relpath, model, layout)
     }
     for i = 1, #model.regions do
         session.order[i] = i
+    end
+    -- recovered base slabs by original conflict index: the default conflictStyle leaves no
+    -- base in the live result parse, so take-base looks the slab up here (nil where the
+    -- re-merge couldn't recover one, which take-base reports as no base version)
+    for _, r in ipairs(model.regions) do
+        session.base_slabs[r.index] = r.base
     end
 
     -- paint the panes + lay down the (latent) folds

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -1,5 +1,5 @@
 -- the merge-tool session: lay the 3-way render into windows — ours / theirs on
--- top (plus base under the diff3_mixed layout), the result spine full-width below — drive
+-- top (plus base under the diff4 layout), the result spine full-width below — drive
 -- conflict navigation (]x/[x), and resolve per conflict (take ours/theirs/both/base/none),
 -- splicing the chosen slab into the result and stripping the markers. the result column is
 -- the real worktree file: :w writes it and auto-stages once no markers remain, then advances
@@ -53,7 +53,7 @@ local INPUT_HL = {
 ---@field total integer                   -- original conflict count (for the winbar N/M)
 ---@field active_index integer|nil        -- live index of the conflict under the cursor
 ---@field labels table<string, string>    -- side -> winbar pane label (OURS (HEAD), ...)
----@field layout "default"|"diff3_mixed"  -- the chosen layout, reused when advancing to the next file
+---@field layout "default"|"diff4"  -- the chosen layout, reused when advancing to the next file
 ---@field result_win integer
 ---@field result_buf integer              -- the real worktree file (editable)
 ---@field bufs integer[]                  -- the scratch input buffers (deleted on close)
@@ -656,7 +656,7 @@ local function show_help()
     require("differ.ui.help").show(lines, { title = " Differ: merge ", dismiss = dismiss })
 end
 
----@type fun(root: string, relpath: string, model: differ.MergeModel, layout: "default"|"diff3_mixed")
+---@type fun(root: string, relpath: string, model: differ.MergeModel, layout: "default"|"diff4")
 local lay_out
 
 -- once a file resolves + stages, open the next conflicted file (git's order, the staged file
@@ -665,7 +665,7 @@ local lay_out
 -- rather than looping. no commit hint: the merge may be a rebase/cherry-pick/etc., so naming
 -- one command would be wrong as often as right
 ---@param root string
----@param layout "default"|"diff3_mixed"
+---@param layout "default"|"diff4"
 local function advance(root, layout)
     local remaining = require("differ.git").conflicted(root)
     if #remaining == 0 then
@@ -684,7 +684,7 @@ end
 ---@param root string
 ---@param relpath string
 ---@param model differ.MergeModel
----@param layout "default"|"diff3_mixed"
+---@param layout "default"|"diff4"
 function lay_out(root, relpath, model, layout)
     if session then -- re-open over a live session
         M.close()
@@ -912,12 +912,12 @@ function lay_out(root, relpath, model, layout)
 end
 
 -- resolve root + the target relpath, then build + open. with no path the current file is
--- used when it's conflicted, else the sole conflicted file, else a picker over them
----@param opts { path?: string, layout?: "default"|"diff3_mixed" }|nil
+-- used when it's conflicted, else the sole conflicted file, else a picker over them. an
+-- explicit opts.layout wins over the configured merge.layout
+---@param opts { path?: string, layout?: "default"|"diff4" }|nil
 function M.open(opts)
     opts = opts or {}
     local git = require("differ.git")
-    local layout = opts.layout or "default"
 
     local file = vim.api.nvim_buf_get_name(0)
     local anchor = (file ~= "" and vim.fn.filereadable(file) == 1) and file or vim.fn.getcwd()
@@ -930,6 +930,9 @@ function M.open(opts)
     if #conflicted == 0 then
         return notify("no conflicted files to resolve")
     end
+
+    local merge_cfg = require("differ").get_config().merge or {}
+    local layout = opts.layout or merge_cfg.layout or "default"
 
     local function go(relpath)
         local model, err = require("differ.merge.model").build(root, relpath, nil)

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -54,6 +54,7 @@ local INPUT_HL = {
 ---@field total integer                   -- original conflict count (for the winbar N/M)
 ---@field active_index integer|nil        -- live index of the conflict under the cursor
 ---@field labels table<string, string>    -- side -> winbar pane label (OURS (HEAD), ...)
+---@field no_ancestor boolean             -- add/add: the base pane says so rather than sitting empty
 ---@field layout "default"|"diff4"  -- the chosen layout, reused when advancing to the next file
 ---@field result_win integer
 ---@field result_buf integer              -- the real worktree file (editable)
@@ -520,8 +521,36 @@ local function resolve_choice(choice)
     end
 end
 
+-- the active conflict's position among the remaining ones
+---@return integer
+local function active_pos()
+    local s = assert(session)
+    for i, r in ipairs(s.regions) do
+        if r.index == s.active_index then
+            return i
+        end
+    end
+    return 1
+end
+
+-- the base pane says why it's empty rather than looking broken: add/add has no ancestor at
+-- all, and an individual conflict carries no slab when the mapping was too ambiguous to
+-- trust. the file-level cause wins, else every conflict would blame itself for it
+---@return string
+local function base_label()
+    local s = assert(session)
+    local label = s.labels.base or "BASE"
+    if s.no_ancestor then
+        return label .. " · no common ancestor"
+    end
+    if #s.regions > 0 and not s.base_slabs[s.order[active_pos()]] then
+        return label .. " · none for this conflict"
+    end
+    return label
+end
+
 -- winbar text for the merge windows: the result shows the conflict counter, an input
--- shows its static side label. a `%!` expression reading the window it renders for
+-- shows its side label. a `%!` expression reading the window it renders for
 ---@return string
 function M.winbar()
     if not session then
@@ -534,17 +563,13 @@ function M.winbar()
             return "RESULT · all resolved"
         end
         local total = session.total
-        local pos = 1 -- the active conflict's position among the remaining
-        for i, r in ipairs(session.regions) do
-            if r.index == session.active_index then
-                pos = i
-                break
-            end
-        end
-        local n = (total - remaining) + pos -- the absolute conflict ordinal
+        local n = (total - remaining) + active_pos() -- the absolute conflict ordinal
         return ("RESULT · conflict %d/%d · %d unresolved"):format(n, total, remaining)
     end
     local side = session.win_side[win]
+    if side == "base" then
+        return base_label()
+    end
     return side and (session.labels[side] or side:upper()) or ""
 end
 
@@ -772,6 +797,7 @@ function lay_out(root, relpath, model, layout)
             theirs = ("THEIRS (%s)"):format((first and first.label_theirs) or "MERGE_HEAD"),
             result = "RESULT",
         },
+        no_ancestor = model.no_ancestor or false,
         layout = layout,
         result_win = result_win,
         result_buf = result_buf,

--- a/lua/differ/merge/model.lua
+++ b/lua/differ/merge/model.lua
@@ -4,6 +4,8 @@
 -- under any merge.conflictStyle; the marker parse only locates the regions
 
 local conflict = require("differ.git.conflict")
+local find_run = require("differ.util.lines").find_run
+local find_runs = require("differ.util.lines").find_runs
 local to_lines = require("differ.util.text").to_lines
 
 ---@class differ.MergeModel
@@ -18,13 +20,63 @@ local to_lines = require("differ.util.text").to_lines
 
 local M = {}
 
+-- the maximal run of synthetic regions this side owns, extending while each candidate's
+-- slab places in order and disjoint inside `lines`. empty slabs are skipped, so they ride
+-- along mid-run and are left behind at its end. `from - 1` when the side located nothing
+---@param lines string[]  -- the worktree region's slab for this side
+---@param synth differ.merge.Region[]
+---@param key "ours"|"theirs"
+---@param from integer
+---@return integer
+local function claim_run(lines, synth, key, from)
+    local last, cursor = from - 1, 1
+    for i = from, #synth do
+        local slab = synth[i][key]
+        if #slab > 0 then
+            local s = find_run(lines, slab, cursor)
+            if not s then
+                break
+            end
+            cursor, last = s + #slab, i
+        end
+    end
+    return last
+end
+
+-- the base-stage span a run covers, anchored on its first and last located slab. the span,
+-- not the sub-slabs concatenated, so a coalesced block keeps its interstitials. all-empty
+-- base slabs cover nothing, which take-base resolves to a deletion
+---@param base_slabs string[][]  -- per synthetic region, in order
+---@param at table<integer, integer>  -- synthetic index -> base-stage start
+---@param first integer
+---@param last integer
+---@param base_lines string[]
+---@return string[]
+local function base_span(base_slabs, at, first, last, base_lines)
+    local from, to
+    for i = first, last do
+        if at[i] then
+            from = from or at[i]
+            to = at[i] + #base_slabs[i] - 1
+        end
+    end
+    if not from then
+        return {}
+    end
+    local slab = {}
+    for i = from, to do
+        slab[#slab + 1] = base_lines[i]
+    end
+    return slab
+end
+
 -- the default `merge` conflictStyle writes no base slab, so the parsed regions carry
--- `base = nil` and the BASE column has nothing to locate or take. recover the slabs by
--- re-merging the stages in diff3 style and copying each synthetic region's base across by
--- position. only the slab is copied, never mark_base: the worktree result genuinely has no
--- base marker, so its per-side painting stays correct. trusted only when the synthetic
--- merge yields the same region count (else the regions may not correspond, and no base
--- beats a mislabelled one); a no-op under diff3/zdiff3, where the markers already carried it
+-- `base = nil` and the BASE column has nothing to take. recover them by re-merging the
+-- stages in diff3 style and mapping the synthetic regions onto the worktree ones: ort
+-- coalesces conflicts that merge-file keeps apart, so a worktree region owns a run of them.
+-- both sides claim independently and must agree where the run ends, a side with nothing
+-- locatable abstains, anything ambiguous leaves base nil (a wrong slab gets spliced in by
+-- take-base). only the slab is copied, never mark_base. a no-op under diff3/zdiff3
 ---@param regions differ.merge.Region[]
 ---@param ours_text string
 ---@param base_text string
@@ -33,16 +85,34 @@ local function recover_base(regions, ours_text, base_text, theirs_text)
     if #regions == 0 or regions[1].base then
         return
     end
-    local synth = require("differ.git").merge_file_diff3(ours_text, base_text, theirs_text)
-    if not synth then
+    local synth_text = require("differ.git").merge_file_diff3(ours_text, base_text, theirs_text)
+    if not synth_text then
         return
     end
-    local synth_regions = conflict.parse(to_lines(synth))
-    if #synth_regions ~= #regions then
+    local synth = conflict.parse(to_lines(synth_text))
+    local base_slabs = {}
+    for i, s in ipairs(synth) do
+        base_slabs[i] = s.base or {}
+    end
+    -- the synthetic regions came out of merging this base, so their slabs must appear in it
+    -- in order; if they don't, the re-merge doesn't describe our stages
+    local base_lines = to_lines(base_text)
+    local at = find_runs(base_lines, base_slabs, 1)
+    if not at then
         return
     end
-    for i, r in ipairs(regions) do
-        r.base = synth_regions[i].base
+    local from = 1
+    for _, r in ipairs(regions) do
+        local ours_last = claim_run(r.ours, synth, "ours", from)
+        local theirs_last = claim_run(r.theirs, synth, "theirs", from)
+        local last = math.max(ours_last, theirs_last)
+        if last >= from then
+            local abstained = ours_last < from or theirs_last < from
+            if abstained or ours_last == theirs_last then
+                r.base = base_span(base_slabs, at, from, last, base_lines)
+            end
+            from = last + 1 -- consumed either way, a disputed run isn't the next region's
+        end
     end
 end
 

--- a/lua/differ/merge/model.lua
+++ b/lua/differ/merge/model.lua
@@ -17,6 +17,7 @@ local to_lines = require("differ.util.text").to_lines
 ---@field result_text string -- the worktree file as-is (markers intact)
 ---@field regions differ.merge.Region[]
 ---@field head string|nil
+---@field no_ancestor boolean -- add/add: no :1: stage, so no base exists to recover or take
 
 local M = {}
 
@@ -168,7 +169,13 @@ function M.build(root, relpath, head)
     local ours_text = git.read_stage(root, relpath, 2)
     local base_text = git.read_stage(root, relpath, 1)
     local theirs_text = git.read_stage(root, relpath, 3)
-    recover_base(regions, ours_text, base_text, theirs_text)
+    -- only ambiguous when the stage read back empty, so the extra call sits inside that
+    local no_ancestor = base_text == "" and not git.has_stage(root, relpath, 1)
+    -- with no ancestor the re-merge still yields empty base slabs, which recover would copy
+    -- across as `{}`; that's truthy, so take-base would splice it and silently drop the block
+    if not no_ancestor then
+        recover_base(regions, ours_text, base_text, theirs_text)
+    end
     return {
         path = relpath,
         root = root,
@@ -178,6 +185,7 @@ function M.build(root, relpath, head)
         result_text = result_text,
         regions = regions,
         head = head,
+        no_ancestor = no_ancestor,
     }
 end
 

--- a/lua/differ/merge/model.lua
+++ b/lua/differ/merge/model.lua
@@ -18,6 +18,34 @@ local to_lines = require("differ.util.text").to_lines
 
 local M = {}
 
+-- the default `merge` conflictStyle writes no base slab, so the parsed regions carry
+-- `base = nil` and the BASE column has nothing to locate or take. recover the slabs by
+-- re-merging the stages in diff3 style and copying each synthetic region's base across by
+-- position. only the slab is copied, never mark_base: the worktree result genuinely has no
+-- base marker, so its per-side painting stays correct. trusted only when the synthetic
+-- merge yields the same region count (else the regions may not correspond, and no base
+-- beats a mislabelled one); a no-op under diff3/zdiff3, where the markers already carried it
+---@param regions differ.merge.Region[]
+---@param ours_text string
+---@param base_text string
+---@param theirs_text string
+local function recover_base(regions, ours_text, base_text, theirs_text)
+    if #regions == 0 or regions[1].base then
+        return
+    end
+    local synth = require("differ.git").merge_file_diff3(ours_text, base_text, theirs_text)
+    if not synth then
+        return
+    end
+    local synth_regions = conflict.parse(to_lines(synth))
+    if #synth_regions ~= #regions then
+        return
+    end
+    for i, r in ipairs(regions) do
+        r.base = synth_regions[i].base
+    end
+end
+
 -- build a MergeModel for a conflicted `relpath`. returns nil + a reason when the file
 -- isn't on disk or carries no conflict markers (already resolved / never conflicted)
 ---@param root string
@@ -34,12 +62,16 @@ function M.build(root, relpath, head)
     if #regions == 0 then
         return nil, "no conflicts to resolve"
     end
+    local ours_text = git.read_stage(root, relpath, 2)
+    local base_text = git.read_stage(root, relpath, 1)
+    local theirs_text = git.read_stage(root, relpath, 3)
+    recover_base(regions, ours_text, base_text, theirs_text)
     return {
         path = relpath,
         root = root,
-        ours_text = git.read_stage(root, relpath, 2),
-        base_text = git.read_stage(root, relpath, 1),
-        theirs_text = git.read_stage(root, relpath, 3),
+        ours_text = ours_text,
+        base_text = base_text,
+        theirs_text = theirs_text,
         result_text = result_text,
         regions = regions,
         head = head,

--- a/lua/differ/merge/model.lua
+++ b/lua/differ/merge/model.lua
@@ -43,6 +43,41 @@ local function claim_run(lines, synth, key, from)
     return last
 end
 
+-- claims that differ are blindness rather than contradiction when every synth region the
+-- shorter side stopped short of is empty on that side: it had nothing to look for there
+---@param synth differ.merge.Region[]
+---@param ours_last integer
+---@param theirs_last integer
+---@return boolean
+local function agree(synth, ours_last, theirs_last)
+    local key = ours_last < theirs_last and "ours" or "theirs"
+    for i = math.min(ours_last, theirs_last) + 1, math.max(ours_last, theirs_last) do
+        if #synth[i][key] > 0 then
+            return false
+        end
+    end
+    return true
+end
+
+-- the run a worktree region owns, scanning past synthetic regions nothing corresponds to
+-- (ort resolves cases merge-file conflicts on, so the re-merge can carry orphans). a claim
+-- that needed skipping must be corroborated by both sides, else a region owning nothing
+-- would hunt the rest of the file for a coincidental match. nil when it owns nothing at all
+---@param region differ.merge.Region
+---@param synth differ.merge.Region[]
+---@param from integer
+---@return { first: integer, ours: integer, theirs: integer }|nil
+local function claim(region, synth, from)
+    for start = from, #synth do
+        local ours = claim_run(region.ours, synth, "ours", start)
+        local theirs = claim_run(region.theirs, synth, "theirs", start)
+        local corroborated = ours >= start and theirs >= start
+        if math.max(ours, theirs) >= start and (start == from or corroborated) then
+            return { first = start, ours = ours, theirs = theirs }
+        end
+    end
+end
+
 -- the base-stage span a run covers, anchored on its first and last located slab. the span,
 -- not the sub-slabs concatenated, so a coalesced block keeps its interstitials. all-empty
 -- base slabs cover nothing, which take-base resolves to a deletion
@@ -103,13 +138,11 @@ local function recover_base(regions, ours_text, base_text, theirs_text)
     end
     local from = 1
     for _, r in ipairs(regions) do
-        local ours_last = claim_run(r.ours, synth, "ours", from)
-        local theirs_last = claim_run(r.theirs, synth, "theirs", from)
-        local last = math.max(ours_last, theirs_last)
-        if last >= from then
-            local abstained = ours_last < from or theirs_last < from
-            if abstained or ours_last == theirs_last then
-                r.base = base_span(base_slabs, at, from, last, base_lines)
+        local run = claim(r, synth, from)
+        if run then
+            local last = math.max(run.ours, run.theirs)
+            if agree(synth, run.ours, run.theirs) then
+                r.base = base_span(base_slabs, at, run.first, last, base_lines)
             end
             from = last + 1 -- consumed either way, a disputed run isn't the next region's
         end

--- a/lua/differ/render/merge.lua
+++ b/lua/differ/render/merge.lua
@@ -8,6 +8,7 @@
 -- forward search (slabs appear in file order), so a unique run highlights and a
 -- not-found run simply doesn't — no highlight beats a wrong highlight
 
+local find_run = require("differ.util.lines").find_run
 local to_lines = require("differ.util.text").to_lines
 
 ---@class differ.merge.ColumnRegion
@@ -51,27 +52,6 @@ local function fold_ranges(total, regions)
         folds[#folds + 1] = { first = first, last = total }
     end
     return folds
-end
-
--- first 1-based start at or after `from` where `slab` matches `lines` run-for-run, or nil
----@param lines string[]
----@param slab string[]
----@param from integer
----@return integer|nil
-local function find_run(lines, slab, from)
-    for start = from, #lines - #slab + 1 do
-        local hit = true
-        for k = 1, #slab do
-            if lines[start + k - 1] ~= slab[k] then
-                hit = false
-                break
-            end
-        end
-        if hit then
-            return start
-        end
-    end
-    return nil
 end
 
 -- locate each region's `key` slab (ours/base/theirs) inside a stage file's lines, in

--- a/lua/differ/render/merge.lua
+++ b/lua/differ/render/merge.lua
@@ -95,14 +95,14 @@ local function locate_regions(lines, regions, key)
     return out
 end
 
--- build the merge columns. base is shown only under the diff3_mixed layout (it's read
+-- build the merge columns. base is shown only under the diff4 layout (it's read
 -- + carried regardless, so the toggle costs nothing); the result column is always last
 ---@param model differ.MergeModel
----@param opts { layout?: "default"|"diff3_mixed" }|nil
+---@param opts { layout?: "default"|"diff4" }|nil
 ---@return differ.merge.RenderResult
 function M.render(model, opts)
     opts = opts or {}
-    local show_base = opts.layout == "diff3_mixed"
+    local show_base = opts.layout == "diff4"
 
     local ours = to_lines(model.ours_text)
     local theirs = to_lines(model.theirs_text)

--- a/lua/differ/util/lines.lua
+++ b/lua/differ/util/lines.lua
@@ -1,12 +1,9 @@
--- shared line-array searching, pure lua, no nvim API. locating a run of lines inside a
--- larger array, in file order, is how both the merge renderer places a region's slab in
--- its stage file and how base recovery maps re-merged regions onto the worktree's
+-- shared line-array searching, pure lua, no nvim API
 
 local M = {}
 
 -- first 1-based start at or after `from` where `slab` matches `lines` run-for-run, or nil.
--- callers must not pass an empty slab: a zero-length run trivially matches at `from`, which
--- is a cursor position rather than a located anchor
+-- an empty slab matches trivially at `from`, so callers must not pass one
 ---@param lines string[]
 ---@param slab string[]
 ---@param from integer
@@ -27,11 +24,9 @@ function M.find_run(lines, slab, from)
     return nil
 end
 
--- place every slab in `slabs` inside `lines`, in order and without overlap, searching
--- forward from `from`. all-or-nothing: nil as soon as one can't be placed after the ones
--- before it, so a caller gets a whole consistent placement or no answer at all. empty slabs
--- are skipped rather than searched for (see find_run) and so take no position: the result
--- is keyed by index into `slabs` and may be sparse, don't take its length
+-- place every slab inside `lines`, in order and disjoint, searching from `from`. all or
+-- nothing: nil as soon as one won't place. empty slabs are skipped and take no position, so
+-- the result is keyed by slab index and may be sparse, don't take its length
 ---@param lines string[]
 ---@param slabs string[][]
 ---@param from integer

--- a/lua/differ/util/lines.lua
+++ b/lua/differ/util/lines.lua
@@ -1,0 +1,54 @@
+-- shared line-array searching, pure lua, no nvim API. locating a run of lines inside a
+-- larger array, in file order, is how both the merge renderer places a region's slab in
+-- its stage file and how base recovery maps re-merged regions onto the worktree's
+
+local M = {}
+
+-- first 1-based start at or after `from` where `slab` matches `lines` run-for-run, or nil.
+-- callers must not pass an empty slab: a zero-length run trivially matches at `from`, which
+-- is a cursor position rather than a located anchor
+---@param lines string[]
+---@param slab string[]
+---@param from integer
+---@return integer|nil
+function M.find_run(lines, slab, from)
+    for start = from, #lines - #slab + 1 do
+        local hit = true
+        for k = 1, #slab do
+            if lines[start + k - 1] ~= slab[k] then
+                hit = false
+                break
+            end
+        end
+        if hit then
+            return start
+        end
+    end
+    return nil
+end
+
+-- place every slab in `slabs` inside `lines`, in order and without overlap, searching
+-- forward from `from`. all-or-nothing: nil as soon as one can't be placed after the ones
+-- before it, so a caller gets a whole consistent placement or no answer at all. empty slabs
+-- are skipped rather than searched for (see find_run) and so take no position: the result
+-- is keyed by index into `slabs` and may be sparse, don't take its length
+---@param lines string[]
+---@param slabs string[][]
+---@param from integer
+---@return table<integer, integer>|nil
+function M.find_runs(lines, slabs, from)
+    local out, cursor = {}, from
+    for i, slab in ipairs(slabs) do
+        if #slab > 0 then
+            local s = M.find_run(lines, slab, cursor)
+            if not s then
+                return nil
+            end
+            out[i] = s
+            cursor = s + #slab
+        end
+    end
+    return out
+end
+
+return M

--- a/test/nvim/config_spec.lua
+++ b/test/nvim/config_spec.lua
@@ -18,3 +18,16 @@ describe("config.resolve history", function()
         assert.are.equal("right", cfg.panel.position) -- the panel table is independent
     end)
 end)
+
+describe("config.resolve merge", function()
+    it("defaults the merge tool to the two-input layout", function()
+        assert.are.equal("default", config.resolve(nil).merge.layout)
+    end)
+
+    it("takes a diff4 override without disturbing the rest", function()
+        local cfg = config.resolve({ merge = { layout = "diff4" } })
+        assert.are.equal("diff4", cfg.merge.layout)
+        assert.are.equal("bottom", cfg.history.position) -- the other tables are independent
+        assert.are.equal("right", cfg.panel.position)
+    end)
+end)

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -111,6 +111,37 @@ describe("git.read_stage", function()
     end)
 end)
 
+describe("git.merge_file_diff3", function()
+    local conflict = require("differ.git.conflict")
+    local to_lines = require("differ.util.text").to_lines
+
+    it("re-merges the three stages into diff3 style with a base slab", function()
+        local out = git_src.merge_file_diff3("a\nOURS\nc\n", "a\nb\nc\n", "a\nTHEIRS\nc\n")
+        local regions = conflict.parse(to_lines(out))
+        assert.are.equal(1, #regions)
+        assert.are.same({ "OURS" }, regions[1].ours)
+        assert.are.same({ "b" }, regions[1].base)
+        assert.are.same({ "THEIRS" }, regions[1].theirs)
+    end)
+
+    it("keeps CRLF bytes in the recovered base slab", function()
+        local out = git_src.merge_file_diff3(
+            "a\r\nOURS\r\nc\r\n",
+            "a\r\nb\r\nc\r\n",
+            "a\r\nTHEIRS\r\nc\r\n"
+        )
+        local regions = conflict.parse(to_lines(out))
+        assert.are.equal(1, #regions)
+        assert.are.same({ "b\r" }, regions[1].base) -- the CR survives, matching the :1: stage
+    end)
+
+    it("returns marker-free text when the stages merge cleanly", function()
+        local out = git_src.merge_file_diff3("a\nb\nc\n", "a\nb\nc\n", "a\nZZZ\nc\n")
+        assert.is_not_nil(out)
+        assert.is_nil(out:find("<<<<<<<", 1, true))
+    end)
+end)
+
 describe("git.read (worktree clean filter)", function()
     local wt = { kind = "worktree", label = "WORKTREE" }
 

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -196,10 +196,10 @@ describe(":Differ mergetool", function()
         assert.are.equal(first, vim.api.nvim_win_get_cursor(s.result_win)[1])
     end)
 
-    it("shows the base column under diff3_mixed", function()
+    it("shows the base column under diff4", function()
         local root = conflict_repo()
         vim.cmd.edit(root .. "/f.txt")
-        merge.open({ layout = "diff3_mixed" })
+        merge.open({ layout = "diff4" })
         assert.are.equal(4, #vim.api.nvim_tabpage_list_wins(0))
     end)
 
@@ -665,5 +665,36 @@ describe(":Differ mergetool UX", function()
         end)
         local after = vim.api.nvim_buf_get_extmarks(s.result_buf, flash_ns, 0, -1, {})
         assert.are.equal(0, #after)
+    end)
+end)
+
+describe(":Differ mergetool layout config", function()
+    local differ = require("differ")
+    local saved
+
+    before_each(function()
+        saved = differ.config
+        differ.config = require("differ.config").resolve({ merge = { layout = "diff4" } })
+    end)
+
+    after_each(function()
+        differ.config = saved
+        if merge.current() then
+            merge.close()
+        end
+    end)
+
+    it("opens the configured layout when no argument names one", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        assert.are.equal(4, #vim.api.nvim_tabpage_list_wins(0))
+    end)
+
+    it("lets an explicit layout beat the configured one", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "default" })
+        assert.are.equal(3, #vim.api.nvim_tabpage_list_wins(0))
     end)
 end)

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -698,3 +698,49 @@ describe(":Differ mergetool layout config", function()
         assert.are.equal(3, #vim.api.nvim_tabpage_list_wins(0))
     end)
 end)
+
+describe(":Differ mergetool diff4 base pane", function()
+    after_each(function()
+        if merge.current() then
+            merge.close()
+        end
+    end)
+
+    it("locates and paints the base pane under the default conflict style", function()
+        local root = conflict_repo() -- default merge style: the markers carry no base slab
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        local base = input(s, "base")
+        assert.is_not_nil(base)
+        assert.is_true(#base.regions > 0) -- recovered, so the slab is located
+        local marks =
+            vim.api.nvim_buf_get_extmarks(vim.api.nvim_win_get_buf(base.win), merge_ns, 0, -1, {})
+        assert.is_true(#marks > 0) -- painted, unlike the pre-recovery inert pane
+    end)
+
+    it("takes base for the conflict, resolving to the common ancestor", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+        assert.is_false(has_marker(s.result_buf))
+        assert.are.same({ "a", "b", "c" }, vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false))
+    end)
+
+    it("takes the right base on a later conflict after the order map shifts", function()
+        local root = conflict_repo_multi() -- three conflicts, base slabs base5/base15/base25
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        -- resolve the first (auto-advances onto the second), then take base there: the live
+        -- index -> original mapping has shifted, so this proves the lookup follows `order`
+        fire(s.result_buf, "differ: take base")
+        fire(s.result_buf, "differ: take base")
+        local lines = vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false)
+        assert.is_true(vim.tbl_contains(lines, "base5")) -- first conflict -> its own base
+        assert.is_true(vim.tbl_contains(lines, "base15")) -- second -> its base, not base5/base25
+        assert.is_true(has_marker(s.result_buf)) -- the third conflict is still open
+    end)
+end)

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -109,6 +109,50 @@ local function conflict_repo_multi()
     return root
 end
 
+-- a repo where both sides change two spots two unchanged lines apart. ort coalesces them
+-- into one conflict block while git merge-file keeps them separate, which is the grouping
+-- disagreement base recovery has to map across (a gap of four or more stops coalescing)
+local function conflict_repo_coalesced()
+    local function body(a, b)
+        return table.concat({ a, "pad1", "pad2", b }, "\n") .. "\n"
+    end
+    local root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+    git_ok(root, "init", "-q")
+    write(root .. "/f.txt", body("A", "B"))
+    git_ok(root, "add", "f.txt")
+    git_ok(root, "commit", "-q", "-m", "base")
+    git_ok(root, "checkout", "-q", "-b", "feature")
+    write(root .. "/f.txt", body("A_THEIRS", "B_THEIRS"))
+    git_ok(root, "commit", "-q", "-am", "theirs")
+    git_ok(root, "checkout", "-q", "main")
+    write(root .. "/f.txt", body("A_OURS", "B_OURS"))
+    git_ok(root, "commit", "-q", "-am", "ours")
+    git(root, "merge", "feature")
+    return root
+end
+
+-- a repo where both branches independently add the same path, so the merge carries no `:1:`
+-- stage: there is no ancestor for the base pane to show or for take-base to restore
+local function conflict_repo_add_add()
+    local root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+    git_ok(root, "init", "-q")
+    write(root .. "/seed.txt", "seed\n")
+    git_ok(root, "add", "seed.txt")
+    git_ok(root, "commit", "-q", "-m", "base")
+    git_ok(root, "checkout", "-q", "-b", "feature")
+    write(root .. "/f.txt", "theirs1\ntheirs2\n")
+    git_ok(root, "add", "f.txt")
+    git_ok(root, "commit", "-q", "-m", "theirs")
+    git_ok(root, "checkout", "-q", "main")
+    write(root .. "/f.txt", "ours1\nours2\n")
+    git_ok(root, "add", "f.txt")
+    git_ok(root, "commit", "-q", "-m", "ours")
+    git(root, "merge", "feature")
+    return root
+end
+
 -- a repo where merging `feature` conflicts on TWO files (f.txt then g.txt), to exercise
 -- write-driven advancing through the conflict set
 local function conflict_repo_two()
@@ -727,6 +771,69 @@ describe(":Differ mergetool diff4 base pane", function()
         assert.is_true(fire(s.result_buf, "differ: take base"))
         assert.is_false(has_marker(s.result_buf))
         assert.are.same({ "a", "b", "c" }, vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false))
+    end)
+
+    it("recovers base across a block ort coalesced but merge-file kept apart", function()
+        local root = conflict_repo_coalesced()
+        vim.cmd.edit(root .. "/f.txt")
+        -- precondition: if a future git stops coalescing here, the mapping this exercises
+        -- isn't being exercised at all, so fail loudly rather than passing on the easy path
+        local conflict = require("differ.git.conflict")
+        local to_lines = require("differ.util.text").to_lines
+        local wt = conflict.parse(
+            to_lines(table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n") .. "\n")
+        )
+        assert.are.equal(1, #wt, "fixture no longer coalesces under ort")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        local base = input(s, "base")
+        assert.is_not_nil(base)
+        assert.is_true(#base.regions > 0) -- located, so the run mapped across the grouping
+    end)
+
+    it("takes base across a coalesced block, interstitials and all", function()
+        local root = conflict_repo_coalesced()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+        assert.is_false(has_marker(s.result_buf))
+        -- the span, not the two changed lines: the unchanged pads between them come back too
+        assert.are.same(
+            { "A", "pad1", "pad2", "B" },
+            vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false)
+        )
+    end)
+
+    it("says the base pane has no common ancestor on an add/add conflict", function()
+        local root = conflict_repo_add_add()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        vim.g.statusline_winid = input(s, "base").win
+        assert.are.equal("BASE · no common ancestor", merge.winbar())
+    end)
+
+    it("refuses take base on an add/add conflict rather than dropping the block", function()
+        local root = conflict_repo_add_add()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        _G.notifs = {}
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+        assert.is_true(has_marker(s.result_buf)) -- the block survives, nothing spliced
+        assert.are.equal("differ: no base version in this conflict", _G.notifs[1].msg)
+    end)
+
+    it("says so in the base winbar when a conflict has no recovered slab", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = merge.current()
+        vim.g.statusline_winid = input(s, "base").win
+        assert.are.equal("BASE", merge.winbar())
+        s.base_slabs = {} -- as if the mapping had been too ambiguous to trust here
+        assert.are.equal("BASE · none for this conflict", merge.winbar())
     end)
 
     it("takes the right base on a later conflict after the order map shifts", function()

--- a/test/unit/lines_spec.lua
+++ b/test/unit/lines_spec.lua
@@ -1,0 +1,71 @@
+-- the shared line-array searches: a single located run, and an ordered disjoint
+-- placement of several. pure lua, no nvim runtime
+
+local lines = require("differ.util.lines")
+
+local HAY = { "a", "b", "c", "a", "b", "d" }
+
+describe("util.lines.find_run", function()
+    it("returns the first start where the slab matches run-for-run", function()
+        assert.are.equal(1, lines.find_run(HAY, { "a", "b" }, 1))
+    end)
+
+    it("skips matches before `from`", function()
+        assert.are.equal(4, lines.find_run(HAY, { "a", "b" }, 2))
+    end)
+
+    it("returns nil when the slab is absent", function()
+        assert.is_nil(lines.find_run(HAY, { "a", "c" }, 1))
+    end)
+
+    it("returns nil when the slab would run past the end", function()
+        assert.is_nil(lines.find_run(HAY, { "d", "e" }, 1))
+    end)
+
+    it("matches a slab that ends exactly at the last line", function()
+        assert.are.equal(5, lines.find_run(HAY, { "b", "d" }, 1))
+    end)
+
+    it("returns nil when `from` is past the last possible start", function()
+        assert.is_nil(lines.find_run(HAY, { "a", "b" }, 6))
+    end)
+end)
+
+describe("util.lines.find_runs", function()
+    it("places every slab in order, keyed by slab index", function()
+        local at = lines.find_runs(HAY, { { "a", "b" }, { "d" } }, 1)
+        assert.are.same({ 1, 6 }, at)
+    end)
+
+    it("places repeated content disjointly rather than on itself", function()
+        local at = lines.find_runs(HAY, { { "a", "b" }, { "a", "b" } }, 1)
+        assert.are.same({ 1, 4 }, at)
+    end)
+
+    it("returns nil when a slab can't be placed at all", function()
+        assert.is_nil(lines.find_runs(HAY, { { "a" }, { "zz" } }, 1))
+    end)
+
+    it("returns nil when the slabs are present but out of order", function()
+        assert.is_nil(lines.find_runs(HAY, { { "d" }, { "c" } }, 1))
+    end)
+
+    it("returns nil when a repeat has no room left after the ones before it", function()
+        assert.is_nil(lines.find_runs(HAY, { { "a", "b" }, { "a", "b" }, { "a", "b" } }, 1))
+    end)
+
+    it("skips an empty slab: no position for it, and the cursor doesn't move", function()
+        local at = lines.find_runs(HAY, { { "a" }, {}, { "a" } }, 1)
+        assert.is_nil(at[2])
+        assert.are.equal(1, at[1])
+        assert.are.equal(4, at[3])
+    end)
+
+    it("places nothing, successfully, when every slab is empty", function()
+        assert.are.same({}, lines.find_runs(HAY, { {}, {} }, 1))
+    end)
+
+    it("searches forward from `from`", function()
+        assert.are.same({ 4 }, lines.find_runs(HAY, { { "a" } }, 2))
+    end)
+end)

--- a/test/unit/merge_model_spec.lua
+++ b/test/unit/merge_model_spec.lua
@@ -1,6 +1,8 @@
 -- the MergeModel builder over a stubbed git layer: the parse path is real (pure
 -- conflict.parse + to_lines), only the I/O reads are faked, so the assembly + the
--- no-conflict / missing-file guards are checked without a git repo or nvim runtime
+-- no-conflict / missing-file guards are checked without a git repo or nvim runtime.
+-- base recovery is stubbed at the re-merge, so the synthetic regions it maps are fed
+-- in directly rather than produced by git merge-file
 
 local model = require("differ.merge.model")
 
@@ -26,7 +28,7 @@ local RESULT_DIFF3 = table.concat({
     ">>>>>>> branch",
 }, "\n") .. "\n"
 
--- a synthetic diff3 re-merge carrying one region with a base slab, matching RESULT's count
+-- a synthetic diff3 re-merge carrying one region, matching RESULT's single conflict
 local SYNTH_ONE = table.concat({
     "keep me",
     "<<<<<<< ours",
@@ -35,6 +37,108 @@ local SYNTH_ONE = table.concat({
     "recovered",
     "=======",
     "theirs",
+    ">>>>>>> theirs",
+}, "\n") .. "\n"
+
+-- ort coalesced two diverged spots into one block; merge-file kept them apart, so the
+-- single worktree region owns both synthetic ones and its base spans the "mid" between them
+local RESULT_COALESCED = table.concat({
+    "head",
+    "<<<<<<< HEAD",
+    "A1",
+    "mid",
+    "B1",
+    "=======",
+    "A2",
+    "mid",
+    "B2",
+    ">>>>>>> branch",
+    "tail",
+}, "\n") .. "\n"
+
+local SYNTH_SPLIT = table.concat({
+    "head",
+    "<<<<<<< ours",
+    "A1",
+    "||||||| base",
+    "A",
+    "=======",
+    "A2",
+    ">>>>>>> theirs",
+    "mid",
+    "<<<<<<< ours",
+    "B1",
+    "||||||| base",
+    "B",
+    "=======",
+    "B2",
+    ">>>>>>> theirs",
+    "tail",
+}, "\n") .. "\n"
+
+local COALESCED_STAGES = {
+    [1] = "head\nA\nmid\nB\ntail\n",
+    [2] = "head\nA1\nmid\nB1\ntail\n",
+    [3] = "head\nA2\nmid\nB2\ntail\n",
+}
+
+-- ours deleted the line theirs modified, so the worktree region's ours slab is empty and
+-- only theirs can claim the synthetic region
+local RESULT_OURS_DELETED = table.concat({
+    "a",
+    "<<<<<<< HEAD",
+    "=======",
+    "Y",
+    ">>>>>>> branch",
+    "b",
+}, "\n") .. "\n"
+
+local SYNTH_OURS_DELETED = table.concat({
+    "a",
+    "<<<<<<< ours",
+    "||||||| base",
+    "X",
+    "=======",
+    "Y",
+    ">>>>>>> theirs",
+    "b",
+}, "\n") .. "\n"
+
+-- the sides disagree: ours holds both synthetic ours slabs, theirs holds only the first
+local RESULT_DISPUTED = table.concat({
+    "<<<<<<< HEAD",
+    "A1",
+    "B1",
+    "=======",
+    "A2",
+    ">>>>>>> branch",
+}, "\n") .. "\n"
+
+local SYNTH_TWO = table.concat({
+    "<<<<<<< ours",
+    "A1",
+    "||||||| base",
+    "A",
+    "=======",
+    "A2",
+    ">>>>>>> theirs",
+    "<<<<<<< ours",
+    "B1",
+    "||||||| base",
+    "B",
+    "=======",
+    "B2",
+    ">>>>>>> theirs",
+}, "\n") .. "\n"
+
+-- a re-merge describing a conflict nothing in the worktree corresponds to
+local SYNTH_FOREIGN = table.concat({
+    "<<<<<<< ours",
+    "zzz",
+    "||||||| base",
+    "base",
+    "=======",
+    "qqq",
     ">>>>>>> theirs",
 }, "\n") .. "\n"
 
@@ -99,18 +203,62 @@ describe("merge.model.build", function()
         assert.are.equal("", m.base_text)
         assert.are.equal("", m.theirs_text)
     end)
+end)
 
-    it("recovers base slabs from a diff3 re-merge when the markers omit them", function()
-        package.loaded["differ.git"] = fake_git({ diff3 = SYNTH_ONE })
+describe("merge.model base recovery", function()
+    after_each(function()
+        package.loaded["differ.git"] = nil
+    end)
+
+    it("recovers the slab for an isolated conflict", function()
+        package.loaded["differ.git"] = fake_git({
+            diff3 = SYNTH_ONE,
+            stages = { [1] = "recovered\n", [2] = "ours\n", [3] = "theirs\n" },
+        })
         local m = model.build("/repo", "a.txt", nil)
         assert.are.same({ "recovered" }, m.regions[1].base)
     end)
 
-    it("leaves base absent when the re-merge count disagrees with the worktree", function()
-        -- two synthetic regions against RESULT's one: the regions may not correspond,
-        -- so nothing is copied across
-        local synth = SYNTH_ONE:gsub("\n$", "\n") .. SYNTH_ONE
-        package.loaded["differ.git"] = fake_git({ diff3 = synth })
+    it("spans the interstitial base lines of a coalesced block", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = RESULT_COALESCED,
+            diff3 = SYNTH_SPLIT,
+            stages = COALESCED_STAGES,
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        -- the run covers base lines A..B, so "mid" comes back with them
+        assert.are.same({ "A", "mid", "B" }, m.regions[1].base)
+    end)
+
+    it("recovers via theirs when ours deleted what theirs modified", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = RESULT_OURS_DELETED,
+            diff3 = SYNTH_OURS_DELETED,
+            stages = { [1] = "a\nX\nb\n", [2] = "a\nb\n", [3] = "a\nY\nb\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "X" }, m.regions[1].base)
+    end)
+
+    it("leaves base absent when the two sides disagree on the run", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = RESULT_DISPUTED,
+            diff3 = SYNTH_TWO,
+            stages = { [1] = "A\nB\n", [2] = "A1\nB1\n", [3] = "A2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_nil(m.regions[1].base)
+    end)
+
+    it("leaves base absent when the region owns no synthetic conflict", function()
+        package.loaded["differ.git"] = fake_git({ diff3 = SYNTH_FOREIGN })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_nil(m.regions[1].base)
+    end)
+
+    it("bails when a synthetic base slab isn't in the base stage", function()
+        -- SYNTH_ONE's base slab is "recovered"; the default base stage is "base"
+        package.loaded["differ.git"] = fake_git({ diff3 = SYNTH_ONE })
         local m = model.build("/repo", "a.txt", nil)
         assert.is_nil(m.regions[1].base)
     end)

--- a/test/unit/merge_model_spec.lua
+++ b/test/unit/merge_model_spec.lua
@@ -6,75 +6,68 @@
 
 local model = require("differ.merge.model")
 
--- a default-style conflicted worktree file (no base slab in the markers)
-local RESULT = table.concat({
-    "keep me",
-    "<<<<<<< HEAD",
-    "ours",
-    "=======",
-    "theirs",
-    ">>>>>>> branch",
-}, "\n") .. "\n"
+local function extend(t, items)
+    for _, v in ipairs(items) do
+        t[#t + 1] = v
+    end
+end
 
--- a diff3-style conflicted worktree file (base slab already present)
-local RESULT_DIFF3 = table.concat({
-    "keep me",
-    "<<<<<<< HEAD",
-    "ours",
-    "||||||| base",
-    "ancestor",
-    "=======",
-    "theirs",
-    ">>>>>>> branch",
-}, "\n") .. "\n"
+-- a conflict block in git's default `merge` conflictStyle, as the worktree file carries it
+local function merge_block(ours, theirs)
+    local out = { "<<<<<<< HEAD" }
+    extend(out, ours)
+    out[#out + 1] = "======="
+    extend(out, theirs)
+    out[#out + 1] = ">>>>>>> branch"
+    return out
+end
 
--- a synthetic diff3 re-merge carrying one region, matching RESULT's single conflict
-local SYNTH_ONE = table.concat({
-    "keep me",
-    "<<<<<<< ours",
-    "ours",
-    "||||||| base",
-    "recovered",
-    "=======",
-    "theirs",
-    ">>>>>>> theirs",
-}, "\n") .. "\n"
+-- the same block in `diff3` conflictStyle, base slab and all, as the re-merge emits
+local function diff3_block(ours, base, theirs)
+    local out = { "<<<<<<< ours" }
+    extend(out, ours)
+    out[#out + 1] = "||||||| base"
+    extend(out, base)
+    out[#out + 1] = "======="
+    extend(out, theirs)
+    out[#out + 1] = ">>>>>>> theirs"
+    return out
+end
+
+-- join blocks and plain context lines into file text
+local function file(...)
+    local out = {}
+    for _, part in ipairs({ ... }) do
+        if type(part) == "string" then
+            out[#out + 1] = part
+        else
+            extend(out, part)
+        end
+    end
+    return table.concat(out, "\n") .. "\n"
+end
+
+-- a conflicted worktree file with no base slab in the markers
+local RESULT = file("keep me", merge_block({ "ours" }, { "theirs" }))
+
+-- the same file with the base slab already there, as diff3/zdiff3 writes it
+local RESULT_DIFF3 = file("keep me", diff3_block({ "ours" }, { "ancestor" }, { "theirs" }))
+
+-- a re-merge carrying one region, matching RESULT's single conflict
+local SYNTH_ONE = file("keep me", diff3_block({ "ours" }, { "recovered" }, { "theirs" }))
 
 -- ort coalesced two diverged spots into one block; merge-file kept them apart, so the
 -- single worktree region owns both synthetic ones and its base spans the "mid" between them
-local RESULT_COALESCED = table.concat({
-    "head",
-    "<<<<<<< HEAD",
-    "A1",
-    "mid",
-    "B1",
-    "=======",
-    "A2",
-    "mid",
-    "B2",
-    ">>>>>>> branch",
-    "tail",
-}, "\n") .. "\n"
+local RESULT_COALESCED =
+    file("head", merge_block({ "A1", "mid", "B1" }, { "A2", "mid", "B2" }), "tail")
 
-local SYNTH_SPLIT = table.concat({
+local SYNTH_SPLIT = file(
     "head",
-    "<<<<<<< ours",
-    "A1",
-    "||||||| base",
-    "A",
-    "=======",
-    "A2",
-    ">>>>>>> theirs",
+    diff3_block({ "A1" }, { "A" }, { "A2" }),
     "mid",
-    "<<<<<<< ours",
-    "B1",
-    "||||||| base",
-    "B",
-    "=======",
-    "B2",
-    ">>>>>>> theirs",
-    "tail",
-}, "\n") .. "\n"
+    diff3_block({ "B1" }, { "B" }, { "B2" }),
+    "tail"
+)
 
 local COALESCED_STAGES = {
     [1] = "head\nA\nmid\nB\ntail\n",
@@ -84,81 +77,21 @@ local COALESCED_STAGES = {
 
 -- the same stages and the same re-merge, but ort kept the two spots apart, so each region
 -- owns one synthetic conflict and the spans stay disjoint
-local RESULT_SEPARATE = table.concat({
-    "head",
-    "<<<<<<< HEAD",
-    "A1",
-    "=======",
-    "A2",
-    ">>>>>>> branch",
-    "mid",
-    "<<<<<<< HEAD",
-    "B1",
-    "=======",
-    "B2",
-    ">>>>>>> branch",
-    "tail",
-}, "\n") .. "\n"
+local RESULT_SEPARATE =
+    file("head", merge_block({ "A1" }, { "A2" }), "mid", merge_block({ "B1" }, { "B2" }), "tail")
 
 -- ours deleted the line theirs modified, so the worktree region's ours slab is empty and
 -- only theirs can claim the synthetic region
-local RESULT_OURS_DELETED = table.concat({
-    "a",
-    "<<<<<<< HEAD",
-    "=======",
-    "Y",
-    ">>>>>>> branch",
-    "b",
-}, "\n") .. "\n"
-
-local SYNTH_OURS_DELETED = table.concat({
-    "a",
-    "<<<<<<< ours",
-    "||||||| base",
-    "X",
-    "=======",
-    "Y",
-    ">>>>>>> theirs",
-    "b",
-}, "\n") .. "\n"
+local RESULT_OURS_DELETED = file("a", merge_block({}, { "Y" }), "b")
+local SYNTH_OURS_DELETED = file("a", diff3_block({}, { "X" }, { "Y" }), "b")
 
 -- the sides disagree: ours holds both synthetic ours slabs, theirs holds only the first
-local RESULT_DISPUTED = table.concat({
-    "<<<<<<< HEAD",
-    "A1",
-    "B1",
-    "=======",
-    "A2",
-    ">>>>>>> branch",
-}, "\n") .. "\n"
-
-local SYNTH_TWO = table.concat({
-    "<<<<<<< ours",
-    "A1",
-    "||||||| base",
-    "A",
-    "=======",
-    "A2",
-    ">>>>>>> theirs",
-    "<<<<<<< ours",
-    "B1",
-    "||||||| base",
-    "B",
-    "=======",
-    "B2",
-    ">>>>>>> theirs",
-}, "\n") .. "\n"
+local RESULT_DISPUTED = file(merge_block({ "A1", "B1" }, { "A2" }))
+local SYNTH_TWO =
+    file(diff3_block({ "A1" }, { "A" }, { "A2" }), diff3_block({ "B1" }, { "B" }, { "B2" }))
 
 -- a re-merge describing a conflict nothing in the worktree corresponds to
-local SYNTH_FOREIGN = table.concat({
-    "<<<<<<< ours",
-    "zzz",
-    "||||||| base",
-    "base",
-    "=======",
-    "qqq",
-    ">>>>>>> theirs",
-}, "\n") .. "\n"
+local SYNTH_FOREIGN = file(diff3_block({ "zzz" }, { "base" }, { "qqq" }))
 
 local function fake_git(opts)
     opts = opts or {}
@@ -268,6 +201,125 @@ describe("merge.model base recovery", function()
         })
         local m = model.build("/repo", "a.txt", nil)
         assert.are.same({ "X" }, m.regions[1].base)
+    end)
+
+    it("anchors spans at BOF and EOF without leaning on context", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(
+                merge_block({ "A1" }, { "A2" }),
+                "mid",
+                merge_block({ "B1" }, { "B2" })
+            ),
+            diff3 = file(
+                diff3_block({ "A1" }, { "A" }, { "A2" }),
+                "mid",
+                diff3_block({ "B1" }, { "B" }, { "B2" })
+            ),
+            stages = { [1] = "A\nmid\nB\n", [2] = "A1\nmid\nB1\n", [3] = "A2\nmid\nB2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "A" }, m.regions[1].base) -- first line of the base stage
+        assert.are.same({ "B" }, m.regions[2].base) -- last line
+    end)
+
+    it("disambiguates duplicate conflict content by order", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(
+                merge_block({ "X1" }, { "X2" }),
+                "mid",
+                merge_block({ "X1" }, { "X2" })
+            ),
+            diff3 = file(
+                diff3_block({ "X1" }, { "P" }, { "X2" }),
+                "mid",
+                diff3_block({ "X1" }, { "Q" }, { "X2" })
+            ),
+            stages = { [1] = "P\nmid\nQ\n", [2] = "X1\nmid\nX1\n", [3] = "X2\nmid\nX2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "P" }, m.regions[1].base)
+        assert.are.same({ "Q" }, m.regions[2].base)
+    end)
+
+    it("carries a sub-conflict with an empty ours slab along inside a run", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "A1", "x", "D1" }, { "A2", "x", "C2", "D2" })),
+            diff3 = file(
+                diff3_block({ "A1" }, { "A" }, { "A2" }),
+                "x",
+                diff3_block({}, { "C" }, { "C2" }),
+                diff3_block({ "D1" }, { "D" }, { "D2" })
+            ),
+            stages = { [1] = "A\nx\nC\nD\n", [2] = "A1\nx\nD1\n", [3] = "A2\nx\nC2\nD2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        -- the run reached D, so it passed over the ours-deleted C on the way
+        assert.are.same({ "A", "x", "C", "D" }, m.regions[1].base)
+    end)
+
+    it("recovers a coalesced block whose last sub-conflict is an ours deletion", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "A1" }, { "A2", "x", "C2" })),
+            diff3 = file(
+                diff3_block({ "A1" }, { "A" }, { "A2" }),
+                "x",
+                diff3_block({}, { "C" }, { "C2" })
+            ),
+            stages = { [1] = "A\nx\nC\n", [2] = "A1\n", [3] = "A2\nx\nC2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "A", "x", "C" }, m.regions[1].base)
+    end)
+
+    it("anchors the span on the first non-empty base slab in the run", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "A1", "B1" }, { "A2", "B2" })),
+            diff3 = file(
+                diff3_block({ "A1" }, {}, { "A2" }),
+                diff3_block({ "B1" }, { "B" }, { "B2" })
+            ),
+            stages = { [1] = "B\n", [2] = "A1\nB1\n", [3] = "A2\nB2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "B" }, m.regions[1].base)
+    end)
+
+    it("skips a synthetic conflict no worktree region owns", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(
+                merge_block({ "A1" }, { "A2" }),
+                "mid",
+                merge_block({ "C1" }, { "C2" })
+            ),
+            diff3 = file(
+                diff3_block({ "A1" }, { "A" }, { "A2" }),
+                diff3_block({ "B1" }, { "B" }, { "B2" }),
+                "mid",
+                diff3_block({ "C1" }, { "C" }, { "C2" })
+            ),
+            stages = { [1] = "A\nB\nmid\nC\n", [2] = "A1\nmid\nC1\n", [3] = "A2\nmid\nC2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "A" }, m.regions[1].base)
+        assert.are.same({ "C" }, m.regions[2].base)
+    end)
+
+    it("won't skip to a claim only one side corroborates", function()
+        -- the second region could reach the third synthetic conflict on theirs alone, but
+        -- getting there means skipping an orphan, so one side's word isn't enough
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "A1" }, { "A2" }), "mid", merge_block({}, { "C2" })),
+            diff3 = file(
+                diff3_block({ "A1" }, { "A" }, { "A2" }),
+                diff3_block({ "B1" }, { "B" }, { "B2" }),
+                "mid",
+                diff3_block({}, { "C" }, { "C2" })
+            ),
+            stages = { [1] = "A\nB\nmid\nC\n", [2] = "A1\nmid\n", [3] = "A2\nmid\nC2\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "A" }, m.regions[1].base)
+        assert.is_nil(m.regions[2].base)
     end)
 
     it("leaves base absent when the two sides disagree on the run", function()

--- a/test/unit/merge_model_spec.lua
+++ b/test/unit/merge_model_spec.lua
@@ -110,6 +110,10 @@ local function fake_git(opts)
         merge_file_diff3 = function()
             return opts.diff3
         end,
+        -- stage presence, only consulted when the stage read back empty; present by default
+        has_stage = function()
+            return opts.has_stage ~= false
+        end,
     }
 end
 
@@ -343,6 +347,32 @@ describe("merge.model base recovery", function()
         package.loaded["differ.git"] = fake_git({ diff3 = SYNTH_ONE })
         local m = model.build("/repo", "a.txt", nil)
         assert.is_nil(m.regions[1].base)
+    end)
+
+    it("takes no base at all for add/add, where there is no :1: stage", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "ours1" }, { "theirs1" })),
+            diff3 = file(diff3_block({ "ours1" }, {}, { "theirs1" })),
+            stages = { [2] = "ours1\n", [3] = "theirs1\n" },
+            has_stage = false,
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_true(m.no_ancestor)
+        -- nil, not {}: an empty slab is truthy, so take-base would splice it and drop the block
+        assert.is_nil(m.regions[1].base)
+    end)
+
+    it("recovers an empty slab when the ancestor exists but is empty", function()
+        -- same empty base_text as add/add, opposite handling: there is a base and it says
+        -- the block had nothing, so take-base deleting it is the right answer
+        package.loaded["differ.git"] = fake_git({
+            worktree = file(merge_block({ "ours1" }, { "theirs1" })),
+            diff3 = file(diff3_block({ "ours1" }, {}, { "theirs1" })),
+            stages = { [2] = "ours1\n", [3] = "theirs1\n" },
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_false(m.no_ancestor)
+        assert.are.same({}, m.regions[1].base)
     end)
 
     it("leaves base absent when the re-merge is unavailable", function()

--- a/test/unit/merge_model_spec.lua
+++ b/test/unit/merge_model_spec.lua
@@ -4,7 +4,7 @@
 
 local model = require("differ.merge.model")
 
--- a default-style conflicted worktree file
+-- a default-style conflicted worktree file (no base slab in the markers)
 local RESULT = table.concat({
     "keep me",
     "<<<<<<< HEAD",
@@ -12,6 +12,30 @@ local RESULT = table.concat({
     "=======",
     "theirs",
     ">>>>>>> branch",
+}, "\n") .. "\n"
+
+-- a diff3-style conflicted worktree file (base slab already present)
+local RESULT_DIFF3 = table.concat({
+    "keep me",
+    "<<<<<<< HEAD",
+    "ours",
+    "||||||| base",
+    "ancestor",
+    "=======",
+    "theirs",
+    ">>>>>>> branch",
+}, "\n") .. "\n"
+
+-- a synthetic diff3 re-merge carrying one region with a base slab, matching RESULT's count
+local SYNTH_ONE = table.concat({
+    "keep me",
+    "<<<<<<< ours",
+    "ours",
+    "||||||| base",
+    "recovered",
+    "=======",
+    "theirs",
+    ">>>>>>> theirs",
 }, "\n") .. "\n"
 
 local function fake_git(opts)
@@ -26,6 +50,10 @@ local function fake_git(opts)
         read_stage = function(_, _, stage)
             return (opts.stages or { [1] = "base\n", [2] = "ours\n", [3] = "theirs\n" })[stage]
                 or ""
+        end,
+        -- the diff3 re-merge used to recover base slabs; nil by default so recovery bails
+        merge_file_diff3 = function()
+            return opts.diff3
         end,
     }
 end
@@ -70,5 +98,34 @@ describe("merge.model.build", function()
         assert.are.equal("ours\n", m.ours_text)
         assert.are.equal("", m.base_text)
         assert.are.equal("", m.theirs_text)
+    end)
+
+    it("recovers base slabs from a diff3 re-merge when the markers omit them", function()
+        package.loaded["differ.git"] = fake_git({ diff3 = SYNTH_ONE })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "recovered" }, m.regions[1].base)
+    end)
+
+    it("leaves base absent when the re-merge count disagrees with the worktree", function()
+        -- two synthetic regions against RESULT's one: the regions may not correspond,
+        -- so nothing is copied across
+        local synth = SYNTH_ONE:gsub("\n$", "\n") .. SYNTH_ONE
+        package.loaded["differ.git"] = fake_git({ diff3 = synth })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_nil(m.regions[1].base)
+    end)
+
+    it("leaves base absent when the re-merge is unavailable", function()
+        package.loaded["differ.git"] = fake_git({ diff3 = nil })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.is_nil(m.regions[1].base)
+    end)
+
+    it("keeps the marker-derived base under diff3 style (no re-merge)", function()
+        -- the worktree already carries a base slab, so recovery is skipped and the
+        -- re-merge stub (which would return a different slab) is never consulted
+        package.loaded["differ.git"] = fake_git({ worktree = RESULT_DIFF3, diff3 = SYNTH_ONE })
+        local m = model.build("/repo", "a.txt", nil)
+        assert.are.same({ "ancestor" }, m.regions[1].base)
     end)
 end)

--- a/test/unit/merge_model_spec.lua
+++ b/test/unit/merge_model_spec.lua
@@ -82,6 +82,24 @@ local COALESCED_STAGES = {
     [3] = "head\nA2\nmid\nB2\ntail\n",
 }
 
+-- the same stages and the same re-merge, but ort kept the two spots apart, so each region
+-- owns one synthetic conflict and the spans stay disjoint
+local RESULT_SEPARATE = table.concat({
+    "head",
+    "<<<<<<< HEAD",
+    "A1",
+    "=======",
+    "A2",
+    ">>>>>>> branch",
+    "mid",
+    "<<<<<<< HEAD",
+    "B1",
+    "=======",
+    "B2",
+    ">>>>>>> branch",
+    "tail",
+}, "\n") .. "\n"
+
 -- ours deleted the line theirs modified, so the worktree region's ours slab is empty and
 -- only theirs can claim the synthetic region
 local RESULT_OURS_DELETED = table.concat({
@@ -228,6 +246,18 @@ describe("merge.model base recovery", function()
         local m = model.build("/repo", "a.txt", nil)
         -- the run covers base lines A..B, so "mid" comes back with them
         assert.are.same({ "A", "mid", "B" }, m.regions[1].base)
+    end)
+
+    it("gives each region its own span when the same conflicts stay apart", function()
+        package.loaded["differ.git"] = fake_git({
+            worktree = RESULT_SEPARATE,
+            diff3 = SYNTH_SPLIT,
+            stages = COALESCED_STAGES,
+        })
+        local m = model.build("/repo", "a.txt", nil)
+        -- one synthetic region each, so neither span reaches across "mid" into the other's
+        assert.are.same({ "A" }, m.regions[1].base)
+        assert.are.same({ "B" }, m.regions[2].base)
     end)
 
     it("recovers via theirs when ours deleted what theirs modified", function()

--- a/test/unit/merge_render_spec.lua
+++ b/test/unit/merge_render_spec.lua
@@ -55,11 +55,11 @@ describe("render.merge (default layout)", function()
     end)
 end)
 
-describe("render.merge (diff3_mixed layout)", function()
+describe("render.merge (diff4 layout)", function()
     it("adds the base column between ours and theirs and locates its slab", function()
         local m = model()
         m.regions[1].base = { "b" }
-        local r = merge.render(m, { layout = "diff3_mixed" })
+        local r = merge.render(m, { layout = "diff4" })
         assert.are.equal(4, #r.columns)
         assert.are.equal("base", r.columns[2].side)
         assert.are.same({ { index = 1, first = 2, last = 2 } }, by_side(r, "base").regions)


### PR DESCRIPTION
## Summary
- config-only `merge.layout` (`default` | `diff4`); `diff4` adds the base column over the result, with no per-invocation argument so `:Differ mergetool <path>` stays unambiguous
- recover per-region base slabs under git's default conflict style, which writes no `|||||||` slab, by re-merging the stages with `git merge-file -p --diff3` and mapping its conflicts onto the worktree's; the base column works without switching to zdiff3
- grouping-agnostic mapping: ort coalesces conflicts `merge-file` keeps apart, so a region owns a run of them and takes the base-stage span it covers, interstitials included. ours and theirs claim independently and must agree, a side with nothing locatable abstains, and orphan re-merge regions are skipped rather than parked on
- add/add takes no base instead of silently dropping the block: there's no `:1:` stage, but the re-merge still yielded empty slabs that recovery copied across as `{}`, which take-base then spliced
- the base pane says why it's empty: `no common ancestor`, or `none for this conflict` where the mapping was too ambiguous to trust
- extract `find_run`/`find_runs` into `differ.util.lines`; document `merge.layout` and the base behaviour in the README

closes #27

## Test plan
- [x] `make check` (lua + go lint, lua_ls type-check, all suites)
- [x] lua unit 334/0, headless-nvim 316/0, go tests ok
- [x] coalesced conflict end-to-end against real git, plus a manual pass in the editor
