### PR TITLE
feat: in-buffer session and review keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- A vimdoc: `doc/differ.txt`, generated from the README, so `:help differ` works
+- In-buffer session keys, so the things you do inside a session no longer need a global launcher: `dc` ends it (routing to the merge, PR or local session), `dd` toggles the file panel, `dl` flips the layout. `dc` binds on the diff, panel and history; `dd` on the diff and panel; `dl` on the diff, the only surface that owns a layout
+- `gS` and `gD` submit and discard a PR review from the diff or panel, so a review can be finished without leaving the files. Capitalised to keep the lowercase `g` family for thread and comment actions; each action's own prompt (the verdict picker, the discard confirm) is the guard
+
+### Changed
+
+- **Breaking:** the merge tool's drop-conflict key moves from `dx` to `<leader>cx`, so the whole choose family shares one prefix. Override `keymaps.choose_none` to keep `dx`
+- **Breaking:** `q` no longer closes the merge tool. The result buffer is the real worktree file and stays editable, so `q` is left to native macro recording; `:Differ close` ends the session. `q` is now unbound on every differ surface except the PR overview, where it still drops back into the review
+- `:Differ pr review` (and `r` on the overview) is start-or-resume: with a draft already pending it reattaches instead of refusing, and lands on the first file not yet marked viewed, since resuming asks what is left to review. On a thread row that anchor wins and the cursor stays there
+- The panel and history cheatsheets are generated from the resolved keymaps rather than hardcoded, so `g?` shows your keys after a `keymaps` override. An action set to `false` drops its row instead of rendering `false`
+- The documented launcher spec covers only the entry points that cannot be buffer-local (`:Differ`, `base`, `log`, `pr list`, `pr <n>`); everything else it used to bind now has an in-buffer key
+
+### Fixed
+
+- The file panel's `g?` lists the session's own maps (the PR viewed nav and review verbs), which bind through the extra-keymaps seam and were never shown
+
+## [0.1.19] — 2026-08-04
+
+### Added
+
 - A `diff4` merge layout (`merge.layout = "diff4"`), adding a base column with the common ancestor above the result. `<leader>cb` takes base in either layout, so the layout is about seeing what you're taking, not being able to take it
 - Base recovery under git's default `merge.conflictStyle`, which writes no base into the markers: differ re-merges the stages in diff3 style and maps those regions onto the worktree conflicts, so take-base works without `zdiff3`. Where the mapping can't be trusted the base pane says why (`no common ancestor` on add/add, `none for this conflict` otherwise) and take-base is refused rather than emptying the block
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,13 @@ vimdoc: $(PANVIMDOC_BIN) ## Regenerate doc/differ.txt from README.md (needs pand
 		--dedup-subheadings true \
 		--shift-heading-level-by -1 2>&1) || { printf '%s\n' "$$out"; exit 1; }
 	@$(OK) "doc/differ.txt regenerated"
+	@# doc/tags is gitignored and lazy only generates helptags for plugins it installed,
+	@# never for a `dir` dev checkout, so :help differ breaks in-tree without this. skipped
+	@# where there's no nvim (ci runs pandoc only), and invisible to ci's differ.txt diff
+	@if command -v nvim >/dev/null 2>&1; then \
+		nvim --headless -c "helptags doc" -c "qa!" >/dev/null 2>&1; \
+		$(OK) "doc/tags regenerated"; \
+	fi
 
 # fetch the pinned panvimdoc into .tools on first use; the whole tree is gitignored
 $(PANVIMDOC_BIN):

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ require("differ").setup({
     goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
     discard = "X", refresh = "R",  -- panel
     toggle_fold = "za",          -- history (range mode)
+    close = "dc",                -- diff/panel/history: end the session
+    toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
+    toggle_layout = "dl",        -- diff: flip stacked / split
     -- pr review (pr diff + panel)
     toggle_viewed = "<Tab>",     -- pr panel: flip the github viewed checkbox
     next_unviewed = "]u", prev_unviewed = "[u",  -- pr panel + diff
@@ -179,11 +182,13 @@ require("differ").setup({
     toggle_thread = "gc",        -- pr diff: collapse/expand the thread under the cursor
     resolve_thread = "gr",       -- pr diff: resolve/unresolve the thread under the cursor
     overview = "go",             -- pr diff + panel: back to the PR overview home
+    review_submit = "gS",        -- pr: submit the pending review
+    review_discard = "gD",       -- pr: discard the pending review and its drafts
     -- merge tool, bound on the result buffer
     next_conflict = "]x", prev_conflict = "[x",
     choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
     choose_all = "<leader>ca",   -- take both (ours then theirs)
-    choose_none = "dx",          -- drop the conflict region
+    choose_none = "<leader>cx",  -- drop the conflict region
   },
   relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
   base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
@@ -243,6 +248,9 @@ The stacked / split view.
 | `d=` / `d-` | More / less context |
 | `df` | Edit-in-review (uncommitted diffs) |
 | `de` | Open the real file and end the session |
+| `dd` | Toggle the file panel |
+| `dl` | Toggle the layout (stacked / split) |
+| `dc` | Close the session |
 | `go` | PR review only: back to the [PR overview](#pr-overview) |
 
 #### Panel
@@ -261,6 +269,8 @@ The file list.
 | `s` / `u` / `S` / `U` | Stage / unstage file, or all |
 | `X` | Discard changes |
 | `R` | Refresh |
+| `dd` | Toggle the file panel |
+| `dc` | Close the session |
 | `g?` | Help |
 
 #### History
@@ -277,6 +287,7 @@ Log / range mode.
 | `c` | Collapse the commit under the cursor (range mode) |
 | `O` / `C` | Expand / collapse every commit (range mode) |
 | `K` | Commit details |
+| `dc` | Close the session |
 | `g?` | Help |
 
 #### PR review
@@ -296,6 +307,8 @@ On top of the diff + panel keys.
 | `go` | Back to the [PR overview](#pr-overview) |
 | `df` | Edit the real file in a split beside the (pinned) diff, keeping the review |
 | `de` | Zoom-edit the real file full-screen in its own tab; `:q` returns to the review |
+| `gS` | Submit the review (pick a verdict, then write a summary) |
+| `gD` | Discard the review and its draft comments (confirms) |
 
 `df`/`de` edit the worktree file on disk, not the reviewed blob, so keep your checkout on the PR's head branch (`:Differ pr checkout`) or the two can drift; differ warns once a session if they don't match.
 
@@ -305,12 +318,14 @@ On top of the diff + panel keys.
 
 | Key | Action |
 |---|---|
-| `e` / `r` | Enter the review / enter and start a review; on a thread row, at that comment's file |
+| `e` / `r` | Enter the review / enter and start or resume one; on a thread row, at that comment's file |
 | `<CR>` | On a thread row: jump into the review at that comment; elsewhere: open the PR in the browser |
 | `]t` / `[t` | Next / previous thread |
 | `gx` | Open the PR in the browser |
 | `q` | Back into the review when one is in progress (closing the page window ends the session) |
 | `g?` | Help |
+
+`r` is start-or-resume: with a draft already pending it reattaches rather than refusing, and lands on the first file you haven't marked viewed - resuming asks what's left to review, not what you last said. On a thread row that anchor wins and the cursor stays there. Entering the review adopts any pending draft automatically, so commenting is in draft mode from the start either way; `:Differ pr review resume` does the same from cold.
 
 Code-comment threads render as a contained box (GitHub's outline, differ's left-spine style) with the diff hunk they anchor to inline: the tail of the hunk, capped, `⋯` when trimmed, `+`/`-` lines carrying the diff's own tints and the code treesitter-highlighted when a parser is installed. Plain PR comments and review verdicts stay flat page text, which is how you tell them apart at a glance.
 
@@ -323,9 +338,11 @@ Bound on the result buffer.
 | `]x` / `[x` | Next / previous conflict |
 | `<leader>co` / `ct` / `cb` | Take ours / theirs / base |
 | `<leader>ca` | Take both (ours then theirs) |
-| `dx` | Drop the conflict region |
-| `q` | Close the merge tool |
+| `<leader>cx` | Drop the conflict region |
+| `:Differ close` | Close the merge tool |
 | `g?` | Help |
+
+The result buffer is the real file and stays editable, so the conflict keys sit behind `<leader>` rather than shadowing live operators, and `q` is left to native macro recording.
 
 `merge.layout` picks the panes: `default` shows ours and theirs over the result, `diff4` adds a base column with the common ancestor. `<leader>cb` takes base in either layout, so `diff4` is about seeing what you're taking, not being able to take it.
 
@@ -337,7 +354,7 @@ Because it's a real file, the merge tool sets `vim.b.disable_autoformat` (confor
 
 ### Launchers
 
-A starting point, not a default: differ ships no global launchers - only the in-view buffer maps above and the optional `command_alias`. These are the `<leader>` launchers I drive it with, as a lazy.nvim spec you can lift wholesale or trim to taste.
+differ ships no global launchers - only the in-view buffer maps above and the optional `command_alias`. Everything you do *inside* a session already has a key, so a launcher only earns its place for the handful of entry points you reach from an ordinary file, where no differ buffer exists yet to bind to. These are the ones I drive it with; lift them wholesale or trim to taste.
 
 <details>
 <summary><b>lazy.nvim spec with <code>&lt;leader&gt;d*</code> / <code>&lt;leader&gt;p*</code> launchers</b></summary>
@@ -350,13 +367,9 @@ A starting point, not a default: differ ships no global launchers - only the in-
   keys = {
     -- local diff / history
     { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
-    { "<leader>dc", "<cmd>Differ close<CR>",                  desc = "Diff: close" },
     { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
-    { "<leader>de", "<cmd>Differ gofile<CR>",                 desc = "Diff: open the real file" },
-    { '<leader>dd', '<cmd>Differ panel<CR>',                  desc = "Diff: panel toggle" },
     { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
     { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
-    { "<leader>dl", "<cmd>Differ layout<CR>",                 desc = "Diff: toggle layout" },
     -- pr review (sidecar + github)
     { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
     {
@@ -368,25 +381,14 @@ A starting point, not a default: differ ships no global launchers - only the in-
       end,
       desc = "PR: open by number",
     },
-    { "<leader>pr",  "<cmd>Differ pr review<CR>",         desc = "PR: review start" },
-    { "<leader>pe",  "<cmd>Differ pr review resume<CR>",  desc = "PR: review resume" },
-    { "<leader>pm",  "<cmd>Differ pr review submit<CR>",  desc = "PR: review submit" },
-    { "<leader>pd",  "<cmd>Differ pr review discard<CR>", desc = "PR: review discard" },
-    { "<leader>psm", "<cmd>Differ pr merge squash<CR>",   desc = "PR: squash merge" },
-    { "<leader>pk",  "<cmd>Differ pr checks<CR>",         desc = "PR: checks" },
-    { "<leader>pO",  "<cmd>Differ pr checkout<CR>",       desc = "PR: checkout" },
-    { "<leader>pR",  "<cmd>Differ pr ready<CR>",          desc = "PR: mark ready" },
-    { "<leader>pD",  "<cmd>Differ pr draft<CR>",          desc = "PR: mark draft" },
-    { "<leader>pX",  "<cmd>Differ pr close<CR>",          desc = "PR: close" },
-    { "<leader>pb",  "<cmd>Differ pr browser<CR>",        desc = "PR: open in browser" },
-    { "<leader>py",  "<cmd>Differ pr url<CR>",            desc = "PR: yank URL" },
-    { "<leader>pq",  "<cmd>Differ close<CR>",             desc = "PR: quit" },
   },
   config = function()
     require("differ").setup({ command_alias = "D" })
   end,
 }
 ```
+
+Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and layout, and `gS` / `gD` submit or discard a review without leaving the files. The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`, `merge`, `browser`, `url`) stay as `:Differ pr <verb>` - once-per-PR actions that don't earn a keymap.
 
 </details>
 

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -105,6 +105,9 @@ Table of Contents                                   *differ-table-of-contents*
         goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
         discard = "X", refresh = "R",  -- panel
         toggle_fold = "za",          -- history (range mode)
+        close = "dc",                -- diff/panel/history: end the session
+        toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
+        toggle_layout = "dl",        -- diff: flip stacked / split
         -- pr review (pr diff + panel)
         toggle_viewed = "<Tab>",     -- pr panel: flip the github viewed checkbox
         next_unviewed = "]u", prev_unviewed = "[u",  -- pr panel + diff
@@ -115,11 +118,13 @@ Table of Contents                                   *differ-table-of-contents*
         toggle_thread = "gc",        -- pr diff: collapse/expand the thread under the cursor
         resolve_thread = "gr",       -- pr diff: resolve/unresolve the thread under the cursor
         overview = "go",             -- pr diff + panel: back to the PR overview home
+        review_submit = "gS",        -- pr: submit the pending review
+        review_discard = "gD",       -- pr: discard the pending review and its drafts
         -- merge tool, bound on the result buffer
         next_conflict = "]x", prev_conflict = "[x",
         choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
         choose_all = "<leader>ca",   -- take both (ours then theirs)
-        choose_none = "dx",          -- drop the conflict region
+        choose_none = "<leader>cx",  -- drop the conflict region
       },
       relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
       base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
@@ -203,6 +208,9 @@ The stacked / split view.
   d= / d-   More / less context
   df        Edit-in-review (uncommitted diffs)
   de        Open the real file and end the session
+  dd        Toggle the file panel
+  dl        Toggle the layout (stacked / split)
+  dc        Close the session
   go        PR review only: back to the PR overview
 
 PANEL ~
@@ -221,6 +229,8 @@ The file list.
   s / u / S / U   Stage / unstage file, or all
   X               Discard changes
   R               Refresh
+  dd              Toggle the file panel
+  dc              Close the session
   g?              Help
 
 HISTORY ~
@@ -237,6 +247,7 @@ Log / range mode.
   c          Collapse the commit under the cursor (range mode)
   O / C      Expand / collapse every commit (range mode)
   K          Commit details
+  dc         Close the session
   g?         Help
 
 PR REVIEW ~
@@ -274,6 +285,12 @@ On top of the diff + panel keys.
   de                                  Zoom-edit the real file full-screen
                                       in its own tab; :q returns to the
                                       review
+
+  gS                                  Submit the review (pick a verdict,
+                                      then write a summary)
+
+  gD                                  Discard the review and its draft
+                                      comments (confirms)
   -----------------------------------------------------------------------
 `df`/`de` edit the worktree file on disk, not the reviewed blob, so keep your
 checkout on the PR’s head branch (`:Differ pr checkout`) or the two can
@@ -288,8 +305,8 @@ PR OVERVIEW ~
   Key                                 Action
   ----------------------------------- -----------------------------------
   e / r                               Enter the review / enter and start
-                                      a review; on a thread row, at that
-                                      comment’s file
+                                      or resume one; on a thread row, at
+                                      that comment’s file
 
   <CR>                                On a thread row: jump into the
                                       review at that comment; elsewhere:
@@ -305,6 +322,13 @@ PR OVERVIEW ~
 
   g?                                  Help
   -----------------------------------------------------------------------
+`r` is start-or-resume: with a draft already pending it reattaches rather than
+refusing, and lands on the first file you haven’t marked viewed - resuming
+asks what’s left to review, not what you last said. On a thread row that
+anchor wins and the cursor stays there. Entering the review adopts any pending
+draft automatically, so commenting is in draft mode from the start either way;
+`:Differ pr review resume` does the same from cold.
+
 Code-comment threads render as a contained box (GitHub’s outline, differ’s
 left-spine style) with the diff hunk they anchor to inline: the tail of the
 hunk, capped, `⋯` when trimmed, `+`/`-` lines carrying the diff’s own tints
@@ -322,9 +346,13 @@ Bound on the result buffer.
   ]x / [x                Next / previous conflict
   <leader>co / ct / cb   Take ours / theirs / base
   <leader>ca             Take both (ours then theirs)
-  dx                     Drop the conflict region
-  q                      Close the merge tool
+  <leader>cx             Drop the conflict region
+  :Differ close          Close the merge tool
   g?                     Help
+The result buffer is the real file and stays editable, so the conflict keys sit
+behind `<leader>` rather than shadowing live operators, and `q` is left to
+native macro recording.
+
 `merge.layout` picks the panes: `default` shows ours and theirs over the
 result, `diff4` adds a base column with the common ancestor. `<leader>cb` takes
 base in either layout, so `diff4` is about seeing what you’re taking, not
@@ -352,10 +380,11 @@ interaction.
 
 LAUNCHERS                                             *differ-usage-launchers*
 
-A starting point, not a default: differ ships no global launchers - only the
-in-view buffer maps above and the optional `command_alias`. These are the
-`<leader>` launchers I drive it with, as a lazy.nvim spec you can lift
-wholesale or trim to taste.
+differ ships no global launchers - only the in-view buffer maps above and the
+optional `command_alias`. Everything you do _inside_ a session already has a
+key, so a launcher only earns its place for the handful of entry points you
+reach from an ordinary file, where no differ buffer exists yet to bind to.
+These are the ones I drive it with; lift them wholesale or trim to taste.
 
 lazy.nvim spec with <leader>d_ / <leader>p_ launchers ~
 
@@ -367,13 +396,9 @@ lazy.nvim spec with <leader>d_ / <leader>p_ launchers ~
       keys = {
         -- local diff / history
         { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
-        { "<leader>dc", "<cmd>Differ close<CR>",                  desc = "Diff: close" },
         { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
-        { "<leader>de", "<cmd>Differ gofile<CR>",                 desc = "Diff: open the real file" },
-        { '<leader>dd', '<cmd>Differ panel<CR>',                  desc = "Diff: panel toggle" },
         { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
         { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
-        { "<leader>dl", "<cmd>Differ layout<CR>",                 desc = "Diff: toggle layout" },
         -- pr review (sidecar + github)
         { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
         {
@@ -385,25 +410,18 @@ lazy.nvim spec with <leader>d_ / <leader>p_ launchers ~
           end,
           desc = "PR: open by number",
         },
-        { "<leader>pr",  "<cmd>Differ pr review<CR>",         desc = "PR: review start" },
-        { "<leader>pe",  "<cmd>Differ pr review resume<CR>",  desc = "PR: review resume" },
-        { "<leader>pm",  "<cmd>Differ pr review submit<CR>",  desc = "PR: review submit" },
-        { "<leader>pd",  "<cmd>Differ pr review discard<CR>", desc = "PR: review discard" },
-        { "<leader>psm", "<cmd>Differ pr merge squash<CR>",   desc = "PR: squash merge" },
-        { "<leader>pk",  "<cmd>Differ pr checks<CR>",         desc = "PR: checks" },
-        { "<leader>pO",  "<cmd>Differ pr checkout<CR>",       desc = "PR: checkout" },
-        { "<leader>pR",  "<cmd>Differ pr ready<CR>",          desc = "PR: mark ready" },
-        { "<leader>pD",  "<cmd>Differ pr draft<CR>",          desc = "PR: mark draft" },
-        { "<leader>pX",  "<cmd>Differ pr close<CR>",          desc = "PR: close" },
-        { "<leader>pb",  "<cmd>Differ pr browser<CR>",        desc = "PR: open in browser" },
-        { "<leader>py",  "<cmd>Differ pr url<CR>",            desc = "PR: yank URL" },
-        { "<leader>pq",  "<cmd>Differ close<CR>",             desc = "PR: quit" },
       },
       config = function()
         require("differ").setup({ command_alias = "D" })
       end,
     }
 <
+
+Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and
+layout, and `gS` / `gD` submit or discard a review without leaving the files.
+The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`,
+`merge`, `browser`, `url`) stay as `:Differ pr <verb>` - once-per-PR actions
+that don’t earn a keymap.
 
 If which-key’s `<leader>` popup doesn’t open over differ’s buffers,
 that’s a trigger-registration quirk on scratch buffers, not a differ bug;

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -135,6 +135,12 @@ M.defaults = {
         discard = "X", -- panel
         refresh = "R",
         toggle_fold = "za", -- history (range mode)
+        -- session-level verbs. the diff/panel/history buffers are read-only scratch,
+        -- so shadowing native q (record macro) and dd/dl (delete) is inert there; the
+        -- merge result buffer is a real file and binds none of these
+        close = "q", -- diff/panel/history: end the session (merge, pr or local)
+        toggle_panel = "dd", -- diff/panel: hide/show the file panel sidebar
+        toggle_layout = "dl", -- diff: flip stacked / split
         -- merge tool, bound on the result buffer. nav + take-this resolution,
         -- the result buffer is the real worktree
         -- file and stays editable, so the whole choose family sits behind <leader>

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -115,12 +115,13 @@ M.defaults = {
         comment = "ga", -- comment on the line (normal) or the selection (visual)
         reply = "gp", -- reply to the thread under the cursor
         delete_comment = "gx", -- delete the latest comment of the thread under the cursor
-        -- pr review lifecycle, on the pr diff + panel. capitalised to keep the
-        -- lowercase g-family for thread/comment actions; each one's own prompt
-        -- (verdict picker, confirm) is the guard, not the key
+        -- pr review lifecycle, on the pr diff + panel, so a review can be finished
+        -- without leaving the files. capitalised to keep the lowercase g-family for
+        -- thread/comment actions; each one's own prompt (verdict picker, confirm) is
+        -- the guard, not the key. resume isn't here: entering the review already
+        -- adopts any pending draft, so `:Differ pr review resume` covers the cold start
         review_submit = "gS", -- pr: submit the pending review
         review_discard = "gD", -- pr: discard the pending review and its drafts
-        review_resume = "gR", -- pr: resume a pending review
         scroll_down = "f", -- all three (shadows native f/b; set false to restore)
         scroll_up = "b",
         select = { "<CR>", "o" }, -- panel, history
@@ -141,10 +142,10 @@ M.defaults = {
         discard = "X", -- panel
         refresh = "R",
         toggle_fold = "za", -- history (range mode)
-        -- session-level verbs. the diff/panel/history buffers are read-only scratch,
-        -- so shadowing native q (record macro) and dd/dl (delete) is inert there; the
-        -- merge result buffer is a real file and binds none of these
-        close = "q", -- diff/panel/history: end the session (merge, pr or local)
+        -- session-level verbs, joining the d-family the diff verbs already use. the
+        -- diff/panel/history buffers are read-only scratch, so the shadowed deletes are
+        -- inert; q stays free for native macro recording on every surface
+        close = "dc", -- diff/panel/history: end the session (merge, pr or local)
         toggle_panel = "dd", -- diff/panel: hide/show the file panel sidebar
         toggle_layout = "dl", -- diff: flip stacked / split
         -- merge tool, bound on the result buffer. nav + take-this resolution,

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -115,6 +115,12 @@ M.defaults = {
         comment = "ga", -- comment on the line (normal) or the selection (visual)
         reply = "gp", -- reply to the thread under the cursor
         delete_comment = "gx", -- delete the latest comment of the thread under the cursor
+        -- pr review lifecycle, on the pr diff + panel. capitalised to keep the
+        -- lowercase g-family for thread/comment actions; each one's own prompt
+        -- (verdict picker, confirm) is the guard, not the key
+        review_submit = "gS", -- pr: submit the pending review
+        review_discard = "gD", -- pr: discard the pending review and its drafts
+        review_resume = "gR", -- pr: resume a pending review
         scroll_down = "f", -- all three (shadows native f/b; set false to restore)
         scroll_up = "b",
         select = { "<CR>", "o" }, -- panel, history

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -136,14 +136,16 @@ M.defaults = {
         refresh = "R",
         toggle_fold = "za", -- history (range mode)
         -- merge tool, bound on the result buffer. nav + take-this resolution,
-        -- mirroring diffview's conflict keys
+        -- the result buffer is the real worktree
+        -- file and stays editable, so the whole choose family sits behind <leader>
+        -- rather than shadowing live operators
         next_conflict = "]x", -- merge: jump to the next/prev conflict
         prev_conflict = "[x",
         choose_ours = "<leader>co", -- merge: take ours / theirs / base for the conflict
         choose_theirs = "<leader>ct",
         choose_base = "<leader>cb",
         choose_all = "<leader>ca", -- take both (ours then theirs)
-        choose_none = "dx", -- drop the conflict region
+        choose_none = "<leader>cx", -- drop the conflict region
     },
     -- show dates as relative ("3 days ago") instead of YYYY-MM-DD wherever the
     -- plugin renders one (the history panel today, more surfaces later)

--- a/lua/differ/history/init.lua
+++ b/lua/differ/history/init.lua
@@ -756,6 +756,10 @@ function History:_setup_window()
         bind(self.bufnr, spec, fn, "differ history: " .. desc)
     end
     local item = self.mode == "range" and "file" or "commit"
+    -- no toggle_panel here: a history session has no file panel to hide/show
+    map(km.close, function()
+        require("differ.command").close()
+    end, "close the session")
     map(km.select, function()
         self:select()
     end, "open " .. item)

--- a/lua/differ/history/init.lua
+++ b/lua/differ/history/init.lua
@@ -685,32 +685,36 @@ end
 
 -- g?: a floating keymap cheatsheet, dismissed with <Esc> / q / g?
 function History:show_help()
-    local lines = {}
+    local km = self.keymaps
+    local help = require("differ.ui.help")
+    local fmt, pair = help.fmt, help.pair
+    local rows = {}
     if self.mode == "range" then
-        vim.list_extend(lines, {
-            " <CR> / o   toggle fold / open file",
-            " za         toggle fold",
-            " O / C      expand / collapse all",
-            " c          collapse commit",
-            " ]f / [f    next / previous file",
-            " ]] / [[    next / previous commit",
-            " gg / G     first / last commit",
+        vim.list_extend(rows, {
+            { fmt(km.select), "toggle fold / open file" },
+            { fmt(km.toggle_fold), "toggle fold" },
+            { pair(km.open_all, km.close_all), "expand / collapse all" },
+            { fmt(km.close_node), "collapse commit" },
+            { pair(km.next_file, km.prev_file), "next / previous file" },
+            { pair(km.next_section, km.prev_section), "next / previous commit" },
+            { pair(km.first_file, km.last_file), "first / last commit" },
         })
     else
-        vim.list_extend(lines, {
-            " <CR> / o   show commit",
-            " ]f / [f    next / previous commit",
-            " ]] / [[    move between commits",
-            " gg / G     first / last commit",
+        vim.list_extend(rows, {
+            { fmt(km.select), "show commit" },
+            { pair(km.next_file, km.prev_file), "next / previous commit" },
+            { pair(km.next_section, km.prev_section), "move between commits" },
+            { pair(km.first_file, km.last_file), "first / last commit" },
         })
     end
-    vim.list_extend(lines, {
-        " ]c / [c    next / previous hunk",
-        " f / b      scroll diff down / up",
-        " K          commit details",
-        " g?         this help",
+    vim.list_extend(rows, {
+        { pair(km.next_hunk, km.prev_hunk), "next / previous hunk" },
+        { pair(km.scroll_down, km.scroll_up), "scroll diff down / up" },
+        { fmt(km.details), "commit details" },
+        { fmt(km.close), "close the session" },
+        { fmt(km.help), "this help" },
     })
-    require("differ.ui.help").show(lines, { title = " Differ: history " })
+    help.show(help.lines(rows), { title = " Differ: history " })
 end
 
 -- K: float the full commit message (subject + body) plus author/date for the commit

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -656,12 +656,8 @@ local function show_help()
         return
     end
     local km = session.keymaps
-    local function fmt(spec)
-        return type(spec) == "table" and table.concat(spec, " / ") or tostring(spec)
-    end
-    local function pair(a, b)
-        return fmt(a) .. " / " .. fmt(b)
-    end
+    local help = require("differ.ui.help")
+    local fmt, pair = help.fmt, help.pair
     local rows = {
         { pair(km.next_conflict, km.prev_conflict), "next / previous conflict" },
         { fmt(km.choose_ours), "take ours" },
@@ -673,18 +669,10 @@ local function show_help()
         { ":Differ close", "close the merge tool" },
         { fmt(km.help), "this help" },
     }
-    local keyw = 0
-    for _, r in ipairs(rows) do
-        keyw = math.max(keyw, #r[1])
-    end
-    local lines = {}
-    for _, r in ipairs(rows) do
-        lines[#lines + 1] = (" %-" .. keyw .. "s   %s"):format(r[1], r[2])
-    end
     -- dismiss on the configured help key too, not just the hardcoded q/<Esc>
     local dismiss = { "q", "<Esc>" }
     vim.list_extend(dismiss, type(km.help) == "table" and km.help or { km.help })
-    require("differ.ui.help").show(lines, { title = " Differ: merge ", dismiss = dismiss })
+    help.show(help.lines(rows), { title = " Differ: merge ", dismiss = dismiss })
 end
 
 ---@type fun(root: string, relpath: string, model: differ.MergeModel, layout: "default"|"diff4")

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -72,7 +72,7 @@ local INPUT_HL = {
 ---@type differ.MergeSession|nil
 local session = nil
 
--- the result-buffer conflict chords (<leader>co/ct/cb/ca, dx) are multi-key, so nvim waits
+-- the result-buffer conflict chords (<leader>co/ct/cb/ca/cx) are multi-key, so nvim waits
 -- timeoutlen for the completing key. a short global timeoutlen (which-key setups often run
 -- 200ms) drops them unless typed fast, so widen the window to a generous floor while the
 -- cursor sits in the result buffer and restore the user's value on leave/close. timeoutlen
@@ -670,7 +670,7 @@ local function show_help()
         { fmt(km.choose_all), "take both (ours then theirs)" },
         { fmt(km.choose_none), "drop the conflict" },
         { ":w", "write the file (auto-stages once resolved)" },
-        { "q", "close the merge tool" },
+        { ":Differ close", "close the merge tool" },
         { fmt(km.help), "this help" },
     }
     local keyw = 0
@@ -859,13 +859,8 @@ function lay_out(root, relpath, model, layout)
         resolve_choice("none")
     end, "differ: drop the conflict")
     rb("help", show_help, "differ: keymap help")
-    -- q closes the tool (conventional, no config action)
-    vim.keymap.set(
-        "n",
-        "q",
-        M.close,
-        { buffer = result_buf, silent = true, desc = "differ: close" }
-    )
+    -- no close key here: the result buffer is the real file and stays editable, so q is
+    -- left to native macro recording. `:Differ close` ends the session
 
     local aug = vim.api.nvim_create_augroup("differ.merge." .. result_buf, { clear = true })
     -- :w writes the real file; once no markers remain it auto-stages (git add = resolve),

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -1021,6 +1021,11 @@ function Panel:show_help()
             { fmt(km.refresh), "refresh" },
         })
     end
+    -- the session's own maps (the pr viewed nav and review verbs), which bind here
+    -- through the extra_keymaps seam and would otherwise never show up
+    for _, m in ipairs(self.extra_keymaps or {}) do
+        rows[#rows + 1] = { fmt(m.spec), m.desc }
+    end
     rows[#rows + 1] = { fmt(km.close), "close the session" }
     rows[#rows + 1] = { fmt(km.help), "this help" }
     help.show(help.lines(rows), { title = " Differ: panel " })

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -996,29 +996,34 @@ end
 
 -- g?: a floating keymap cheatsheet, dismissed with <Esc> / g?
 function Panel:show_help()
-    local lines = {
-        " <CR> / o   open file / toggle fold",
-        " c          close node / parent",
-        " C / O      close / open all nodes",
-        " ]f / [f    next / previous file",
-        " gg / G     first / last file",
-        " ]] / [[    next / previous section",
-        " ]c / [c    next / previous hunk",
-        " f / b      scroll diff down / up",
-        " i          toggle listing (tree / name)",
-        " de         go to the real file",
+    local km = self.keymaps
+    local help = require("differ.ui.help")
+    local fmt, pair = help.fmt, help.pair
+    local rows = {
+        { fmt(km.select), "open file / toggle fold" },
+        { fmt(km.close_node), "close node / parent" },
+        { pair(km.close_all, km.open_all), "close / open all nodes" },
+        { pair(km.next_file, km.prev_file), "next / previous file" },
+        { pair(km.first_file, km.last_file), "first / last file" },
+        { pair(km.next_section, km.prev_section), "next / previous section" },
+        { pair(km.next_hunk, km.prev_hunk), "next / previous hunk" },
+        { pair(km.scroll_down, km.scroll_up), "scroll diff down / up" },
+        { fmt(km.toggle_listing), "toggle listing (tree / name)" },
+        { fmt(km.toggle_panel), "toggle the file panel" },
+        { fmt(km.goto_file), "go to the real file" },
     }
     if self.actions then
-        vim.list_extend(lines, {
-            " s / u      stage / unstage file",
-            " S / U      stage / unstage all",
-            " X          discard file (confirm)",
-            " df         edit the real file (in review)",
-            " R          refresh",
+        vim.list_extend(rows, {
+            { pair(km.stage, km.unstage), "stage / unstage file" },
+            { pair(km.stage_all, km.unstage_all), "stage / unstage all" },
+            { fmt(km.discard), "discard file (confirm)" },
+            { fmt(km.edit_file), "edit the real file (in review)" },
+            { fmt(km.refresh), "refresh" },
         })
     end
-    vim.list_extend(lines, { " g?         this help" })
-    require("differ.ui.help").show(lines, { title = " Differ: panel " })
+    rows[#rows + 1] = { fmt(km.close), "close the session" }
+    rows[#rows + 1] = { fmt(km.help), "this help" }
+    help.show(help.lines(rows), { title = " Differ: panel " })
 end
 
 -- window appearance + buffer-local keymaps

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -1100,6 +1100,12 @@ function Panel:_setup_window()
         end
         run()
     end
+    map(km.close, function()
+        require("differ.command").close()
+    end, "close the session")
+    map(km.toggle_panel, function()
+        require("differ.command").panel()
+    end, "toggle the file panel")
     map(km.select, function()
         self:select()
     end, "open / toggle fold")

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -368,7 +368,7 @@ function M.prev_thread()
 end
 
 -- gr: toggle the resolved state of the thread under the cursor (a cursor-context keymap,
--- not an ex-command). optimistic — flip + re-apply (highlight swap) immediately, then
+-- not an ex-command). optimistic - flip + re-apply (highlight swap) immediately, then
 -- reconcile to the
 -- server's returned state, rolling back + flagging on error. one line can stack
 -- several threads, so it acts on the first open one (else the first, to unresolve);
@@ -436,7 +436,7 @@ function M.handle_conflict(on_ready)
             show_file(cur) -- re-source the diff + overlay at the new head
         end
         notify(
-            "the PR head moved; refreshed to the latest — review and re-submit",
+            "the PR head moved; refreshed to the latest - review and re-submit",
             vim.log.levels.WARN
         )
         if on_ready then
@@ -611,7 +611,7 @@ local function adopt_pending_review(pr)
         if type(review_id) == "string" and review_id ~= "" then
             session.review_id = review_id
             notify(
-                "you have a pending review here — comments are drafts (:Differ pr review resume to manage)"
+                "you have a pending review here - comments are drafts (:Differ pr review resume to manage)"
             )
         end
     end)
@@ -694,15 +694,6 @@ local function open_session(pr, detail, opts)
         return {
             { spec = km.review_submit, fn = M.submit, desc = "submit the review" },
             { spec = km.review_discard, fn = M.discard_review, desc = "discard the review" },
-            -- wrapped: resume takes an optional PR number, and from inside a session
-            -- the key can only mean "this one"
-            {
-                spec = km.review_resume,
-                fn = function()
-                    M.resume()
-                end,
-                desc = "resume the review",
-            },
         }
     end
     local panel_extra = {
@@ -845,11 +836,14 @@ local function enter_files(review, focus)
     -- stash is consumed, so a later plain entry doesn't replay a stale position
     local target = focus or session.overview_return
     session.overview_return = nil
-    if not (target and M.goto_anchor(target)) then
+    local positioned = target ~= nil and M.goto_anchor(target)
+    if not positioned then
         session.panel:select(true)
     end
     if review then
-        require("differ.pr.review").start(session) -- idempotent
+        -- idempotent; a pending draft reattaches. it only picks the landing file when
+        -- we haven't already honoured an explicit target (the overview's thread rows)
+        require("differ.pr.review").start(session, { jump = not positioned })
     elseif first then
         adopt_pending_review(session.pr)
     end
@@ -985,7 +979,7 @@ function M.review(opts)
     return M.open({ number = session.pr.number, land = "files", review = true })
 end
 
--- :Differ pr overview (and the diff/panel `go`) — go back to the PR home from the
+-- :Differ pr overview (and the diff/panel `go`) - go back to the PR home from the
 -- review (closes the diff + hides the panel, keeping the session), or re-show it while
 -- already on the page. the diff position is stashed so re-entering the files restores
 -- it; re-showing from the page keeps an earlier stash rather than clobbering it
@@ -1091,7 +1085,7 @@ local function pr_title()
     return (session and session.pr_meta.title) or ("#" .. (session and session.pr.number or "?"))
 end
 
--- :Differ pr merge [squash|merge|rebase] — confirm, then merge with the chosen method.
+-- :Differ pr merge [squash|merge|rebase] - confirm, then merge with the chosen method.
 -- a `conflict` error means the Go side pre-check found the PR unmergeable; surface that
 -- rather than treating it as an internal failure. on success the PR is merged, so the
 -- session closes (its blobs are now history)
@@ -1128,7 +1122,7 @@ function M.merge(method_arg)
     end)
 end
 
--- :Differ pr ready|draft|close|reopen — map the verb to a state and transition. close
+-- :Differ pr ready|draft|close|reopen - map the verb to a state and transition. close
 -- confirms (destructive); the reversible verbs act immediately. on success the session's
 -- cached state/draft flags follow the server's echoed state
 ---@param verb string
@@ -1161,7 +1155,7 @@ function M.set_state(verb)
     end
 end
 
--- :Differ pr checkout — local git on the session's head_ref (client-side, no
+-- :Differ pr checkout - local git on the session's head_ref (client-side, no
 -- sidecar round-trip): fetch the ref + check it out via the local git plumbing
 function M.checkout()
     M.with_session(function(s)
@@ -1185,7 +1179,7 @@ function M.checkout()
     end)
 end
 
--- :Differ pr browser — open the PR's html url in the system browser (client-side,
+-- :Differ pr browser - open the PR's html url in the system browser (client-side,
 -- the `url` field from get_pr; no sidecar round-trip)
 function M.browser()
     M.with_session(function(s)
@@ -1197,7 +1191,7 @@ function M.browser()
     end)
 end
 
--- :Differ pr url — yank the PR's html url to the system clipboard (client-side)
+-- :Differ pr url - yank the PR's html url to the system clipboard (client-side)
 function M.url()
     M.with_session(function(s)
         local url = s.pr_meta.url
@@ -1209,7 +1203,7 @@ function M.url()
     end)
 end
 
--- :Differ pr checks — the read-only CI checks view
+-- :Differ pr checks - the read-only CI checks view
 function M.checks()
     M.with_session(function(s)
         require("differ.pr.checks").show(s)
@@ -1247,7 +1241,7 @@ function M.resume(arg)
         end)
     end
     if not session then
-        return notify("no active pull request — open one with :Differ pr review <number>")
+        return notify("no active pull request - open one with :Differ pr review <number>")
     end
     require("differ.pr.review").reattach(session)
 end

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -688,6 +688,23 @@ local function open_session(pr, detail, opts)
     -- on the panel, unviewed nav on both. the generic panel/diff don't own them, so
     -- they reach the buffer via the extra_keymaps seam, not the fixed action set
     local panel_km, diff_km = cfg.keymaps.panel, cfg.keymaps.diff
+    -- the review lifecycle verbs, bound the same on both pr surfaces. each entry point
+    -- guards itself (submit picks a verdict, discard confirms), so the keys act directly
+    local function lifecycle(km)
+        return {
+            { spec = km.review_submit, fn = M.submit, desc = "submit the review" },
+            { spec = km.review_discard, fn = M.discard_review, desc = "discard the review" },
+            -- wrapped: resume takes an optional PR number, and from inside a session
+            -- the key can only mean "this one"
+            {
+                spec = km.review_resume,
+                fn = function()
+                    M.resume()
+                end,
+                desc = "resume the review",
+            },
+        }
+    end
     local panel_extra = {
         { spec = panel_km.overview, fn = M.overview, desc = "PR overview" },
         { spec = panel_km.toggle_viewed, fn = toggle_viewed, desc = "toggle viewed" },
@@ -706,6 +723,7 @@ local function open_session(pr, detail, opts)
             desc = "previous unviewed file",
         },
     }
+    vim.list_extend(panel_extra, lifecycle(panel_km))
     -- the diff surface keeps focus in the diff window when stepping (keep_focus = true);
     -- the thread actions also bind here, via the same extra_keymaps seam
     session.diff_extra_keymaps = {
@@ -749,6 +767,7 @@ local function open_session(pr, detail, opts)
             desc = "edit the real file (zoom tab)",
         },
     }
+    vim.list_extend(session.diff_extra_keymaps, lifecycle(diff_km))
 
     -- build the file panel + driven diff into the session tab. deferred so the overview
     -- stays panel-less; a no-op once the panel exists (entering the files reuses it)

--- a/lua/differ/pr/review.lua
+++ b/lua/differ/pr/review.lua
@@ -41,12 +41,14 @@ local function diff_win(session)
     end
 end
 
--- :Differ pr review — start (or reattach to) the viewer's pending draft. idempotent in
--- the sidecar, so this never orphans a second draft
+-- :Differ pr review - start (or reattach to) the viewer's pending draft. idempotent in
+-- the sidecar, so this never orphans a second draft. a session that's already drafting
+-- reattaches instead of refusing, so the one gesture always lands you in the review
 ---@param session table
-function M.start(session)
+---@param opts { jump?: boolean }|nil  -- jump=false when the caller already positioned
+function M.start(session, opts)
     if session.review_id then
-        return notify("a review is already in progress; comments are drafts")
+        return M.reattach(session, opts)
     end
     client.start_review(session.pr, function(err, res)
         if not alive(session) then
@@ -56,14 +58,18 @@ function M.start(session)
             return require("differ.pr").notify_err(err)
         end
         session.review_id = res and res.review_id
-        notify("review started — comments are drafts until you submit")
+        notify("review started - comments are drafts until you submit")
     end)
 end
 
--- :Differ pr review resume — reattach the current session to its pending draft and jump to a
--- pending comment (position restore). a no-op notice when there's no draft
+-- :Differ pr review resume - reattach the current session to its pending draft and land
+-- on the first file still unviewed, since resuming asks what's left to review rather
+-- than what was last said. also the path `start` takes when a draft already exists.
+-- opts.jump = false leaves the cursor alone for a caller that already positioned (the
+-- overview's thread rows). a no-op notice when there's no draft
 ---@param session table
-function M.reattach(session)
+---@param opts { jump?: boolean }|nil
+function M.reattach(session, opts)
     client.get_pending_review(session.pr, function(err, res)
         if not alive(session) then
             return
@@ -78,19 +84,20 @@ function M.reattach(session)
             return notify("no pending review to resume on this PR")
         end
         session.review_id = review_id
-        local first = res.comments and res.comments[1]
-        if first then
-            require("differ.pr").goto_anchor({
-                path = first.path,
-                side = first.side,
-                line = first.line,
-            })
+        if not (opts and opts.jump == false) then
+            -- nothing unviewed means nothing left to resume onto, so the panel's
+            -- current selection stands and the cursor stays put
+            local next_up =
+                require("differ.pr.viewed").next_unviewed(session.entries or {}, 0, "next")
+            if next_up and session.panel then
+                session.panel:goto_path(session.entries[next_up].path)
+            end
         end
-        notify("resumed your pending review — comments are drafts")
+        notify("resumed your pending review - comments are drafts")
     end)
 end
 
--- :Differ pr review submit — finalise the draft as one batch. pick an event, author a summary
+-- :Differ pr review submit - finalise the draft as one batch. pick an event, author a summary
 -- in the compose float, then submit with the session head guard. on success the drafts
 -- become published (re-fetched) and immediate mode resumes
 ---@param session table
@@ -142,7 +149,7 @@ function M._do_submit(session, event, body)
     end)
 end
 
--- :Differ pr review discard — drop the pending draft and its unsubmitted comments. destructive,
+-- :Differ pr review discard - drop the pending draft and its unsubmitted comments. destructive,
 -- so it confirms first; the draft threads then vanish from the overlay
 ---@param session table
 function M.discard(session)

--- a/lua/differ/ui/help.lua
+++ b/lua/differ/ui/help.lua
@@ -1,8 +1,51 @@
--- floating keymap cheatsheet shared by the panel, history and diff surfaces.
--- takes prebuilt lines (each " lhs   desc") and opens a centred minimal float,
--- dismissed with q / <Esc> / g? (or the caller's own dismiss keys)
+-- floating keymap cheatsheet shared by the panel, history, diff and merge surfaces.
+-- `lines` renders {lhs, description} rows from the resolved keymaps; `show` opens a
+-- centred minimal float, dismissed with q / <Esc> / g? (or the caller's own keys)
 
 local M = {}
+
+-- a keymaps spec as a help lhs: a string, a list joined with " / ", or nil when the
+-- action is disabled (false), which drops the row
+---@param spec string|string[]|false|nil
+---@return string|nil
+function M.fmt(spec)
+    if not spec then
+        return nil
+    end
+    return type(spec) == "table" and table.concat(spec, " / ") or tostring(spec)
+end
+
+-- two related actions sharing a row ("]c / [c"), keeping whichever side is enabled
+---@param a string|string[]|false|nil
+---@param b string|string[]|false|nil
+---@return string|nil
+function M.pair(a, b)
+    local first, second = M.fmt(a), M.fmt(b)
+    if first and second then
+        return first .. " / " .. second
+    end
+    return first or second
+end
+
+-- align {lhs, description} rows into help lines. a nil lhs means the action is
+-- disabled, so the row is skipped and doesn't pad the column either
+---@param rows { [1]: string|nil, [2]: string }[]
+---@return string[]
+function M.lines(rows)
+    local keyw = 0
+    for _, r in ipairs(rows) do
+        if r[1] then
+            keyw = math.max(keyw, #r[1])
+        end
+    end
+    local out = {}
+    for _, r in ipairs(rows) do
+        if r[1] then
+            out[#out + 1] = (" %-" .. keyw .. "s   %s"):format(r[1], r[2])
+        end
+    end
+    return out
+end
 
 ---@param lines string[]
 ---@param opts? { title?: string, dismiss?: string[] }

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -640,6 +640,18 @@ function View:_setup_window(winid, bufnr)
     bind(bufnr, km.help, function()
         self:show_help()
     end, "differ: keymap help")
+    -- session verbs that were otherwise only reachable as :Differ subcommands. close
+    -- routes through the command layer because it picks the live session (merge, pr or
+    -- local); layout is this view's own, so call it directly
+    bind(bufnr, km.close, function()
+        require("differ.command").close()
+    end, "differ: close the session")
+    bind(bufnr, km.toggle_panel, function()
+        require("differ.command").panel()
+    end, "differ: toggle the file panel")
+    bind(bufnr, km.toggle_layout, function()
+        self:toggle_layout()
+    end, "differ: toggle the layout")
     -- stage / unstage the hunk under the cursor, hunk-level here vs file-level
     -- in the panel. bound for the whole worktree-status session; the per-file
     -- direction is checked at call time (the buffer is read-only, so shadowing native

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -715,24 +715,25 @@ end
 -- session's extra maps (the pr unviewed nav and thread/comment verbs)
 function View:show_help()
     local km = self.keymaps
-    local function fmt(spec)
-        return type(spec) == "table" and table.concat(spec, " / ") or tostring(spec)
-    end
-    local function pair(a, b)
-        return fmt(a) .. " / " .. fmt(b)
-    end
+    local help = require("differ.ui.help")
+    local fmt, pair = help.fmt, help.pair
     -- an extra map that reuses a fixed lhs overrides its bind (extras bind later), so
     -- the fixed row is dropped in favour of the extra's own. goto_file is the one
     -- fixed action a session overrides today (the pr zoom edit)
     local shadowed = {}
     for _, m in ipairs(self.extra_keymaps or {}) do
-        shadowed[fmt(m.spec)] = true
+        local lhs = fmt(m.spec)
+        if lhs then
+            shadowed[lhs] = true
+        end
     end
     local rows = {
         { pair(km.next_hunk, km.prev_hunk), "next / previous hunk" },
         { pair(km.next_file, km.prev_file), "next / previous file" },
         { pair(km.scroll_down, km.scroll_up), "scroll down / up" },
         { pair(km.more_context, km.less_context), "more / less context" },
+        { fmt(km.toggle_layout), "toggle layout (stacked / split)" },
+        { fmt(km.toggle_panel), "toggle the file panel" },
     }
     if not shadowed[fmt(km.goto_file)] then
         rows[#rows + 1] = { fmt(km.goto_file), "go to the real file" }
@@ -747,20 +748,13 @@ function View:show_help()
     for _, m in ipairs(self.extra_keymaps or {}) do
         rows[#rows + 1] = { fmt(m.spec), m.desc }
     end
+    rows[#rows + 1] = { fmt(km.close), "close the session" }
     rows[#rows + 1] = { fmt(km.help), "this help" }
 
-    local keyw = 0
-    for _, r in ipairs(rows) do
-        keyw = math.max(keyw, #r[1])
-    end
-    local lines = {}
-    for _, r in ipairs(rows) do
-        lines[#lines + 1] = (" %-" .. keyw .. "s   %s"):format(r[1], r[2])
-    end
     -- dismiss on the configured help key too, not just the hardcoded g?
     local dismiss = { "q", "<Esc>" }
     vim.list_extend(dismiss, type(km.help) == "table" and km.help or { km.help })
-    require("differ.ui.help").show(lines, { title = " Differ: diff ", dismiss = dismiss })
+    help.show(help.lines(rows), { title = " Differ: diff ", dismiss = dismiss })
 end
 
 -- the column whose window is currently focused, defaulting to the first. split

--- a/test/nvim/keymaps_spec.lua
+++ b/test/nvim/keymaps_spec.lua
@@ -46,14 +46,17 @@ describe("session verb keymaps", function()
 
     it("binds close, panel toggle and layout toggle on the diff", function()
         local km = lhs_set(view().columns[1].bufnr)
-        assert.are.equal("differ: close the session", km["q"])
+        assert.are.equal("differ: close the session", km["dc"])
         assert.are.equal("differ: toggle the file panel", km["dd"])
         assert.are.equal("differ: toggle the layout", km["dl"])
+        -- q is never differ's on a session surface; the pr overview's own q (back into
+        -- the review) is the only one in the plugin
+        assert.is_nil(km["q"])
     end)
 
     it("binds close and panel toggle on the panel, but not layout", function()
         local km = lhs_set(panel().bufnr)
-        assert.are.equal("differ panel: close the session", km["q"])
+        assert.are.equal("differ panel: close the session", km["dc"])
         assert.are.equal("differ panel: toggle the file panel", km["dd"])
         assert.is_nil(km["dl"]) -- layout belongs to the diff view
     end)
@@ -63,7 +66,7 @@ describe("session verb keymaps", function()
             History.new({ mode = "file", path = "a.lua", commits = {}, on_select = function() end })
         h:open()
         local km = lhs_set(h.bufnr)
-        assert.are.equal("differ history: close the session", km["q"])
+        assert.are.equal("differ history: close the session", km["dc"])
         assert.is_nil(km["dd"])
         assert.is_nil(km["dl"])
     end)
@@ -71,7 +74,7 @@ describe("session verb keymaps", function()
     it("drops a verb the user disables with false", function()
         local km =
             lhs_set(view({ keymaps = { close = false, toggle_layout = "gL" } }).columns[1].bufnr)
-        assert.is_nil(km["q"]) -- q falls back to native macro recording
+        assert.is_nil(km["dc"])
         assert.is_nil(km["dl"])
         assert.are.equal("differ: toggle the layout", km["gL"])
     end)

--- a/test/nvim/keymaps_spec.lua
+++ b/test/nvim/keymaps_spec.lua
@@ -1,0 +1,78 @@
+-- runs under headless nvim: the session verbs (close / toggle_panel / toggle_layout)
+-- bind only on the surfaces that can perform them, and honour a `false` override
+local diff = require("differ.model.diff")
+local View = require("differ.view")
+local Panel = require("differ.panel")
+local History = require("differ.history")
+
+local function lhs_set(bufnr)
+    local got = {}
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+        got[m.lhs] = m.desc or ""
+    end
+    return got
+end
+
+local function view(opts)
+    local v = View.new(
+        diff.build({
+            path = "x",
+            old_rev = "A",
+            new_rev = "B",
+            old_text = "a\nb\n",
+            new_text = "a\nB\n",
+        }),
+        vim.tbl_extend("force", { layout = "stacked", context = 3 }, opts or {})
+    )
+    v:open()
+    return v
+end
+
+local function panel(opts)
+    local p = Panel.new(vim.tbl_extend("force", {
+        sections = {
+            { entries = { { path = "a.lua", status = "M", additions = 1, deletions = 0 } } },
+        },
+        on_select = function() end,
+    }, opts or {}))
+    p:open()
+    return p
+end
+
+describe("session verb keymaps", function()
+    after_each(function()
+        vim.cmd("silent! only")
+    end)
+
+    it("binds close, panel toggle and layout toggle on the diff", function()
+        local km = lhs_set(view().columns[1].bufnr)
+        assert.are.equal("differ: close the session", km["q"])
+        assert.are.equal("differ: toggle the file panel", km["dd"])
+        assert.are.equal("differ: toggle the layout", km["dl"])
+    end)
+
+    it("binds close and panel toggle on the panel, but not layout", function()
+        local km = lhs_set(panel().bufnr)
+        assert.are.equal("differ panel: close the session", km["q"])
+        assert.are.equal("differ panel: toggle the file panel", km["dd"])
+        assert.is_nil(km["dl"]) -- layout belongs to the diff view
+    end)
+
+    it("binds only close on history: there's no panel to toggle", function()
+        local h =
+            History.new({ mode = "file", path = "a.lua", commits = {}, on_select = function() end })
+        h:open()
+        local km = lhs_set(h.bufnr)
+        assert.are.equal("differ history: close the session", km["q"])
+        assert.is_nil(km["dd"])
+        assert.is_nil(km["dl"])
+    end)
+
+    it("drops a verb the user disables with false", function()
+        local km =
+            lhs_set(view({ keymaps = { close = false, toggle_layout = "gL" } }).columns[1].bufnr)
+        assert.is_nil(km["q"]) -- q falls back to native macro recording
+        assert.is_nil(km["dl"])
+        assert.are.equal("differ: toggle the layout", km["gL"])
+    end)
+end)

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -255,6 +255,17 @@ describe(":Differ mergetool", function()
         assert.is_nil(merge.current())
     end)
 
+    it("leaves q to native macro recording on the editable result buffer", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = merge.current()
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(s.result_buf, "n")) do
+            assert.are_not.equal("q", m.lhs) -- :Differ close ends the session instead
+        end
+        merge.close()
+    end)
+
     it("widens a short timeoutlen in the result buffer and restores it on close", function()
         local root = conflict_repo()
         local saved = vim.o.timeoutlen

--- a/test/nvim/pr_review_spec.lua
+++ b/test/nvim/pr_review_spec.lua
@@ -1,0 +1,120 @@
+-- runs under headless nvim: the pending-review draft lifecycle. stubs pr.client (the
+-- one seam review.lua reaches the sidecar through), so a fake session with a fake panel
+-- is enough to drive start / reattach without a real PR session
+local client = require("differ.pr.client")
+local review = require("differ.pr.review")
+
+-- swap the client calls out for the duration of a test. `calls` records which client
+-- methods fired; the fake panel records the path reattach landed on
+local function stub(pending)
+    local calls = {}
+    local real = {
+        start_review = client.start_review,
+        get_pending_review = client.get_pending_review,
+    }
+    client.start_review = function(_pr, cb)
+        calls[#calls + 1] = "start_review"
+        cb(nil, { review_id = "fresh" })
+    end
+    client.get_pending_review = function(_pr, cb)
+        calls[#calls + 1] = "get_pending_review"
+        cb(nil, pending)
+    end
+    return calls,
+        function()
+            client.start_review = real.start_review
+            client.get_pending_review = real.get_pending_review
+        end
+end
+
+-- entries as the panel holds them; `viewed` is what next_unviewed scans
+local function fake_session(review_id, entries)
+    local landed = {}
+    return {
+        pr = { owner = "acme", repo = "widget", number = 7 },
+        review_id = review_id,
+        entries = entries,
+        panel = {
+            landed = landed,
+            goto_path = function(self, path)
+                self.landed[#self.landed + 1] = path
+            end,
+        },
+        -- alive() only asks the view whether it's still open
+        view = {
+            is_open = function()
+                return true
+            end,
+            columns = {},
+        },
+    }
+end
+
+local FILES = {
+    { path = "a.lua", viewed = true },
+    { path = "b.lua", viewed = true },
+    { path = "c.lua", viewed = false },
+    { path = "d.lua", viewed = false },
+}
+
+describe("review.start", function()
+    it("starts a fresh draft when the session has none", function()
+        local calls, restore = stub({})
+        local s = fake_session(nil, FILES)
+        review.start(s)
+        assert.are.same({ "start_review" }, calls)
+        assert.are.equal("fresh", s.review_id)
+        restore()
+    end)
+
+    it("reattaches instead of refusing when a draft is already in progress", function()
+        local calls, restore = stub({ review_id = "existing" })
+        local s = fake_session("existing", FILES)
+        review.start(s)
+        -- the point: no second start_review, and it doesn't dead-end on a notice
+        assert.are.same({ "get_pending_review" }, calls)
+        restore()
+    end)
+end)
+
+describe("review.reattach", function()
+    it("lands on the first file still unviewed", function()
+        local _, restore = stub({ review_id = "existing" })
+        local s = fake_session("existing", FILES)
+        review.reattach(s)
+        assert.are.same({ "c.lua" }, s.panel.landed)
+        restore()
+    end)
+
+    it("leaves the cursor alone when the caller already positioned", function()
+        local _, restore = stub({ review_id = "existing" })
+        local s = fake_session("existing", FILES)
+        review.reattach(s, { jump = false })
+        assert.are.same({}, s.panel.landed) -- the overview's thread anchor stands
+        restore()
+    end)
+
+    it("stays put when every file has been viewed", function()
+        local _, restore = stub({ review_id = "existing" })
+        local s = fake_session("existing", {
+            { path = "a.lua", viewed = true },
+            { path = "b.lua", viewed = true },
+        })
+        review.reattach(s)
+        assert.are.same({}, s.panel.landed)
+        restore()
+    end)
+
+    it("notifies and lands nowhere when the PR has no draft", function()
+        local _, restore = stub({ review_id = nil })
+        local s = fake_session(nil, FILES)
+        _G.notifs = {}
+        review.reattach(s)
+        assert.are.equal(
+            "differ: no pending review to resume on this PR",
+            _G.notifs[#_G.notifs].msg
+        )
+        assert.are.same({}, s.panel.landed)
+        restore()
+    end)
+end)

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -171,3 +171,40 @@ describe("pr session notifies", function()
         restore()
     end)
 end)
+
+describe("pr review lifecycle keymaps", function()
+    after_each(function()
+        if pr.current_session() then
+            pr.end_session()
+        end
+    end)
+
+    it("binds submit / discard / resume on both the diff and the panel", function()
+        local restore = stub_sidecar({
+            get_pr = { result = get_pr_result() },
+            get_file_versions = {
+                result = { base = { content = "a\n" }, head = { content = "b\n" } },
+            },
+            get_threads = { result = {} },
+        })
+
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            local s = pr.current_session()
+            return s and s.view and s.view:is_open() and s.panel
+        end))
+
+        local s = pr.current_session()
+        for _, buf in ipairs({ s.view.columns[1].bufnr, s.panel.bufnr }) do
+            local km = {}
+            for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+                km[m.lhs] = m.desc
+            end
+            assert.is_truthy(km["gS"]:find("submit the review", 1, true))
+            assert.is_truthy(km["gD"]:find("discard the review", 1, true))
+            assert.is_truthy(km["gR"]:find("resume the review", 1, true))
+        end
+
+        restore()
+    end)
+end)

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -179,7 +179,7 @@ describe("pr review lifecycle keymaps", function()
         end
     end)
 
-    it("binds submit / discard / resume on both the diff and the panel", function()
+    it("binds submit / discard on both the diff and the panel", function()
         local restore = stub_sidecar({
             get_pr = { result = get_pr_result() },
             get_file_versions = {
@@ -202,7 +202,7 @@ describe("pr review lifecycle keymaps", function()
             end
             assert.is_truthy(km["gS"]:find("submit the review", 1, true))
             assert.is_truthy(km["gD"]:find("discard the review", 1, true))
-            assert.is_truthy(km["gR"]:find("resume the review", 1, true))
+            assert.is_nil(km["gR"]) -- entering the review already adopts a pending draft
         end
 
         restore()

--- a/test/unit/help_spec.lua
+++ b/test/unit/help_spec.lua
@@ -1,0 +1,44 @@
+-- pure-lua: the help cheatsheet's row formatting. `show` needs nvim, but fmt/pair/
+-- lines don't, so the disabled-action handling is unit-testable
+local help = require("differ.ui.help")
+
+describe("help.fmt", function()
+    it("renders a single lhs and joins a multi-lhs list", function()
+        assert.are.equal("g?", help.fmt("g?"))
+        assert.are.equal("<CR> / o", help.fmt({ "<CR>", "o" }))
+    end)
+
+    it("returns nil for a disabled action", function()
+        assert.is_nil(help.fmt(false))
+        assert.is_nil(help.fmt(nil))
+    end)
+end)
+
+describe("help.pair", function()
+    it("joins both sides", function()
+        assert.are.equal("]c / [c", help.pair("]c", "[c"))
+    end)
+
+    it("keeps whichever side survives when the other is disabled", function()
+        assert.are.equal("]c", help.pair("]c", false))
+        assert.are.equal("[c", help.pair(false, "[c"))
+        assert.is_nil(help.pair(false, false))
+    end)
+end)
+
+describe("help.lines", function()
+    it("aligns descriptions to the widest lhs", function()
+        assert.are.same({
+            " g?      this help",
+            " ]c/[c   next hunk",
+        }, help.lines({ { "g?", "this help" }, { "]c/[c", "next hunk" } }))
+    end)
+
+    it("skips disabled rows and doesn't let them pad the column", function()
+        -- the dropped row's lhs is the longest, so a naive width pass would over-pad
+        assert.are.same(
+            { " g?   this help" },
+            help.lines({ { nil, "a very long disabled lhs" }, { "g?", "this help" } })
+        )
+    end)
+end)


### PR DESCRIPTION
## Summary
- `dc` / `dd` / `dl` end the session, toggle the file panel and flip the layout from inside it, so the things you do mid-session no longer need a global launcher. `dc` binds on the diff, panel and history and routes through the command layer, which already picks the live session (merge, pr or local); `dd` on the diff and panel; `dl` on the diff, the only surface owning a layout
- `gS` / `gD` submit and discard a pr review without leaving the files, through the existing `extra_keymaps` seam. capitalised to keep the lowercase g-family for thread and comment actions; each action already guards itself (verdict picker, discard confirm), so the key acts directly
- **breaking:** `choose_none` moves `dx` -> `<leader>cx`, so the whole conflict-choose family shares one prefix instead of four-of-five
- **breaking:** `q` no longer closes the merge tool. the result buffer is the real worktree file and stays editable, so `q` is left to native macro recording and `:Differ close` ends the session. `q` is now unbound on every surface but the pr overview, where it still drops back into the review
- `:Differ pr review` (and `r` on the overview) is start-or-resume rather than refusing when a draft exists, which is what `command.lua` already documented it as. it lands on the first file not yet marked viewed, since resuming asks what is left to review, and leaves the cursor alone when the caller already positioned it (the overview's thread rows), which start would otherwise clobber
- panel and history cheatsheets generate from the resolved keymaps instead of hardcoded strings, so `g?` reflects a `keymaps` override; `fmt`/`pair` move to `ui.help` beside a new `lines`, and a disabled action drops its row rather than rendering `false`
- the panel's `g?` lists its session maps (pr viewed nav, review verbs), which bind through the extras seam and were never shown
- the launcher spec in the readme drops to the entry points that cannot be buffer-local; `make vimdoc` also regenerates `doc/tags`, which lazy never generates for a `dir` checkout

## Test plan
- [x] `make check` (lua + go lint, lua_ls type-check, all suites)
- [x] lua unit 340/0, headless-nvim 328/0, go tests ok
- [x] new specs: `keymaps_spec` (binding matrix per surface, `false` override), `help_spec` (row formatting, disabled rows), `pr_review_spec` (start-or-resume, unviewed landing, jump suppression)
- [x] `make vimdoc` reproduces the committed `doc/differ.txt`
- [x] keymaps verified on real buffers headlessly, per surface