### PR TITLE
feat: revert hunks, and keep the session in step with git

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,11 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
     "runtime.version": "LuaJIT",
-    "workspace.library": [
-        "$VIMRUNTIME/lua",
-        "${3rd}/busted/library",
-        "${3rd}/luassert/library"
-    ],
     "workspace.ignoreDir": [".luacheckrc", ".tools"],
     "diagnostics.globals": ["vim"],
     "diagnostics.disable": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `X` reverts the hunk under the cursor in the diff, the hunk-level counterpart to the panel's file-level discard. It confirms first, since unlike `s`/`u` it destroys the change rather than moving it between the index and the worktree: an unstaged hunk is dropped from the worktree, a staged one from the index and worktree together. Where a file's whole content is one hunk the confirm names the consequence instead of counting hunks, so reverting a new file says it deletes it and reverting a deleted file says it restores it. The frozen diff is spliced in place rather than re-read, so the cursor stays where the hunk was; when a revert leaves the file with no changes at all the panel moves you to the next one. Deleted files revert without gaining hunk staging, so `s`/`u` still refuse there
+
+### Fixed
+
+- A file discarded from the panel no longer leaves its own buffer showing the discarded content. Nvim doesn't reload a buffer on a window switch, so the stale text sat there until something forced a check; differ now runs a `checktime` on the file it rewrote, which leaves a buffer with unsaved edits alone
+- The diff's `g?` lists the staging and revert keys per file rather than per session, so a file that can't stage by hunk no longer advertises `s`/`u`
+
+## [0.1.20] — 2026-08-05
+
+### Added
+
 - A vimdoc: `doc/differ.txt`, generated from the README, so `:help differ` works
 - In-buffer session keys, so the things you do inside a session no longer need a global launcher: `dc` ends it (routing to the merge, PR or local session), `dd` toggles the file panel, `dl` flips the layout. `dc` binds on the diff, panel and history; `dd` on the diff and panel; `dl` on the diff, the only surface that owns a layout
 - `gS` and `gD` submit and discard a PR review from the diff or panel, so a review can be finished without leaving the files. Capitalised to keep the lowercase `g` family for thread and comment actions; each action's own prompt (the verdict picker, the discard confirm) is the guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- A staging key pressed in the file panel no longer tears down an in-progress hunk review in the diff. `s`/`u`/`S`/`U`/`X` write the index like their diff-window counterparts, but didn't re-baseline the change signature that tells differ which git movements are its own, so the watcher read the write back as an outside change and re-sourced the frozen diff: the in-place staged marks were lost and the diff collapsed to whichever side survived. Every list reload now records that state, whatever drove it
+- The diff window no longer strands on a file that went clean outside differ while other changes remained. There was nothing to re-source it to, so it kept showing a diff of a file now identical to HEAD, and since it never moved on, no later refresh could recover it; it now hands over to the nearest surviving change, without stealing focus
+- `R` in the panel re-sources the diff as well as the file list, matching what the watcher does. It's the manual counterpart, pressed because something changed outside differ, so reloading only the list left the diff stale
 - A file discarded from the panel no longer leaves its own buffer showing the discarded content. Nvim doesn't reload a buffer on a window switch, so the stale text sat there until something forced a check; differ now runs a `checktime` on the file it rewrote, which leaves a buffer with unsaved edits alone
 - The diff's `g?` lists the staging and revert keys per file rather than per session, so a file that can't stage by hunk no longer advertises `s`/`u`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `context` defaults to the whole file rather than 10 lines, so a diff opens with no folds in it and reads as the file it came from. Folds were always created open, so nothing was ever hidden, but the fold markers still broke the file up on sight for no gain. The threshold is still there for anyone who wants it, through `context` in `setup()`, `:Differ context <n>`, or `d-`
+- `d-` narrows away from whole-file context instead of doing nothing. There is no finite threshold to decrement from `math.huge`, so the first step down seeds 10 and narrows a line at a time after that; `d=` at whole-file stays a no-op, since there is nothing wider to reach
 - An uncommitted session ends itself once its file list empties, rather than leaving an empty panel beside a diff of a file that is now clean. The change set can empty under you from either side: the last change reverted or discarded in differ, or a commit, checkout or stash from another pane. Either way the session closes and returns you to the tab you opened it from. Rev-pair sessions never reload their list, so they are untouched
 - A hidden file panel (`dd`) keeps refreshing with the worktree. It is still a live session driving a visible diff, so refreshes now track whether the session exists rather than whether the sidebar is shown; a revert with the sidebar hidden hands the diff on to the next file instead of stranding it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `X` reverts the hunk under the cursor in the diff, the hunk-level counterpart to the panel's file-level discard. It confirms first, since unlike `s`/`u` it destroys the change rather than moving it between the index and the worktree: an unstaged hunk is dropped from the worktree, a staged one from the index and worktree together. Where a file's whole content is one hunk the confirm names the consequence instead of counting hunks, so reverting a new file says it deletes it and reverting a deleted file says it restores it. The frozen diff is spliced in place rather than re-read, so the cursor stays where the hunk was; when a revert leaves the file with no changes at all the panel moves you to the next one. Deleted files revert without gaining hunk staging, so `s`/`u` still refuse there
 
+### Changed
+
+- An uncommitted session ends itself once its file list empties, rather than leaving an empty panel beside a diff of a file that is now clean. The change set can empty under you from either side: the last change reverted or discarded in differ, or a commit, checkout or stash from another pane. Either way the session closes and returns you to the tab you opened it from. Rev-pair sessions never reload their list, so they are untouched
+- A hidden file panel (`dd`) keeps refreshing with the worktree. It is still a live session driving a visible diff, so refreshes now track whether the session exists rather than whether the sidebar is shown; a revert with the sidebar hidden hands the diff on to the next file instead of stranding it
+
 ### Fixed
 
 - A file discarded from the panel no longer leaves its own buffer showing the discarded content. Nvim doesn't reload a buffer on a window switch, so the stale text sat there until something forced a check; differ now runs a `checktime` on the file it rewrote, which leaves a buffer with unsaved edits alone

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ differ's only install step is building the Go sidecar, so point your manager's b
 ```lua
 require("differ").setup({
   layout = "stacked",            -- "stacked" | "split", toggleable per-view
-  context = 10,                  -- context lines (math.huge = full file)
+  context = math.huge,           -- fold threshold; math.huge = whole file, no folds
   wrap = true,                   -- soft-wrap long lines in the diff view
   diff_counter = true,           -- "hunk K/N" counter in the diff window's winbar
   cursorline_tint = true,        -- tint the cursor line by add/remove so the change
@@ -223,11 +223,11 @@ These re-render the active view only. No refetch, no re-diff, and the state is l
 |---|---|
 | `:Differ layout [stacked\|split]` | Set layout; no argument flips it |
 | `:Differ context <n>` | Set the fold threshold around hunks |
-| `:Differ context full` | Show the whole file, no folds |
+| `:Differ context full` | Show the whole file, no folds (the default) |
 | `:Differ context +` / `-` | Widen / narrow the threshold by one |
 | `:Differ panel [left\|right\|top\|bottom]` | Reposition the live panel or history sidebar |
 
-Every line of the file is always in the buffer (search, yank, and motions all work); `context` only decides where a native fold forms once an unchanged run of lines exceeds it either side of a hunk. Folds are created open, not closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`). `context full` skips fold creation entirely.
+`context` defaults to the whole file, so no folds are created at all and a diff reads as the file it came from. Set it to a number to fold the long unchanged runs away instead: every line is in the buffer either way (search, yank, and motions all work), and `context` only decides where a native fold forms once an unchanged run exceeds it either side of a hunk. Folds are created open, not closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`). `d-` narrows out of whole-file the same way, landing on a threshold of 10 and stepping down a line at a time from there; `d=` has nothing wider to reach, so it does nothing.
 
 Set `command_alias` in `setup()` to register a shorter name for the same command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must start with an uppercase letter (enforced by vim, not by me). If you lazy-load on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see [troubleshooting](TROUBLESHOOTING.md#command_alias-and-lazy-loading) for why.
 
@@ -255,7 +255,8 @@ The stacked / split view.
 | `dc` | Close the session |
 | `go` | PR review only: back to the [PR overview](#pr-overview) |
 
-`X` throws a hunk away rather than moving it between the index and the worktree, so it confirms first. On an unstaged diff it drops the worktree change; on a staged one it clears the hunk from the index and the worktree together. Where a file's whole content is one hunk the confirm says what that means - reverting a new file deletes it, reverting a deleted one brings it back - and when a revert leaves nothing to show, the panel moves you on to the next change.
+
+`X` reverts the hunk entirely, so it confirms first. Reverting a new file deletes it, reverting a deleted one brings it back.
 
 An uncommitted session tracks the worktree, so its file list can empty while you work - the last change reverted, or a commit made in another pane. When it does there is nothing left to review, so the session ends on its own and drops you back in the tab you opened it from. Rev-pair sessions (`:Differ main...HEAD`) diff fixed revisions and never empty.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ require("differ").setup({
     more_context = "d=", less_context = "d-",  -- diff
     edit_file = "df",            -- diff: edit-in-review; pr diff: worktree split beside the pinned diff
     goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
-    discard = "X", refresh = "R",  -- panel
+    discard = "X",               -- diff (revert a hunk), panel (discard a file)
+    refresh = "R",               -- panel
     toggle_fold = "za",          -- history (range mode)
     close = "dc",                -- diff/panel/history: end the session
     toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
@@ -245,6 +246,7 @@ The stacked / split view.
 | `f` / `b` | Scroll a quarter page down / up |
 | `s` / `u` | Stage / unstage the hunk |
 | `S` / `U` | Stage / unstage all |
+| `X` | Revert the hunk under the cursor (confirms first) |
 | `d=` / `d-` | More / less context |
 | `df` | Edit-in-review (uncommitted diffs) |
 | `de` | Open the real file and end the session |
@@ -252,6 +254,8 @@ The stacked / split view.
 | `dl` | Toggle the layout (stacked / split) |
 | `dc` | Close the session |
 | `go` | PR review only: back to the [PR overview](#pr-overview) |
+
+`X` throws a hunk away rather than moving it between the index and the worktree, so it confirms first. On an unstaged diff it drops the worktree change; on a staged one it clears the hunk from the index and the worktree together. Where a file's whole content is one hunk the confirm says what that means - reverting a new file deletes it, reverting a deleted one brings it back - and when a revert leaves nothing to show, the panel moves you on to the next change.
 
 #### Panel
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The file list.
 | `c` / `C` / `O` | Collapse node / collapse all / expand all |
 | `s` / `u` / `S` / `U` | Stage / unstage file, or all |
 | `X` | Discard changes |
-| `R` | Refresh |
+| `R` | Refresh the list and the diff against git |
 | `dd` | Toggle the file panel |
 | `dc` | Close the session |
 | `g?` | Help |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ The stacked / split view.
 
 `X` throws a hunk away rather than moving it between the index and the worktree, so it confirms first. On an unstaged diff it drops the worktree change; on a staged one it clears the hunk from the index and the worktree together. Where a file's whole content is one hunk the confirm says what that means - reverting a new file deletes it, reverting a deleted one brings it back - and when a revert leaves nothing to show, the panel moves you on to the next change.
 
+An uncommitted session tracks the worktree, so its file list can empty while you work - the last change reverted, or a commit made in another pane. When it does there is nothing left to review, so the session ends on its own and drops you back in the tab you opened it from. Rev-pair sessions (`:Differ main...HEAD`) diff fixed revisions and never empty.
+
 #### Panel
 
 The file list.

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -222,6 +222,12 @@ means - reverting a new file deletes it, reverting a deleted one brings it back
 - and when a revert leaves nothing to show, the panel moves you on to the next
 change.
 
+An uncommitted session tracks the worktree, so its file list can empty while
+you work - the last change reverted, or a commit made in another pane. When it
+does there is nothing left to review, so the session ends on its own and drops
+you back in the tab you opened it from. Rev-pair sessions (`:Differ
+main...HEAD`) diff fixed revisions and never empty.
+
 
 PANEL ~
 

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -103,7 +103,8 @@ Table of Contents                                   *differ-table-of-contents*
         more_context = "d=", less_context = "d-",  -- diff
         edit_file = "df",            -- diff: edit-in-review; pr diff: worktree split beside the pinned diff
         goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
-        discard = "X", refresh = "R",  -- panel
+        discard = "X",               -- diff (revert a hunk), panel (discard a file)
+        refresh = "R",               -- panel
         toggle_fold = "za",          -- history (range mode)
         close = "dc",                -- diff/panel/history: end the session
         toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
@@ -199,12 +200,13 @@ DIFF ~
 The stacked / split view.
 
   Key       Action
-  --------- -----------------------------------------
+  --------- ---------------------------------------------------
   ]c / [c   Next / previous hunk
   ]f / [f   Next / previous file
   f / b     Scroll a quarter page down / up
   s / u     Stage / unstage the hunk
   S / U     Stage / unstage all
+  X         Revert the hunk under the cursor (confirms first)
   d= / d-   More / less context
   df        Edit-in-review (uncommitted diffs)
   de        Open the real file and end the session
@@ -212,6 +214,14 @@ The stacked / split view.
   dl        Toggle the layout (stacked / split)
   dc        Close the session
   go        PR review only: back to the PR overview
+`X` throws a hunk away rather than moving it between the index and the
+worktree, so it confirms first. On an unstaged diff it drops the worktree
+change; on a staged one it clears the hunk from the index and the worktree
+together. Where a file’s whole content is one hunk the confirm says what that
+means - reverting a new file deletes it, reverting a deleted one brings it back
+- and when a revert leaves nothing to show, the panel moves you on to the next
+change.
+
 
 PANEL ~
 

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -244,7 +244,7 @@ The file list.
   c / C / O       Collapse node / collapse all / expand all
   s / u / S / U   Stage / unstage file, or all
   X               Discard changes
-  R               Refresh
+  R               Refresh the list and the diff against git
   dd              Toggle the file panel
   dc              Close the session
   g?              Help

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -49,7 +49,7 @@ Table of Contents                                   *differ-table-of-contents*
 >lua
     require("differ").setup({
       layout = "stacked",            -- "stacked" | "split", toggleable per-view
-      context = 10,                  -- context lines (math.huge = full file)
+      context = math.huge,           -- fold threshold; math.huge = whole file, no folds
       wrap = true,                   -- soft-wrap long lines in the diff view
       diff_counter = true,           -- "hunk K/N" counter in the diff window's winbar
       cursorline_tint = true,        -- tint the cursor line by add/remove so the change
@@ -169,18 +169,23 @@ local to that view.
 
   :Differ context <n>                        Set the fold threshold around hunks
 
-  :Differ context full                       Show the whole file, no folds
+  :Differ context full                       Show the whole file, no folds (the
+                                             default)
 
   :Differ context + / -                      Widen / narrow the threshold by one
 
   :Differ panel [left\|right\|top\|bottom]   Reposition the live panel or
                                              history sidebar
   ------------------------------------------------------------------------------
-Every line of the file is always in the buffer (search, yank, and motions all
-work); `context` only decides where a native fold forms once an unchanged run
-of lines exceeds it either side of a hunk. Folds are created open, not closed,
-so nothing is hidden until you close one yourself (`zc`/`za`/`zM`). `context
-full` skips fold creation entirely.
+`context` defaults to the whole file, so no folds are created at all and a diff
+reads as the file it came from. Set it to a number to fold the long unchanged
+runs away instead: every line is in the buffer either way (search, yank, and
+motions all work), and `context` only decides where a native fold forms once an
+unchanged run exceeds it either side of a hunk. Folds are created open, not
+closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`).
+`d-` narrows out of whole-file the same way, landing on a threshold of 10 and
+stepping down a line at a time from there; `d=` has nothing wider to reach, so
+it does nothing.
 
 Set `command_alias` in `setup()` to register a shorter name for the same
 command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must
@@ -214,13 +219,8 @@ The stacked / split view.
   dl        Toggle the layout (stacked / split)
   dc        Close the session
   go        PR review only: back to the PR overview
-`X` throws a hunk away rather than moving it between the index and the
-worktree, so it confirms first. On an unstaged diff it drops the worktree
-change; on a staged one it clears the hunk from the index and the worktree
-together. Where a file’s whole content is one hunk the confirm says what that
-means - reverting a new file deletes it, reverting a deleted one brings it back
-- and when a revert leaves nothing to show, the panel moves you on to the next
-change.
+`X` reverts the hunk entirely, so it confirms first. Reverting a new file
+deletes it, reverting a deleted one brings it back.
 
 An uncommitted session tracks the worktree, so its file list can empty while
 you work - the last change reverted, or a commit made in another pane. When it

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -21,7 +21,7 @@
 
 ---@class differ.Config
 ---@field layout differ.Layout
----@field context integer
+---@field context number  -- math.huge = whole file, no folds
 ---@field wrap boolean
 ---@field diff_counter boolean
 ---@field cursorline_tint boolean
@@ -46,7 +46,7 @@ local SURFACE_SET = { diff = true, panel = true, history = true, merge = true }
 ---@type differ.Config
 M.defaults = {
     layout = "stacked",
-    context = 10, -- generous default; tight context makes diffs hard to read
+    context = math.huge, -- whole file, no folds
     wrap = true, -- soft-wrap long lines in the diff view
     diff_counter = true, -- "hunk K/N" counter in the diff window's winbar
     -- tint the diff cursor line by the line's change kind (a stronger add/delete

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -890,7 +890,6 @@ function M.panel(opts)
         return sig
     end
     local last_sig = git_signature()
-
     local function refresh_panel()
         if panel then
             panel:refresh()
@@ -899,9 +898,48 @@ function M.panel(opts)
         -- outside change and re-source over the in-place staged marks
         last_sig = git_signature()
     end
+    -- throw one hunk away rather than move it between index and worktree. an unstaged
+    -- hunk exists only in the worktree, so a single reverse apply is the whole job. a
+    -- staged one is in the index and, unless it was edited since, the worktree too, so
+    -- it takes both: index first, because a worktree copy that won't take the patch
+    -- then leaves the file merely unstaged (a state the panel already models) instead
+    -- of holding a change the index no longer has. returns whether the model's new
+    -- side moved, which is what tells the caller to re-source
+    ---@param model differ.DiffModel
+    ---@param hunk differ.Hunk
+    ---@param offset integer  -- index-side only; see differ.view.Staging
+    ---@return boolean
+    local function revert_hunk(model, hunk, offset)
+        ---@param off integer
+        local function reverse_patch(off)
+            return patch.hunk(model.path, hunk, model.old_text, model.new_text, off, true)
+        end
+        if model.new_rev ~= INDEX.label then
+            local ok, err = M.apply_patch(root, reverse_patch(0), true, "worktree")
+            if not ok then
+                notify(("hunk revert failed: %s"):format(err or ""), vim.log.levels.ERROR)
+            end
+            return ok
+        end
+        local ok, err = M.apply_patch(root, reverse_patch(offset), true, "index")
+        if not ok then
+            notify(("hunk revert failed: %s"):format(err or ""), vim.log.levels.ERROR)
+            return false
+        end
+        -- unstaging shifts the index but never the worktree, so the worktree's copy
+        -- still sits where the model says and this half needs no offset
+        if not M.apply_patch(root, reverse_patch(0), true, "worktree") then
+            local msg =
+                "%s: reverted from the index; the worktree copy changed since, so it stays unstaged"
+            notify(msg:format(model.path), vim.log.levels.WARN)
+        end
+        return true -- the index half landed either way
+    end
+
     ---@param entry differ.FileEntry
     ---@return differ.view.Staging|nil
     local function stage_for(entry)
+
         if not stageable then
             return nil
         end
@@ -924,6 +962,7 @@ function M.panel(opts)
                     end
                     return ok
                 end,
+                revert = revert_hunk,
                 refresh = refresh_panel,
             }
         end

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -907,13 +907,20 @@ function M.panel(opts)
         return sig
     end
     local last_sig = git_signature()
+    -- record the state the list now reflects, so the next external event doesn't read an
+    -- in-differ op as an outside change and re-source over the in-place staged marks.
+    -- wired as the panel's on_refresh, which is the one point every reload passes through:
+    -- the panel's own staging keys never come through refresh_panel, and used to leave the
+    -- signature stale enough that the watcher tore down an in-progress hunk review
+    local function record_state()
+        last_sig = git_signature()
+    end
     local function refresh_panel()
         if panel then
-            panel:refresh()
+            panel:refresh() -- fires on_refresh -> record_state
+        else
+            record_state()
         end
-        -- record state so the next external event doesn't read this in-differ op as an
-        -- outside change and re-source over the in-place staged marks
-        last_sig = git_signature()
     end
     -- throw one hunk away rather than move it between index and worktree. an unstaged
     -- hunk exists only in the worktree, so a single reverse apply is the whole job. a
@@ -1149,9 +1156,21 @@ function M.panel(opts)
             if pick and show_entry(pick, focus_line) then
                 return
             end
+            -- the shown file went clean while others survived (committed on its own,
+            -- checked out). there's nothing to re-source it to, so hand the window to
+            -- the nearest surviving change rather than strand it on a diff of a file
+            -- that now matches HEAD, which no later refresh would ever move off.
+            -- nothing here is user-driven, so focus goes back where it was
+            local focused = vim.api.nvim_get_current_win()
+            if panel:open_nearest(true) then
+                if vim.api.nvim_win_is_valid(focused) then
+                    vim.api.nvim_set_current_win(focused)
+                end
+                return
+            end
         end
-        -- no view, or the file went fully clean: leave the diff and just record state
-        last_sig = git_signature()
+        -- no view, and nothing to hand over to: just record the state
+        record_state()
     end
 
     -- watch the git dir and the shown file's dir so an external change (lazygit, an
@@ -1176,6 +1195,7 @@ function M.panel(opts)
         footer = footer_label(args, root),
         actions = actions,
         on_external_change = refresh_external,
+        on_refresh = record_state,
         keymaps = cfg.keymaps.panel --[[@as differ.KeymapSet]],
         listing = opts.listing or panel_cfg.listing,
         position = opts.position or panel_cfg.position,

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -603,16 +603,24 @@ function M.unstage_all(root)
     git({ "reset", "-q", "HEAD" }, root)
 end
 
--- apply a single-hunk patch to the index (hunk staging). `--unidiff-zero`
--- because the patch carries no context (built straight from the hunk model);
--- `--reverse` unstages. git apply is atomic, so a non-applying patch fails cleanly
--- with stderr rather than half-writing. returns ok + git's stderr on failure
+-- apply a single-hunk patch, atomically. `--unidiff-zero` because the patch carries
+-- no context (built straight from the hunk model); `--reverse` undoes rather than
+-- applies. `target` picks the side written: the index for hunk staging, the worktree
+-- for hunk revert. never `--index` (both at once), which checks the whole path is in
+-- sync and so refuses on any file that has changes on the other side, hunk-unrelated
+-- ones included; a revert that must reach both composes two calls instead. git apply
+-- is atomic, so a non-applying patch fails cleanly with stderr rather than
+-- half-writing. returns ok + git's stderr on failure
 ---@param root string
 ---@param text string  -- the unified diff to apply
 ---@param reverse boolean
+---@param target? "index"|"worktree"  -- default "index"
 ---@return boolean ok, string|nil err
-function M.apply_patch(root, text, reverse)
-    local cmd = { "git", "apply", "--cached", "--unidiff-zero", "--whitespace=nowarn" }
+function M.apply_patch(root, text, reverse, target)
+    local cmd = { "git", "apply", "--unidiff-zero", "--whitespace=nowarn" }
+    if (target or "index") == "index" then
+        cmd[#cmd + 1] = "--cached"
+    end
     if reverse then
         cmd[#cmd + 1] = "--reverse"
     end

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -632,6 +632,22 @@ function M.apply_patch(root, text, reverse, target)
     return true
 end
 
+-- an open buffer on a file differ just rewrote keeps showing the old content until
+-- something checks: a window switch doesn't, so a revert or discard would sit next to
+-- a stale window. checktime reloads it, and leaves a buffer with unsaved edits alone
+-- (nvim warns rather than clobbering), so this is safe to fire unconditionally
+---@param root string
+---@param relpath string
+local function reload_buffer(root, relpath)
+    local buf = vim.fn.bufnr(root .. "/" .. relpath)
+    if buf ~= -1 and vim.api.nvim_buf_is_loaded(buf) then
+        -- silent!: the file may be gone entirely (a discarded untracked file)
+        pcall(vim.api.nvim_buf_call, buf, function()
+            vim.cmd("silent! checktime")
+        end)
+    end
+end
+
 -- discard a file's changes: untracked or a staged-add drops the file (unstaging
 -- first if needed); anything tracked in HEAD reverts index + worktree to HEAD.
 -- destructive, so the panel confirms before calling this
@@ -647,6 +663,7 @@ function M.discard(root, entry)
     else
         git({ "checkout", "HEAD", "--", entry.path }, root) -- revert index + worktree
     end
+    reload_buffer(root, entry.path)
 end
 
 -- drop empty sections so the panel never shows a bare "Staged (0)" header; returns
@@ -919,6 +936,7 @@ function M.panel(opts)
             if not ok then
                 notify(("hunk revert failed: %s"):format(err or ""), vim.log.levels.ERROR)
             end
+            reload_buffer(root, model.path)
             return ok
         end
         local ok, err = M.apply_patch(root, reverse_patch(offset), true, "index")
@@ -933,13 +951,13 @@ function M.panel(opts)
                 "%s: reverted from the index; the worktree copy changed since, so it stays unstaged"
             notify(msg:format(model.path), vim.log.levels.WARN)
         end
+        reload_buffer(root, model.path)
         return true -- the index half landed either way
     end
 
     ---@param entry differ.FileEntry
     ---@return differ.view.Staging|nil
     local function stage_for(entry)
-
         if not stageable then
             return nil
         end
@@ -980,6 +998,13 @@ function M.panel(opts)
                     end
                     return true
                 end,
+                -- the file is the hunk, so reverting it is deleting it; `discard`
+                -- already knows to drop the staged add first
+                revert = function()
+                    M.discard(root, entry)
+                    return true
+                end,
+                revert_label = "deletes the file",
                 refresh = refresh_panel,
             }
         end

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -955,6 +955,25 @@ function M.panel(opts)
         return true -- the index half landed either way
     end
 
+    -- bring a deleted file back. which side it comes from is fixed by which diff is on
+    -- screen: a staged deletion is recorded in the index, so only HEAD still has the
+    -- content; an unstaged one is still in the index, and that's what its diff compares
+    -- against, so restoring from HEAD instead would silently drop edits staged before
+    -- the delete
+    ---@param entry differ.FileEntry
+    ---@return boolean
+    local function restore_deleted(entry)
+        local cmd = entry.staged and { "checkout", "HEAD", "--", entry.path }
+            or { "checkout", "--", entry.path }
+        local _, err = git(cmd, root)
+        if err then
+            notify(("restore failed: %s"):format(err), vim.log.levels.ERROR)
+            return false
+        end
+        reload_buffer(root, entry.path)
+        return true
+    end
+
     ---@param entry differ.FileEntry
     ---@return differ.view.Staging|nil
     local function stage_for(entry)
@@ -1005,6 +1024,19 @@ function M.panel(opts)
                     return true
                 end,
                 revert_label = "deletes the file",
+                refresh = refresh_panel,
+            }
+        end
+        -- a deleted file diffs its content against nothing, so there's no hunk to stage
+        -- (the panel stages the deletion wholesale) but there is one to undo: no
+        -- `apply`, so s/u keep refusing while X brings the file back
+        if entry.status == "D" then
+            return {
+                initial = entry.staged and "staged" or "unstaged",
+                revert = function()
+                    return restore_deleted(entry)
+                end,
+                revert_label = "restores the file",
                 refresh = refresh_panel,
             }
         end

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -1119,15 +1119,17 @@ function M.panel(opts)
     -- staying frozen. gated on the signature so unrelated terminal events are no-ops
     local function refresh_external()
         -- a debounced watcher fire (or a queued schedule) can land after the panel is
-        -- gone; bail before touching its deleted buffer
-        if not (panel and panel:is_open()) then
+        -- gone; bail before touching its deleted buffer. a hidden sidebar is still live
+        -- (and still driving a visible diff), so it refreshes like an open one
+        if not (panel and panel:is_alive()) then
             return
         end
         if git_signature() == last_sig then
             return
         end
-        if panel then
-            panel:refresh()
+        panel:refresh()
+        if not panel:is_alive() then
+            return -- the change set emptied and on_empty ended the session
         end
         if view and view:is_open() and active_entry then
             -- the content shifted underneath the user; hold the cursor near where it was
@@ -1185,9 +1187,26 @@ function M.panel(opts)
                 return
             end
             -- a stale entry (committed or changed outside differ) has an empty diff;
-            -- refresh the list rather than opening a blank view
+            -- refresh the list rather than opening a blank view. that refresh can end
+            -- the session (it was the last entry), which says so on its own
             refresh_panel()
-            notify(("no changes for %s"):format(entry.path))
+            if panel and panel:is_alive() then
+                notify(("no changes for %s"):format(entry.path))
+            end
+        end,
+        -- the change set emptied under the session (a commit, or the last change
+        -- reverted): there's nothing left to review, so end it rather than leave an
+        -- empty sidebar next to a diff of a file that's now clean. only the worktree
+        -- source can reach this; a rev-pair list never reloads
+        on_empty = function()
+            notify("no changes left")
+            local back = panel and panel.return_tab
+            if panel then
+                panel:close() -- cascades to the diff view + the session tab
+            end
+            if back and vim.api.nvim_tabpage_is_valid(back) then
+                vim.api.nvim_set_current_tabpage(back)
+            end
         end,
         on_close = function()
             if watcher then

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -52,14 +52,14 @@ end
 ---@field old_rev string|nil
 ---@field new_rev string|nil
 ---@field layout differ.Layout|nil
----@field context integer|nil
+---@field context number|nil
 
 -- open a View from an already-built DiffModel. the git frontend and panel use
 -- this; `opts` overrides the layout/context defaults and carries the hunk-staging
 -- capability for worktree-status panels
 ---@class differ.DiffModelOpts
 ---@field layout? differ.Layout
----@field context? integer
+---@field context? number
 ---@field staging? differ.view.Staging
 ---@field can_stage? boolean
 ---@field on_edit_unstage? fun(path: string)

--- a/lua/differ/model/diff.lua
+++ b/lua/differ/model/diff.lua
@@ -106,4 +106,58 @@ function M.build(opts)
     }
 end
 
+-- the new side's text with hunk `idx` undone: its old lines put back where its new
+-- lines sit. only the new side ever moves, in both diff directions (a revert rewrites
+-- the worktree on an index↔worktree diff, the index on a head↔index one), so there's
+-- one case here rather than two
+---@param model differ.DiffModel
+---@param h differ.Hunk
+---@return string
+local function reverted_text(model, h)
+    local lines = to_lines(model.new_text)
+    -- a zero-count hunk occupies nothing on the new side, and `new_start` names the
+    -- line it sits *after*, so the restored lines go in after it rather than over it
+    local at = h.new_count > 0 and h.new_start or h.new_start + 1
+    local out = {}
+    for i = 1, at - 1 do
+        out[#out + 1] = lines[i]
+    end
+    vim.list_extend(out, h.old_lines)
+    for i = at + h.new_count, #lines do
+        out[#out + 1] = lines[i]
+    end
+
+    -- whichever side supplies the result's last line supplies its terminator too:
+    -- a hunk reaching the end of the new side leaves no tail behind it, so the old
+    -- side's ending wins. getting this wrong would re-diff as a phantom eof hunk
+    local last = h.new_count > 0 and (h.new_start + h.new_count - 1) or h.new_start
+    local source = last == #lines and model.old_text or model.new_text
+    local text = table.concat(out, "\n")
+    if #out > 0 and source:sub(-1) == "\n" then
+        text = text .. "\n"
+    end
+    return text
+end
+
+-- a model with hunk `idx` reverted on the new side. rebuilt from the spliced text
+-- rather than patched in place, so the hunk list can never drift from the text it
+-- describes; callers hold the result as their new frozen model. the rebuild
+-- renumbers and re-derives boundaries, so surviving hunks keep their content but not
+-- their index, and callers holding per-hunk state must re-key it
+---@param model differ.DiffModel
+---@param idx integer
+---@return differ.DiffModel
+function M.revert_hunk(model, idx)
+    local h = assert(model.hunks[idx], "revert_hunk: no hunk at index " .. tostring(idx))
+    return M.build({
+        path = model.path,
+        old_rev = model.old_rev,
+        new_rev = model.new_rev,
+        old_text = model.old_text,
+        new_text = reverted_text(model, h),
+        head = model.head,
+        root = model.root,
+    })
+end
+
 return M

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -71,6 +71,7 @@ local STATUS_HL = {
 ---@field on_close fun()|nil
 ---@field on_external_change fun()|nil
 ---@field on_empty fun()|nil
+---@field on_refresh fun()|nil
 ---@field root string|nil
 ---@field footer string|nil
 ---@field actions differ.panel.Actions|nil
@@ -105,6 +106,10 @@ Panel.__index = Panel
 -- (the local frontend ends the session). only reachable with `actions`, so rev-pair and
 -- pr panels, whose lists never reload, never fire it
 ---@field on_empty? fun()
+-- fired after every list reload, whatever drove it. the local frontend re-baselines its
+-- change signature here, so the panel's own staging keys are recorded as differ's doing
+-- and the watcher doesn't read them back as an outside change
+---@field on_refresh? fun()
 ---@field root? string  -- repo/worktree path shown in the panel header
 ---@field footer? string -- rev spec shown under "Showing changes for:"
 ---@field actions? differ.panel.Actions -- file-level staging hooks (slice C)
@@ -149,6 +154,7 @@ function Panel.new(opts)
         on_close = opts.on_close,
         on_external_change = opts.on_external_change,
         on_empty = opts.on_empty,
+        on_refresh = opts.on_refresh,
         root = opts.root,
         footer = opts.footer,
         actions = opts.actions,
@@ -674,18 +680,36 @@ end
 -- re-read the model (after a stage op or on focus) and repaint, keeping the cursor
 -- line (clamped). no-op without staging actions (rev-pair panels aren't reloadable).
 -- gated on liveness, not visibility: a hidden sidebar is still a live session driving a
--- visible diff, so its model tracks git either way. a reload that empties the change set
--- hands over to `on_empty`, which may end the session, so nothing touches self after it
+-- visible diff, so its model tracks git either way. every reload reports itself through
+-- `on_refresh` (whatever drove it, including the panel's own staging keys), and one that
+-- empties the change set hands over to `on_empty`, which may end the session, so nothing
+-- touches self after it
 function Panel:refresh()
     if not self.actions or not self:is_alive() then
         return
     end
     local lnum = self:is_open() and vim.api.nvim_win_get_cursor(self.winid)[1] or 1
     self:set_sections(self.actions.reload())
+    if self.on_refresh then
+        self.on_refresh()
+    end
     if self.file_total == 0 and self.on_empty then
         return self.on_empty()
     end
     self:_restore_cursor(lnum)
+end
+
+-- the full "git may have moved outside differ" refresh: re-source the list *and* the
+-- diff the panel drives, falling back to the list alone for a session without the hook.
+-- what R and the external-change autocmds both want; refresh() is the list-only half,
+-- which on its own would re-baseline the session's change signature and so stop the
+-- watcher from ever catching the diff up
+function Panel:reload()
+    if self.on_external_change then
+        self.on_external_change()
+    else
+        self:refresh()
+    end
 end
 
 -- s/u/S/U: stage or unstage the cursor's target (a file, or every file under a
@@ -1228,7 +1252,7 @@ function Panel:_setup_window()
             self:discard()
         end, "discard file")
         map(km.refresh, function()
-            self:refresh()
+            self:reload()
         end, "refresh")
         map(km.edit_file, function()
             diff_file_verb(function()
@@ -1298,13 +1322,7 @@ function Panel:_watch_external_changes()
                 if not self:is_alive() then
                     return
                 end
-                -- on_external_change re-sources the diff too; refresh() is the list-only
-                -- fallback for a panel without the hook
-                if self.on_external_change then
-                    self.on_external_change()
-                else
-                    self:refresh()
-                end
+                self:reload()
             end)
         end,
     })

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -70,6 +70,7 @@ local STATUS_HL = {
 ---@field on_select fun(entry: differ.FileEntry)
 ---@field on_close fun()|nil
 ---@field on_external_change fun()|nil
+---@field on_empty fun()|nil
 ---@field root string|nil
 ---@field footer string|nil
 ---@field actions differ.panel.Actions|nil
@@ -100,6 +101,10 @@ Panel.__index = Panel
 ---@field on_select fun(entry: differ.FileEntry)
 ---@field on_close? fun()  -- runs on :close (e.g. tear down the driven view)
 ---@field on_external_change? fun() -- re-source list + diff after an outside git change
+-- fired when a refresh leaves the change set empty; the session decides what that means
+-- (the local frontend ends the session). only reachable with `actions`, so rev-pair and
+-- pr panels, whose lists never reload, never fire it
+---@field on_empty? fun()
 ---@field root? string  -- repo/worktree path shown in the panel header
 ---@field footer? string -- rev spec shown under "Showing changes for:"
 ---@field actions? differ.panel.Actions -- file-level staging hooks (slice C)
@@ -143,6 +148,7 @@ function Panel.new(opts)
         on_select = opts.on_select,
         on_close = opts.on_close,
         on_external_change = opts.on_external_change,
+        on_empty = opts.on_empty,
         root = opts.root,
         footer = opts.footer,
         actions = opts.actions,
@@ -666,13 +672,19 @@ function Panel:_op_targets()
 end
 
 -- re-read the model (after a stage op or on focus) and repaint, keeping the cursor
--- line (clamped). no-op without staging actions (rev-pair panels aren't reloadable)
+-- line (clamped). no-op without staging actions (rev-pair panels aren't reloadable).
+-- gated on liveness, not visibility: a hidden sidebar is still a live session driving a
+-- visible diff, so its model tracks git either way. a reload that empties the change set
+-- hands over to `on_empty`, which may end the session, so nothing touches self after it
 function Panel:refresh()
-    if not self.actions or not self:is_open() then
+    if not self.actions or not self:is_alive() then
         return
     end
-    local lnum = self.winid and vim.api.nvim_win_get_cursor(self.winid)[1] or 1
+    local lnum = self:is_open() and vim.api.nvim_win_get_cursor(self.winid)[1] or 1
     self:set_sections(self.actions.reload())
+    if self.file_total == 0 and self.on_empty then
+        return self.on_empty()
+    end
     self:_restore_cursor(lnum)
 end
 
@@ -755,14 +767,17 @@ end
 -- open the file row at or after the cursor, else the nearest one before it. for when a
 -- file leaves the list from under the cursor (a whole-file revert): the diff window
 -- would otherwise be left showing something that no longer exists. false when the list
--- holds no files at all, or the sidebar is hidden
+-- holds no files at all. steps from the live cursor when the sidebar is visible, else
+-- from the last opened row, like ]f/[f, so a hidden sidebar still hands the diff over
 ---@param keep_focus boolean|nil
 ---@return boolean opened
 function Panel:open_nearest(keep_focus)
-    if not self:is_open() then
+    if not self:is_alive() then
         return false
     end
-    local lnum = vim.api.nvim_win_get_cursor(self.winid)[1]
+    local lnum = self:is_open() and vim.api.nvim_win_get_cursor(self.winid)[1]
+        or self.selected_row
+        or self:_first_file_line()
     -- _file_row starts one past its argument, so step back one to include the cursor's
     -- own row: after a refresh that's the entry which slid up into the departed one
     local row = self:_file_row(lnum - 1, "next", false) or self:_file_row(lnum + 1, "prev", false)
@@ -770,7 +785,9 @@ function Panel:open_nearest(keep_focus)
         return false
     end
     self.selected_row = row
-    vim.api.nvim_win_set_cursor(self.winid, { row, 0 })
+    if self:is_open() then
+        vim.api.nvim_win_set_cursor(self.winid, { row, 0 })
+    end
     self:_open(self.meta[row].entry, keep_focus)
     return true
 end
@@ -1278,7 +1295,7 @@ function Panel:_watch_external_changes()
         desc = "differ: refresh the panel when git state changed externally",
         callback = function()
             vim.schedule(function()
-                if not self:is_open() then
+                if not self:is_alive() then
                     return
                 end
                 -- on_external_change re-sources the diff too; refresh() is the list-only
@@ -1296,6 +1313,14 @@ end
 ---@return boolean
 function Panel:is_open()
     return self.winid ~= nil and vim.api.nvim_win_is_valid(self.winid)
+end
+
+-- the session still exists, whether or not the sidebar is shown: :close wipes the
+-- buffer, hide() only drops the window. what refreshes gate on, so a queued one can't
+-- land on a closed panel while a hidden one still reloads
+---@return boolean
+function Panel:is_alive()
+    return vim.api.nvim_buf_is_valid(self.bufnr)
 end
 
 -- restore the cursor line after a re-render/reposition (clamped to the content)
@@ -1383,8 +1408,13 @@ function Panel:toggle()
 end
 
 -- close the panel window and wipe its buffer. `on_close` (if set) tears down the
--- diff view the panel drives, so closing the panel ends the whole differ session
+-- diff view the panel drives, so closing the panel ends the whole differ session.
+-- idempotent: a caller holding a reference to a session that ended itself (on_empty)
+-- must not re-run the teardown
 function Panel:close()
+    if not self:is_alive() then
+        return
+    end
     self:_close_window()
     if self.augroup then
         pcall(vim.api.nvim_del_augroup_by_id, self.augroup)

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -752,6 +752,29 @@ function Panel:_file_row(lnum, direction, wrap)
     return nil, false
 end
 
+-- open the file row at or after the cursor, else the nearest one before it. for when a
+-- file leaves the list from under the cursor (a whole-file revert): the diff window
+-- would otherwise be left showing something that no longer exists. false when the list
+-- holds no files at all, or the sidebar is hidden
+---@param keep_focus boolean|nil
+---@return boolean opened
+function Panel:open_nearest(keep_focus)
+    if not self:is_open() then
+        return false
+    end
+    local lnum = vim.api.nvim_win_get_cursor(self.winid)[1]
+    -- _file_row starts one past its argument, so step back one to include the cursor's
+    -- own row: after a refresh that's the entry which slid up into the departed one
+    local row = self:_file_row(lnum - 1, "next", false) or self:_file_row(lnum + 1, "prev", false)
+    if not row then
+        return false
+    end
+    self.selected_row = row
+    vim.api.nvim_win_set_cursor(self.winid, { row, 0 })
+    self:_open(self.meta[row].entry, keep_focus)
+    return true
+end
+
 -- ]f / [f: move to the next/prev file row and open it (lockstep file stepping).
 -- wraps at the ends by default (notifying, since it's otherwise not obvious you
 -- cycled back rather than simply moved); `wrap == false` (the staging review flow)

--- a/lua/differ/render/init.lua
+++ b/lua/differ/render/init.lua
@@ -40,7 +40,7 @@ local RENDERERS = {
 
 -- render a model under the given layout
 ---@param model differ.DiffModel
----@param opts { layout: differ.Layout, context: integer, deep_diff: table }
+---@param opts { layout: differ.Layout, context: number, deep_diff: table }
 ---@return differ.RenderResult
 function M.render(model, opts)
     local mod = RENDERERS[opts.layout]

--- a/lua/differ/render/split.lua
+++ b/lua/differ/render/split.lua
@@ -21,7 +21,7 @@ local BINARY_NOTICE = "Binary file not shown"
 -- render a model into two index-aligned columns ("old" left, "new" right). both
 -- columns share the same fold ranges since their rows are aligned
 ---@param model differ.DiffModel
----@param opts { context: integer, deep_diff?: table }
+---@param opts { context: number, deep_diff?: table }
 ---@return differ.RenderResult
 function M.render(model, opts)
     local old_map, new_map = LineMap.new(), LineMap.new()

--- a/lua/differ/render/stacked.lua
+++ b/lua/differ/render/stacked.lua
@@ -15,7 +15,7 @@ local BINARY_NOTICE = "Binary file not shown"
 -- render a model into a single "unified" column: interleaved buffer lines plus
 -- a populated line map and the fold ranges (buffer coords) the view collapses
 ---@param model differ.DiffModel
----@param opts { context: integer, deep_diff?: table }
+---@param opts { context: number, deep_diff?: table }
 ---@return differ.RenderResult
 function M.render(model, opts)
     local map = LineMap.new()

--- a/lua/differ/render/walk.lua
+++ b/lua/differ/render/walk.lua
@@ -17,7 +17,7 @@ local M = {}
 -- a gap that exceeds `context` lead/tail is flagged `foldable` so the renderer can
 -- mark it for a native fold rather than dropping it
 ---@param model differ.DiffModel
----@param context integer
+---@param context number
 ---@param old_line_count integer
 ---@param cb differ.WalkCallbacks
 function M.walk(model, context, old_line_count, cb)

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -21,6 +21,9 @@ local STATUSCOLUMN_EXPR = '%!v:lua.require("differ.ui.statuscolumn").render()'
 local FOLDTEXT_EXPR = 'v:lua.require("differ.ui.foldtext").render()'
 local CTRL_D = vim.api.nvim_replace_termcodes("<C-d>", true, false, true)
 local CTRL_U = vim.api.nvim_replace_termcodes("<C-u>", true, false, true)
+-- where the first narrow step lands when coming down from whole-file, which has no
+-- finite neighbour to decrement
+local FULL_STEP_DOWN = 10
 
 local set_wo = require("differ.util.win").set_local
 
@@ -548,11 +551,15 @@ function View:set_context(n)
     self:_apply_folds(closed) -- ranges shifted with the context; windows unchanged
 end
 
--- widen/narrow context by `delta`. no-op while whole-file (can't decrement ∞)
+-- widen/narrow context by `delta`. narrowing from whole-file seeds FULL_STEP_DOWN
+-- (∞ has nothing to decrement); widening there is already a no-op
 ---@param delta integer
 function View:adjust_context(delta)
     if self.context == math.huge then
-        return
+        if delta >= 0 then
+            return
+        end
+        return self:set_context(FULL_STEP_DOWN)
     end
     self:set_context(math.max(0, self.context + delta))
 end
@@ -1668,7 +1675,7 @@ function View:_relayout()
         vim.api.nvim_set_current_win(self.columns[1].winid)
         vim.cmd("syncbind")
     end
-    self:_apply_folds() -- windows now exist; collapse the unchanged regions
+    self:_apply_folds() -- windows now exist; build the folds over unchanged regions
     self:_paint_cursorline() -- windows now exist; show the cursor line over the bg
     self:_arm_close_guard() -- re-arm now the winids are current
 end

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -64,6 +64,9 @@ local armed_view = nil
 -- `initial` is every hunk's opening state (an unstaged diff opens unstaged, a staged
 -- one opens staged). `apply` patches one hunk and returns ok; `refresh` repaints the
 -- panel counts and is called once after a single toggle or a whole S/U batch
+-- `apply` and `revert` are independently optional, and each one's absence gates its own
+-- keys: a deleted file can be restored (`revert`) but has nothing to stage by hunk, so
+-- it offers no `apply` and s/u keep refusing on it.
 -- `revert` throws a hunk away instead of moving it between index and worktree, and its
 -- absence is what gates the key off a source that can't do it. `offset` shifts its
 -- index-side apply past hunks unstaged before it; its worktree apply needs none, since
@@ -72,7 +75,7 @@ local armed_view = nil
 -- what it will do to the file, the view words the question
 ---@class differ.view.Staging
 ---@field initial "staged"|"unstaged"
----@field apply fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer, reverse: boolean): boolean
+---@field apply? fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer, reverse: boolean): boolean
 ---@field revert? fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer): boolean
 ---@field revert_label? string  -- e.g. "deletes the file"
 ---@field refresh fun()
@@ -754,9 +757,13 @@ function View:show_help()
     if self:_editable_source() then
         rows[#rows + 1] = { fmt(km.edit_file), "edit the real file (in review)" }
     end
-    if self.can_stage then
+    -- per-file, not session-wide: a deleted file reverts but doesn't stage by hunk, so
+    -- listing s/u there would advertise keys that refuse
+    if self:_can_stage_hunk() then
         rows[#rows + 1] = { pair(km.stage, km.unstage), "stage / unstage hunk" }
         rows[#rows + 1] = { pair(km.stage_all, km.unstage_all), "stage / unstage all" }
+    end
+    if self.staging and self.staging.revert then
         rows[#rows + 1] = { fmt(km.discard), "revert hunk (confirm)" }
     end
     for _, m in ipairs(self.extra_keymaps or {}) do
@@ -973,6 +980,14 @@ function View:_hunk_index_under_cursor()
     return line and line.hunk or nil
 end
 
+-- whether the hunk-staging keys act here: the session allows staging and this file's
+-- capability implements it. a deleted file supplies only `revert`, so s/u refuse on it
+-- while X still works
+---@return boolean
+function View:_can_stage_hunk()
+    return self.can_stage and self.staging ~= nil and self.staging.apply ~= nil
+end
+
 -- patch hunk `idx` to `want_staged` in the index from the frozen hunk model (never
 -- buffer text), shifted past the hunks staged before it, and mark it. no panel
 -- refresh / repaint, so callers can batch. returns whether it changed
@@ -980,12 +995,13 @@ end
 ---@param want_staged boolean
 ---@return boolean
 function View:_apply_hunk(idx, want_staged)
-    if (self.staged_hunks[idx] or false) == want_staged then
+    local apply = self.staging and self.staging.apply
+    if not apply or (self.staged_hunks[idx] or false) == want_staged then
         return false
     end
     local offset = self:_stage_offset(idx)
     -- reverse unstages: we patch away a change currently in the index
-    if self.staging.apply(self.model, self.model.hunks[idx], offset, not want_staged) then
+    if apply(self.model, self.model.hunks[idx], offset, not want_staged) then
         self.staged_hunks[idx] = want_staged
         return true
     end
@@ -998,7 +1014,7 @@ end
 -- it steps to the next file, which opens on its first unstaged hunk. so repeated s
 -- walks the whole change set, accepting hunk by hunk
 function View:stage_hunk()
-    if not (self.can_stage and self.staging) then
+    if not self:_can_stage_hunk() then
         return vim.notify("differ: hunk staging isn't available here", vim.log.levels.WARN)
     end
     local idx = self:_hunk_index_under_cursor()
@@ -1027,7 +1043,7 @@ end
 -- previous file landing on its last hunk, so repeated u walks the change set
 -- backward, undoing hunk by hunk
 function View:unstage_hunk()
-    if not (self.can_stage and self.staging) then
+    if not self:_can_stage_hunk() then
         return vim.notify("differ: hunk staging isn't available here", vim.log.levels.WARN)
     end
     local idx = self:_hunk_index_under_cursor()
@@ -1058,7 +1074,7 @@ end
 -- working on it
 ---@param want_staged boolean
 function View:_toggle_hunk(want_staged)
-    if not (self.can_stage and self.staging) then
+    if not self:_can_stage_hunk() then
         return vim.notify("differ: hunk staging isn't available here", vim.log.levels.WARN)
     end
     local idx = self:_hunk_index_under_cursor()
@@ -1081,7 +1097,7 @@ end
 -- S: stage every hunk in the file, or, when they're all staged already (nothing left
 -- to do), step to the next file, the file-level echo of s advancing past the last hunk
 function View:stage_all()
-    if not self:_toggle_all(true) and self.can_stage and self.staging then
+    if not self:_toggle_all(true) and self:_can_stage_hunk() then
         if not self:step_file("next", false) then -- stop at the last file, don't wrap
             vim.notify("differ: no more files to stage", vim.log.levels.INFO)
         end
@@ -1091,7 +1107,7 @@ end
 -- U: unstage every hunk, or, when none are staged (nothing to do), step back a file
 -- landing on its last hunk, the file-level echo of u retreating past the first hunk
 function View:unstage_all()
-    if not self:_toggle_all(false) and self.can_stage and self.staging then
+    if not self:_toggle_all(false) and self:_can_stage_hunk() then
         if self:step_file("prev", false) then -- stop at the first file, don't wrap
             self:_focus_last_hunk() -- only when a previous file actually opened
         else
@@ -1107,7 +1123,7 @@ end
 ---@param want_staged boolean
 ---@return boolean changed
 function View:_toggle_all(want_staged)
-    if not (self.can_stage and self.staging) then
+    if not self:_can_stage_hunk() then
         vim.notify("differ: hunk staging isn't available here", vim.log.levels.WARN)
         return false
     end
@@ -1379,7 +1395,7 @@ function View:edit_file()
     if self.model.new_rev == "INDEX" then
         if self.on_edit_unstage then
             self.on_edit_unstage(self.model.path)
-        elseif self.can_stage and self.staging then
+        elseif self:_can_stage_hunk() then
             self:_toggle_all(false)
         end
     end

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -64,9 +64,14 @@ local armed_view = nil
 -- `initial` is every hunk's opening state (an unstaged diff opens unstaged, a staged
 -- one opens staged). `apply` patches one hunk and returns ok; `refresh` repaints the
 -- panel counts and is called once after a single toggle or a whole S/U batch
+-- `revert` throws a hunk away instead of moving it between index and worktree, and is
+-- absent where that isn't meaningful (a new file's single whole-file hunk), which is
+-- what gates the key. `offset` shifts its index-side apply past hunks unstaged before
+-- it; its worktree apply needs none, since a revert re-sources the model
 ---@class differ.view.Staging
 ---@field initial "staged"|"unstaged"
 ---@field apply fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer, reverse: boolean): boolean
+---@field revert? fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer): boolean
 ---@field refresh fun()
 
 ---@class differ.View
@@ -669,6 +674,11 @@ function View:_setup_window(winid, bufnr)
         bind(bufnr, km.unstage_all, function()
             self:unstage_all()
         end, "differ: unstage all hunks")
+        -- hunk-level here vs the panel's file-level discard, and destructive either
+        -- way, so it confirms rather than acting straight off the key
+        bind(bufnr, km.discard, function()
+            self:revert_hunk()
+        end, "differ: revert hunk")
     end
     for _, m in ipairs(self.extra_keymaps or {}) do
         bind(bufnr, m.spec, m.fn, m.desc, m.mode)
@@ -744,6 +754,7 @@ function View:show_help()
     if self.can_stage then
         rows[#rows + 1] = { pair(km.stage, km.unstage), "stage / unstage hunk" }
         rows[#rows + 1] = { pair(km.stage_all, km.unstage_all), "stage / unstage all" }
+        rows[#rows + 1] = { fmt(km.discard), "revert hunk (confirm)" }
     end
     for _, m in ipairs(self.extra_keymaps or {}) do
         rows[#rows + 1] = { fmt(m.spec), m.desc }
@@ -1109,6 +1120,100 @@ function View:_toggle_all(want_staged)
         self:_paint_cursorline() -- re-lift the cursor tint above the fresh staged fill
     end
     return changed
+end
+
+-- the index-side shift for a revert on a staged diff: unstaging a hunk swaps its new
+-- lines back for its old ones, so every hunk after it sits that many lines off the
+-- frozen model. only the index moves under an unstage, so this never applies to the
+-- worktree half of a revert
+---@param idx integer
+---@return integer
+function View:_unstage_offset(idx)
+    local off = 0
+    for j = 1, idx - 1 do
+        if not self.staged_hunks[j] then
+            local h = self.model.hunks[j]
+            off = off + (h.old_count - h.new_count)
+        end
+    end
+    return off
+end
+
+-- shift per-hunk staged marks down past a hunk that has just left the model. the
+-- rebuilt list normally loses exactly the reverted hunk and keeps the rest in order;
+-- if it didn't, the marks can't be mapped, so reseed them from the source instead of
+-- carrying wrong ones
+---@param removed integer
+---@param before integer  -- hunk count before the revert
+function View:_rekey_staged(removed, before)
+    if #self.model.hunks ~= before - 1 then
+        return self:_init_staged()
+    end
+    local out = {}
+    for i, staged in pairs(self.staged_hunks) do
+        if i < removed then
+            out[i] = staged
+        elseif i > removed then
+            out[i - 1] = staged
+        end
+    end
+    self.staged_hunks = out
+end
+
+-- X: throw the hunk under the cursor away, after a confirm. unlike s/u this doesn't
+-- move a change between index and worktree, it destroys it, so the frozen model can't
+-- just be marked: the hunk is spliced out and the diff re-renders around it. bound for
+-- the whole worktree-status session; what's actually revertable is checked here
+function View:revert_hunk()
+    if not (self.can_stage and self.staging) then
+        return vim.notify("differ: hunk revert isn't available here", vim.log.levels.WARN)
+    end
+    local revert = self.staging.revert
+    if not revert then
+        -- a new file diffs as one whole-file hunk, so reverting it means deleting the
+        -- file: a file-level act, and the panel already owns it
+        return vim.notify(
+            "differ: reverting a new file means deleting it; use the file panel",
+            vim.log.levels.WARN
+        )
+    end
+    local idx = self:_hunk_index_under_cursor()
+    if not idx then
+        return vim.notify("differ: no hunk under the cursor", vim.log.levels.WARN)
+    end
+    -- on an unstaged diff a marked hunk is already in the index, so reverting only the
+    -- worktree copy would leave the two differing the opposite way round
+    if self.model.new_rev == "WORKTREE" and self.staged_hunks[idx] then
+        return vim.notify(
+            "differ: hunk is staged; unstage it (u) before reverting",
+            vim.log.levels.WARN
+        )
+    end
+
+    local prompt = ("Revert hunk %d/%d in %s?"):format(idx, #self.model.hunks, self.model.path)
+    if vim.fn.confirm(prompt, "&Yes\n&No", 2) ~= 1 then
+        return
+    end
+
+    local offset = self.model.new_rev == "INDEX" and self:_unstage_offset(idx) or 0
+    if not revert(self.model, self.model.hunks[idx], offset) then
+        return
+    end
+
+    -- hold the reading position across the re-render: the hunk is gone, but the file
+    -- around it hasn't moved for the user
+    local focus = self:cursor_new_line()
+    local before = #self.model.hunks
+    self.model = require("differ.model.diff").revert_hunk(self.model, idx)
+    self:_rekey_staged(idx, before)
+    self:rerender({ layout = self.layout, context = self.context, deep_diff = self.deep_diff })
+    self:_apply_folds()
+    if focus then
+        self:focus_new_line(focus, true)
+    end
+    self.staging.refresh()
+    self:_paint_staged()
+    self:_paint_cursorline()
 end
 
 -- jump-to-file (the `de` verb): leave the diff and open the real file on disk

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -1163,6 +1163,46 @@ function View:_rekey_staged(removed, before)
     self.staged_hunks = out
 end
 
+-- the new-side line to land on once `h` is reverted: the cursor's own line, shifted by
+-- whatever the revert added or removed above it. a cursor inside the reverted region
+-- has no line of its own to return to, so it lands at the region's start
+---@param h differ.Hunk
+---@param lnum integer  -- the new-side line the cursor was on
+---@return integer
+local function reverted_focus(h, lnum)
+    -- a zero-count hunk sits *after* new_start rather than covering it, which makes the
+    -- region empty and every line either side of it fall through to the shift
+    local first = h.new_count > 0 and h.new_start or h.new_start + 1
+    local last = first + h.new_count - 1
+    if lnum < first then
+        return lnum
+    end
+    if lnum > last then
+        return lnum + (h.old_count - h.new_count)
+    end
+    return first
+end
+
+-- put the new side's cursor on the buffer line rendering `new_lnum`, else the nearest
+-- rendered line either side. unlike focus_new_line this never snaps to a hunk: the
+-- line a revert leaves you on is unchanged context by definition, and staying on it is
+-- the whole point
+---@param new_lnum integer
+function View:_hold_new_line(new_lnum)
+    local col = self.columns[#self.columns]
+    if not (col and col.winid and vim.api.nvim_win_is_valid(col.winid)) then
+        return
+    end
+    local at, d = col.map.from_new[new_lnum], 1
+    while not at and d <= #col.map.lines do
+        at = col.map.from_new[new_lnum - d] or col.map.from_new[new_lnum + d]
+        d = d + 1
+    end
+    if at then
+        pcall(vim.api.nvim_win_set_cursor, col.winid, { at, 0 })
+    end
+end
+
 -- X: throw the hunk under the cursor away, after a confirm. unlike s/u this doesn't
 -- move a change between index and worktree, it destroys it, so the frozen model can't
 -- just be marked: the hunk is spliced out and the diff re-renders around it. bound for
@@ -1197,14 +1237,20 @@ function View:revert_hunk()
     end
 
     local offset = self.model.new_rev == "INDEX" and self:_unstage_offset(idx) or 0
-    if not revert(self.model, self.model.hunks[idx], offset) then
+    -- a whole-file revert, or one taking the file's last hunk, leaves no diff at all
+    local emptied = label ~= nil or #self.model.hunks == 1
+    local hunk = self.model.hunks[idx] -- captured before the model is replaced
+    local before = #self.model.hunks
+    local focus = self:cursor_new_line()
+
+    if not revert(self.model, hunk, offset) then
         return
     end
 
-    -- a whole-file revert leaves nothing to show, and the refresh has just dropped the
-    -- entry from the panel, so hand over to whatever took its place rather than
-    -- splicing down to an empty diff and stranding the window on it
-    if label then
+    -- nothing left to show here, and the refresh has just dropped the entry from the
+    -- panel: hand over to whatever took its place rather than stranding the window on
+    -- an empty diff
+    if emptied then
         self.staging.refresh()
         local panel = require("differ.panel").current()
         if not (panel and panel:open_nearest(true)) then
@@ -1213,16 +1259,13 @@ function View:revert_hunk()
         return
     end
 
-    -- hold the reading position across the re-render: the hunk is gone, but the file
-    -- around it hasn't moved for the user
-    local focus = self:cursor_new_line()
-    local before = #self.model.hunks
     self.model = require("differ.model.diff").revert_hunk(self.model, idx)
     self:_rekey_staged(idx, before)
     self:rerender({ layout = self.layout, context = self.context, deep_diff = self.deep_diff })
     self:_apply_folds()
+    -- stay where the reverted hunk was rather than being pulled to the next one
     if focus then
-        self:focus_new_line(focus, true)
+        self:_hold_new_line(reverted_focus(hunk, focus))
     end
     self.staging.refresh()
     self:_paint_staged()

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -84,7 +84,7 @@ local armed_view = nil
 ---@field columns differ.ViewColumn[]
 ---@field model differ.DiffModel
 ---@field layout differ.Layout
----@field context integer
+---@field context number
 ---@field wrap boolean  -- soft-wrap long lines in the diff windows
 ---@field counter boolean  -- hunk-counter winbar on the diff windows
 ---@field cursorline_tint boolean  -- tint the cursor line by add/delete kind
@@ -108,7 +108,7 @@ View.__index = View
 
 ---@class differ.view.Opts
 ---@field layout differ.Layout
----@field context integer
+---@field context number
 ---@field wrap? boolean
 ---@field counter? boolean
 ---@field cursorline_tint? boolean
@@ -268,7 +268,7 @@ end
 -- re-render the active model and atomically replace each column's content, map,
 -- gutter rail, and highlight layer. window layout is unchanged; if a re-render
 -- changes the column count (a layout toggle), call :open() to relayout
----@param opts { layout: differ.Layout, context: integer, deep_diff: table }
+---@param opts { layout: differ.Layout, context: number, deep_diff: table }
 function View:rerender(opts)
     self.layout = opts.layout
     self.context = opts.context
@@ -523,7 +523,7 @@ end
 
 -- set the per-view context line count (math.huge = whole file). same column
 -- count, so no relayout, content/map/gutter/highlights refresh in place
----@param n integer
+---@param n number
 function View:set_context(n)
     -- snapshot which folds are closed before rerender replaces col.folds with the
     -- ranges at the new context, so a manually-closed fold (zc/zm) survives the

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -64,14 +64,17 @@ local armed_view = nil
 -- `initial` is every hunk's opening state (an unstaged diff opens unstaged, a staged
 -- one opens staged). `apply` patches one hunk and returns ok; `refresh` repaints the
 -- panel counts and is called once after a single toggle or a whole S/U batch
--- `revert` throws a hunk away instead of moving it between index and worktree, and is
--- absent where that isn't meaningful (a new file's single whole-file hunk), which is
--- what gates the key. `offset` shifts its index-side apply past hunks unstaged before
--- it; its worktree apply needs none, since a revert re-sources the model
+-- `revert` throws a hunk away instead of moving it between index and worktree, and its
+-- absence is what gates the key off a source that can't do it. `offset` shifts its
+-- index-side apply past hunks unstaged before it; its worktree apply needs none, since
+-- a revert re-sources the model. `revert_label` names the consequence for a file whose
+-- whole content is one hunk, where reverting isn't a partial act: the frontend knows
+-- what it will do to the file, the view words the question
 ---@class differ.view.Staging
 ---@field initial "staged"|"unstaged"
 ---@field apply fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer, reverse: boolean): boolean
 ---@field revert? fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer): boolean
+---@field revert_label? string  -- e.g. "deletes the file"
 ---@field refresh fun()
 
 ---@class differ.View
@@ -1170,12 +1173,7 @@ function View:revert_hunk()
     end
     local revert = self.staging.revert
     if not revert then
-        -- a new file diffs as one whole-file hunk, so reverting it means deleting the
-        -- file: a file-level act, and the panel already owns it
-        return vim.notify(
-            "differ: reverting a new file means deleting it; use the file panel",
-            vim.log.levels.WARN
-        )
+        return vim.notify("differ: this hunk can't be reverted", vim.log.levels.WARN)
     end
     local idx = self:_hunk_index_under_cursor()
     if not idx then
@@ -1190,13 +1188,28 @@ function View:revert_hunk()
         )
     end
 
-    local prompt = ("Revert hunk %d/%d in %s?"):format(idx, #self.model.hunks, self.model.path)
+    -- a whole-file revert isn't partial, so it says so rather than counting hunks
+    local label = self.staging.revert_label
+    local prompt = label and ("Revert all of %s? This %s."):format(self.model.path, label)
+        or ("Revert hunk %d/%d in %s?"):format(idx, #self.model.hunks, self.model.path)
     if vim.fn.confirm(prompt, "&Yes\n&No", 2) ~= 1 then
         return
     end
 
     local offset = self.model.new_rev == "INDEX" and self:_unstage_offset(idx) or 0
     if not revert(self.model, self.model.hunks[idx], offset) then
+        return
+    end
+
+    -- a whole-file revert leaves nothing to show, and the refresh has just dropped the
+    -- entry from the panel, so hand over to whatever took its place rather than
+    -- splicing down to an empty diff and stranding the window on it
+    if label then
+        self.staging.refresh()
+        local panel = require("differ.panel").current()
+        if not (panel and panel:open_nearest(true)) then
+            vim.notify("differ: no changes left to show", vim.log.levels.INFO)
+        end
         return
     end
 

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -552,7 +552,6 @@ function View:set_context(n)
 end
 
 -- widen/narrow context by `delta`. narrowing from whole-file seeds FULL_STEP_DOWN
--- (∞ has nothing to decrement); widening there is already a no-op
 ---@param delta integer
 function View:adjust_context(delta)
     if self.context == math.huge then

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -1275,8 +1275,10 @@ function View:revert_hunk()
     -- an empty diff
     if emptied then
         self.staging.refresh()
+        -- that refresh ends the session when this was the change set's last change, and
+        -- reports it; only speak up when the panel is still there but has nowhere to go
         local panel = require("differ.panel").current()
-        if not (panel and panel:open_nearest(true)) then
+        if panel and not panel:open_nearest(true) then
             vim.notify("differ: no changes left to show", vim.log.levels.INFO)
         end
         return

--- a/test/nvim/diff_spec.lua
+++ b/test/nvim/diff_spec.lua
@@ -52,3 +52,113 @@ describe("model.diff.build", function()
         assert.are.equal(0, #m.hunks)
     end)
 end)
+
+describe("model.diff.revert_hunk", function()
+    ---@param old string
+    ---@param new string
+    ---@return differ.DiffModel
+    local function model(old, new)
+        return diff.build({
+            path = "x.lua",
+            old_rev = "INDEX",
+            new_rev = "WORKTREE",
+            old_text = old,
+            new_text = new,
+        })
+    end
+
+    it("restores the old side exactly when the only hunk goes", function()
+        local m = model("a\nb\nc\n", "a\nB\nc\n")
+        assert.are.equal(1, #m.hunks)
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("a\nb\nc\n", r.new_text)
+        assert.are.equal(0, #r.hunks)
+        assert.are.equal(m.old_text, r.old_text) -- the old side never moves
+    end)
+
+    it("leaves the untouched hunk in place", function()
+        local m = model("a\nb\nc\nd\ne\n", "a\nB\nc\nD\ne\n")
+        assert.are.equal(2, #m.hunks)
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("a\nb\nc\nD\ne\n", r.new_text)
+        assert.are.equal(1, #r.hunks)
+        assert.are.same({ "d" }, r.hunks[1].old_lines)
+        assert.are.same({ "D" }, r.hunks[1].new_lines)
+    end)
+
+    it("drops the added lines of a pure insertion", function()
+        local m = model("a\nc\n", "a\nb1\nb2\nc\n")
+        assert.are.equal(0, m.hunks[1].old_count)
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("a\nc\n", r.new_text)
+        assert.are.equal(0, #r.hunks)
+    end)
+
+    -- a deletion holds no lines on the new side, so `new_start` names the line it
+    -- follows rather than one it covers; restoring has to insert after, not over
+    it("puts back the removed lines of a pure deletion", function()
+        local m = model("a\nb\nc\n", "a\nc\n")
+        assert.are.equal(0, m.hunks[1].new_count)
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("a\nb\nc\n", r.new_text)
+        assert.are.equal(0, #r.hunks)
+    end)
+
+    it("puts back lines deleted from the very top of the file", function()
+        local m = model("a\nb\nc\n", "b\nc\n")
+        assert.are.equal(0, m.hunks[1].new_start) -- follows the line before the first
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("a\nb\nc\n", r.new_text)
+        assert.are.equal(0, #r.hunks)
+    end)
+
+    -- the terminator follows whichever side supplies the last line, or the revert
+    -- re-diffs as a phantom hunk on the final line
+    it("takes the old side's missing final newline when the hunk reaches eof", function()
+        local r = diff.revert_hunk(model("a\nb", "a\nB\n"), 1)
+        assert.are.equal("a\nb", r.new_text)
+        assert.are.equal(0, #r.hunks)
+    end)
+
+    it("keeps the new side's ending when the hunk stops short of eof", function()
+        local r = diff.revert_hunk(model("a\nb\nc", "A\nb\nc"), 1)
+        assert.are.equal("a\nb\nc", r.new_text)
+        assert.are.equal(0, #r.hunks)
+    end)
+
+    -- hunks are always parted by at least one unchanged line, and a revert doesn't
+    -- remove those, so the survivors stay distinct; only their indices move
+    it("keeps neighbouring hunks separate and renumbers them", function()
+        local m = model("a\nx\nb\ny\nc\n", "A\nx\nB\ny\nC\n")
+        assert.are.equal(3, #m.hunks)
+
+        local r = diff.revert_hunk(m, 2)
+        assert.are.equal("A\nx\nb\ny\nC\n", r.new_text)
+        assert.are.equal(2, #r.hunks)
+        assert.are.same({ "C" }, r.hunks[2].new_lines) -- was hunk 3
+    end)
+
+    it("carries the model's identity fields through the rebuild", function()
+        local m = diff.build({
+            path = "x.lua",
+            old_rev = "HEAD",
+            new_rev = "INDEX",
+            old_text = "a\nb\n",
+            new_text = "a\nB\n",
+            head = "main",
+            root = "/repo",
+        })
+
+        local r = diff.revert_hunk(m, 1)
+        assert.are.equal("x.lua", r.path)
+        assert.are.equal("HEAD", r.old_rev)
+        assert.are.equal("INDEX", r.new_rev)
+        assert.are.equal("main", r.head)
+        assert.are.equal("/repo", r.root)
+    end)
+end)

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1298,6 +1298,171 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
+    -- answer the revert confirm with `choice` for the duration of `fn`
+    local function confirming(choice, fn)
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function()
+            return choice
+        end
+        local ok, err = pcall(fn)
+        vim.fn.confirm = orig
+        assert(ok, err)
+    end
+
+    it("reverts one hunk from the worktree, leaving the others and the index", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")
+        git(root, "commit", "-q", "-am", "8 lines")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal(2, #v.model.hunks)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 }) -- the 1 -> 1x hunk
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        -- the first edit is gone from disk, the second survives, the index never moved
+        assert.are.equal("1\n2\n3\n4\n5\n6\n7\n8x\n", worktree(root, "a.lua"))
+        assert.are.equal("1\n2\n3\n4\n5\n6\n7\n8\n", indexed(root, "a.lua"))
+        -- the model was spliced, not re-read: one hunk left, and it's the survivor
+        assert.are.equal(1, #v.model.hunks)
+        assert.are.same({ "8x" }, v.model.hunks[1].new_lines)
+        p:close()
+    end)
+
+    it("leaves the worktree alone when the confirm is declined", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(2, function() -- "No"
+            v:revert_hunk()
+        end)
+
+        assert.are.equal("local x = 2\nreturn x\n", worktree(root, "a.lua"))
+        assert.are.equal(1, #v.model.hunks)
+        p:close()
+    end)
+
+    it("reverts a staged hunk out of the index and the worktree together", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")
+        git(root, "commit", "-q", "-am", "8 lines")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8x\n")
+        git(root, "add", "a.lua") -- both edits staged; the worktree matches the index
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("staged", v.staging.initial)
+        assert.are.equal(2, #v.model.hunks)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        -- gone from both sides, so the file has no unstaged residue to clean up
+        assert.are.equal("1\n2\n3\n4\n5\n6\n7\n8x\n", indexed(root, "a.lua"))
+        assert.are.equal("1\n2\n3\n4\n5\n6\n7\n8x\n", worktree(root, "a.lua"))
+        assert.are.equal(1, #v.model.hunks)
+        p:close()
+    end)
+
+    -- reverting only the worktree copy of a hunk already pushed to the index would
+    -- leave the two differing the other way round, so the key refuses instead
+    it("refuses to revert a hunk staged during the session", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        v:stage_hunk()
+        assert.is_true(v.staged_hunks[1])
+
+        confirming(1, function() -- would say yes, but it never gets asked
+            v:revert_hunk()
+        end)
+        assert.are.equal("local x = 2\nreturn x\n", worktree(root, "a.lua"))
+        assert.are.equal(1, #v.model.hunks)
+        p:close()
+    end)
+
+    it("refuses to revert a new file's whole-file hunk", function()
+        local root = fresh_repo()
+        write(root .. "/new.lua", "fresh\n") -- untracked: no partial revert to make
+        vim.cmd.edit(root .. "/new.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.is_nil(v.staging.revert)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+        assert.are.equal(1, vim.fn.filereadable(root .. "/new.lua")) -- still there
+        p:close()
+    end)
+
+    it("keeps staged marks on the hunks that outlive a revert", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n9\n")
+        git(root, "commit", "-q", "-am", "9 lines")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5x\n6\n7\n8\n9x\n") -- three hunks
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal(3, #v.model.hunks)
+
+        -- stage the first, then revert the second: the mark has to follow hunk 1
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        v:stage_hunk()
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        local second = nil
+        for lnum, line in ipairs(v.columns[1].map.lines) do
+            if line.hunk == 2 then
+                second = lnum
+                break
+            end
+        end
+        vim.api.nvim_win_set_cursor(p.origin_win, { assert(second), 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(2, #v.model.hunks)
+        assert.is_true(v.staged_hunks[1]) -- still the 1 -> 1x hunk
+        assert.is_nil(v.staged_hunks[2]) -- what was hunk 3, unstaged, renumbered down
+        assert.are.same({ "9x" }, v.model.hunks[2].new_lines)
+        p:close()
+    end)
+
     it("lands the cursor on the first hunk, not the leading context", function()
         local root = fresh_repo()
         write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n")
@@ -1661,7 +1826,7 @@ describe(":Differ diff hunk staging", function()
         git_src.panel({ rev = {}, open_first = true })
         local p = Panel.current()
         local lhs = keymaps(view_in_origin(p).columns[1].bufnr)
-        for _, k in ipairs({ "s", "u", "S", "U" }) do
+        for _, k in ipairs({ "s", "u", "S", "U", "X" }) do
             assert.is_true(lhs[k])
         end
         p:close()
@@ -1674,6 +1839,7 @@ describe(":Differ diff hunk staging", function()
         assert.is_nil(lhs2["u"])
         assert.is_nil(lhs2["S"])
         assert.is_nil(lhs2["U"])
+        assert.is_nil(lhs2["X"]) -- nor revertable: there's no worktree side to write
         p2:close()
     end)
 

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -199,6 +199,83 @@ describe("git.read (worktree clean filter)", function()
     end)
 end)
 
+describe("git.apply_patch (target)", function()
+    local patch = require("differ.git.patch")
+    local INDEX = { kind = "index", label = "INDEX" }
+    local WT = { kind = "worktree", label = "WORKTREE" }
+
+    -- committed and indexed as `a b c d e`, with the worktree carrying two
+    -- independent single-line edits, so a patch can name one hunk and leave the other
+    local BASE = "a\nb\nc\nd\ne\n"
+    local EDITED = "a\nB\nc\nD\ne\n"
+    local function two_hunk_repo()
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git(root, "init", "-q")
+        write(root .. "/f.txt", BASE)
+        git(root, "add", "f.txt")
+        git(root, "commit", "-q", "-m", "init")
+        write(root .. "/f.txt", EDITED)
+        return root
+    end
+
+    -- the index-vs-worktree model, whose hunks are the ones the diff view holds frozen
+    local function unstaged_model(root)
+        return git_src.model({ old = INDEX, new = WT }, root, { path = "f.txt" })
+    end
+
+    ---@param model differ.DiffModel
+    ---@param idx integer
+    ---@param reverse boolean
+    local function hunk_patch(model, idx, reverse)
+        return patch.hunk("f.txt", model.hunks[idx], model.old_text, model.new_text, 0, reverse)
+    end
+
+    it("reverse-applies to the worktree and leaves the index alone", function()
+        local root = two_hunk_repo()
+        local model = unstaged_model(root)
+        assert.are.equal(2, #model.hunks)
+
+        assert.is_true(git_src.apply_patch(root, hunk_patch(model, 2, true), true, "worktree"))
+        -- only the second edit is undone; the first survives, as does the index
+        assert.are.equal("a\nB\nc\nd\ne\n", git_src.read(WT, root, "f.txt"))
+        assert.are.equal(BASE, git_src.read(INDEX, root, "f.txt"))
+    end)
+
+    it("defaults to the index and leaves the worktree alone", function()
+        local root = two_hunk_repo()
+        local model = unstaged_model(root)
+
+        assert.is_true(git_src.apply_patch(root, hunk_patch(model, 1, false), false))
+        assert.are.equal("a\nB\nc\nd\ne\n", git_src.read(INDEX, root, "f.txt"))
+        assert.are.equal(EDITED, git_src.read(WT, root, "f.txt"))
+    end)
+
+    -- the revert-on-a-staged-hunk path composes two calls, and the worktree one is
+    -- located against content the user may have edited since; it must fail whole
+    it("fails without writing when the worktree no longer holds the hunk's content", function()
+        local root = two_hunk_repo()
+        local model = unstaged_model(root)
+        write(root .. "/f.txt", "a\nB\nc\nZZZ\ne\n") -- the D line was rewritten since
+
+        local ok, err = git_src.apply_patch(root, hunk_patch(model, 2, true), true, "worktree")
+        assert.is_false(ok)
+        assert.is_not_nil(err)
+        assert.are.equal("a\nB\nc\nZZZ\ne\n", git_src.read(WT, root, "f.txt"))
+    end)
+
+    -- the patch carries the model's frozen line numbers, so an edit above the hunk
+    -- desynchronises them; `--unidiff-zero` relocates by content instead
+    it("relocates a zero-context hunk when lines shifted above it", function()
+        local root = two_hunk_repo()
+        local model = unstaged_model(root)
+        write(root .. "/f.txt", "x1\nx2\nx3\na\nB\nc\nD\ne\n") -- D moves from line 4 to 7
+
+        assert.is_true(git_src.apply_patch(root, hunk_patch(model, 2, true), true, "worktree"))
+        assert.are.equal("x1\nx2\nx3\na\nB\nc\nd\ne\n", git_src.read(WT, root, "f.txt"))
+    end)
+end)
+
 describe("git.file_entries (rev-pair sources)", function()
     it("unions in untracked files for a worktree new-side, but not a rev new-side", function()
         local root = fresh_repo()

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -664,6 +664,7 @@ describe(":Differ panel", function()
         it("refreshes on " .. ev .. " so external git changes appear", function()
             local root = fresh_repo()
             write(root .. "/a.lua", "local x = 2\nreturn x\n")
+            write(root .. "/keep.lua", "kept\n") -- survives the commit, so the session does too
             vim.cmd.edit(root .. "/a.lua")
 
             git_src.panel({})
@@ -701,6 +702,7 @@ describe(":Differ panel", function()
     it("guards a stale entry: selecting a now-clean file refreshes, no blank view", function()
         local root = fresh_repo()
         write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        write(root .. "/keep.lua", "kept\n") -- a survivor, so the refresh doesn't end the session
         vim.cmd.edit(root .. "/a.lua")
 
         git_src.panel({})
@@ -1565,6 +1567,97 @@ describe(":Differ diff hunk staging", function()
         local after = view_in_origin(p)
         assert.are.equal("keep.lua", after.model.path) -- not left on an empty a.lua
         assert.is_true(#after.model.hunks > 0)
+        p:close()
+    end)
+
+    -- with nothing left to review, an open sidebar next to a diff of a file that's now
+    -- clean is a dead end: every key is a no-op and the diff is frozen on a stale model
+    it("ends the session when the last change in the set is reverted", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n") -- the only change in the repo
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal(1, #v.model.hunks)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        _G.notifs = {}
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(V1, worktree(root, "a.lua"))
+        assert.is_nil(Panel.current()) -- the session is gone, not left empty
+        assert.is_false(p:is_alive())
+        assert.is_false(v:is_open()) -- and it took the diff view with it
+        assert.are.equal("differ: no changes left", _G.notifs[1].msg)
+        assert.are.equal(1, #_G.notifs) -- said once, not once per teardown step
+    end)
+
+    it("lands back in the tab :Differ was invoked from", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+        local invoked_from = vim.api.nvim_get_current_tabpage()
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        assert.is_false(invoked_from == vim.api.nvim_get_current_tabpage()) -- own tab
+        local v = view_in_origin(p)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(invoked_from, vim.api.nvim_get_current_tabpage())
+    end)
+
+    -- the file list can also empty from outside differ: a commit in a tmux pane, a
+    -- lazygit discard. the watcher's refresh has to end the session the same way
+    it("ends the session when an outside commit empties the change set", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.is_true(v:is_open())
+
+        git(root, "commit", "-q", "-am", "committed elsewhere")
+        _G.notifs = {}
+        p.on_external_change() -- what the fs watcher / FocusGained fire
+
+        assert.is_nil(Panel.current())
+        assert.is_false(p:is_alive())
+        assert.is_false(v:is_open())
+        assert.are.equal("differ: no changes left", _G.notifs[1].msg)
+    end)
+
+    it("keeps the session when other changes survive the revert", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        write(root .. "/b.lua", "kept\n") -- a second change, untracked
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("a.lua", v.model.path)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(p, Panel.current()) -- still live, on the surviving change
+        assert.are.equal("b.lua", view_in_origin(p).model.path)
         p:close()
     end)
 

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1495,6 +1495,66 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
+    -- the cursor used to be pulled to the nearest surviving hunk, because the line a
+    -- revert leaves you on is unchanged context and the re-source focus snaps to hunks
+    it("keeps the cursor where the reverted hunk was, not on the next one", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n")
+        git(root, "commit", "-q", "-am", "12 lines")
+        -- hunks far apart, so being pulled to the second one is unmistakable
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal(2, #v.model.hunks)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 }) -- the 1 -> 1x hunk
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        -- the surviving hunk is the last line of the file; landing on it would mean a
+        -- new-side line of 12, and the whole point is that we didn't move there
+        local col = v.columns[#v.columns]
+        local lnum = vim.api.nvim_win_get_cursor(col.winid)[1]
+        local mapped = col.map.lines[lnum]
+        assert.is_not_nil(mapped)
+        assert.are.equal(1, mapped.new) -- still on line 1, now restored context
+        assert.is_nil(mapped.hunk) -- and it is context, not a hunk line
+        p:close()
+    end)
+
+    it("moves on when the revert takes the file's last hunk", function()
+        local root = fresh_repo()
+        write(root .. "/keep.lua", "kept\n")
+        git(root, "add", "keep.lua")
+        git(root, "commit", "-q", "-m", "keep")
+        write(root .. "/keep.lua", "kept and edited\n") -- a survivor to land on
+        write(root .. "/a.lua", "local x = 2\nreturn x\n") -- a.lua has one hunk
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("a.lua", v.model.path)
+        assert.are.equal(1, #v.model.hunks)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(V1, worktree(root, "a.lua")) -- reverted
+        local after = view_in_origin(p)
+        assert.are.equal("keep.lua", after.model.path) -- not left on an empty a.lua
+        assert.is_true(#after.model.hunks > 0)
+        p:close()
+    end)
+
     it("reloads an open buffer of the file it just reverted", function()
         local root = fresh_repo()
         write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -906,6 +906,12 @@ describe(":Differ panel staging (slice C)", function()
 
         assert.is_nil(entry_of(p, "a.lua")) -- no longer a change
         assert.are.equal(V1, table.concat(vim.fn.readfile(root .. "/a.lua"), "\n") .. "\n")
+        -- the file's own buffer is reloaded too, not left showing the discarded edit
+        local filebuf = vim.fn.bufnr(root .. "/a.lua")
+        assert.are.equal(
+            V1,
+            table.concat(vim.api.nvim_buf_get_lines(filebuf, 0, -1, false), "\n") .. "\n"
+        )
         p:close()
     end)
 
@@ -1407,22 +1413,109 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
-    it("refuses to revert a new file's whole-file hunk", function()
+    -- a new file's content is its only hunk, so reverting it deletes the file; the
+    -- confirm has to say that rather than counting hunks at the user
+    it("reverts a new file by deleting it, warning that it will", function()
         local root = fresh_repo()
-        write(root .. "/new.lua", "fresh\n") -- untracked: no partial revert to make
+        write(root .. "/new.lua", "fresh\n") -- untracked
         vim.cmd.edit(root .. "/new.lua")
 
         git_src.panel({ rev = {}, open_first = true })
         local p = Panel.current()
         local v = view_in_origin(p)
-        assert.is_nil(v.staging.revert)
+        assert.are.equal("deletes the file", v.staging.revert_label)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        local asked
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function(msg)
+            asked = msg
+            return 1
+        end
+        local ok, err = pcall(function()
+            v:revert_hunk()
+        end)
+        vim.fn.confirm = orig
+        assert(ok, err)
+
+        assert.are.equal("Revert all of new.lua? This deletes the file.", asked)
+        assert.are.equal(0, vim.fn.filereadable(root .. "/new.lua"))
+        p:close()
+    end)
+
+    it("reverts a staged add by dropping the file and its staged entry", function()
+        local root = fresh_repo()
+        write(root .. "/new.lua", "fresh\n")
+        git(root, "add", "new.lua") -- staged add: "A"
+        vim.cmd.edit(root .. "/new.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
 
         vim.api.nvim_set_current_win(p.origin_win)
         vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
         confirming(1, function()
             v:revert_hunk()
         end)
-        assert.are.equal(1, vim.fn.filereadable(root .. "/new.lua")) -- still there
+
+        assert.are.equal(0, vim.fn.filereadable(root .. "/new.lua"))
+        assert.is_nil(git(root, "ls-files", "--", "new.lua"):match("new%.lua")) -- unstaged too
+        p:close()
+    end)
+
+    -- deleting the file out from under the diff would otherwise strand the window on a
+    -- path that no longer exists, showing "hunk 0/0" against an empty buffer
+    it("moves to another file after a whole-file revert, not an empty diff", function()
+        local root = fresh_repo()
+        write(root .. "/keep.lua", "kept\n")
+        git(root, "add", "keep.lua")
+        git(root, "commit", "-q", "-m", "keep")
+        write(root .. "/keep.lua", "kept and edited\n") -- a real change to land on
+        write(root .. "/gone.lua", "temporary\n") -- untracked, about to go
+        vim.cmd.edit(root .. "/gone.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("gone.lua", v.model.path)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal(0, vim.fn.filereadable(root .. "/gone.lua"))
+        -- the view followed the panel onto the surviving change
+        local after = view_in_origin(p)
+        assert.are.equal("keep.lua", after.model.path)
+        assert.is_true(#after.model.hunks > 0)
+        p:close()
+    end)
+
+    it("reloads an open buffer of the file it just reverted", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")
+        git(root, "commit", "-q", "-am", "8 lines")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8x\n")
+        vim.cmd.edit(root .. "/a.lua") -- the real file is open in a buffer
+        local filebuf = vim.api.nvim_get_current_buf()
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        -- without a checktime this buffer would still hold the reverted line
+        local lines = vim.api.nvim_buf_get_lines(filebuf, 0, -1, false)
+        assert.are.equal("1", lines[1])
+        assert.is_false(vim.bo[filebuf].modified)
         p:close()
     end)
 

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -380,6 +380,12 @@ describe(":Differ panel", function()
         end
     end
 
+    -- the View driven by the panel, read without moving focus (which the focus-steal
+    -- assertions below depend on): it lives in the origin window
+    local function view_at(p)
+        return require("differ.view").for_buf(vim.api.nvim_win_get_buf(p.origin_win))
+    end
+
     -- the section content only: strip the 3-line header (root/help/blank) and the
     -- 3-line footer (blank/"Showing changes for:"/rev) so assertions don't depend on
     -- the temp-dir path or the HEAD sha
@@ -655,6 +661,54 @@ describe(":Differ panel", function()
         p:select()
         -- same window + buffer: the View was re-sourced, not recreated
         assert.are.equal(diff_buf, vim.api.nvim_win_get_buf(p.origin_win))
+        p:close()
+    end)
+
+    -- the change set surviving isn't enough: if the file the diff was on is the one
+    -- that went clean, the window is left on a diff of a file that matches HEAD, and
+    -- every later refresh walks into the same dead end (active_entry never moves on)
+    it(
+        "hands the diff to a surviving change when its own file goes clean outside differ",
+        function()
+            local root = fresh_repo()
+            write(root .. "/a.lua", "local x = 2\nreturn x\n")
+            write(root .. "/keep.lua", "kept\n") -- a survivor the diff should land on
+            vim.cmd.edit(root .. "/a.lua")
+
+            git_src.panel({ rev = {}, open_first = true })
+            local p = Panel.current()
+            assert.are.equal("a.lua", view_at(p).model.path)
+
+            git(root, "checkout", "HEAD", "--", "a.lua") -- only the shown file goes clean
+            vim.api.nvim_set_current_win(p.winid) -- reviewing from the sidebar
+            p.on_external_change()
+
+            assert.are.equal(p, Panel.current()) -- keep.lua survives, so the session does
+            assert.are.equal("keep.lua", view_at(p).model.path)
+            -- the refresh isn't user-driven, so it must not yank focus into the diff
+            assert.are.equal(p.winid, vim.api.nvim_get_current_win())
+            p:close()
+        end
+    )
+
+    -- R is the manual counterpart of the watcher, pressed precisely because something
+    -- changed outside differ, so it has to re-source the diff and not just the list: a
+    -- list-only reload re-baselines the change signature, which would then stop the
+    -- watcher from ever catching the diff up
+    it("R re-sources the diff, not just the file list", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        assert.are.equal(1, #view_at(p).model.hunks)
+
+        write(root .. "/a.lua", "local x = 2\nreturn x\nlocal y = 3\n") -- edited outside
+        vim.api.nvim_set_current_win(p.winid)
+        vim.api.nvim_feedkeys("R", "x", false)
+
+        assert.are.equal(2, #view_at(p).model.hunks) -- the diff picked the edit up
         p:close()
     end)
 
@@ -1099,6 +1153,44 @@ describe(":Differ diff hunk staging", function()
         assert.are.equal(2, #v.model.hunks)
         assert.are.same(before, vim.api.nvim_buf_get_lines(v.columns[1].bufnr, 0, -1, false))
         assert.is_true(v.staged_hunks[1])
+        assert.is_nil(v.staged_hunks[2])
+        p:close()
+    end)
+
+    -- the in-place staged marks are the whole point of the frozen diff, and the watcher
+    -- protects them by re-sourcing only when git moved for a reason differ didn't cause.
+    -- a staging key pressed in the sidebar writes the index too, so it has to re-baseline
+    -- that signature or the next watcher fire reads it as an outside change
+    it("keeps in-place staged marks across a staging op driven from the panel", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")
+        write(root .. "/z.lua", "z1\nz2\n")
+        git(root, "add", "z.lua")
+        git(root, "commit", "-q", "-am", "two files")
+        write(root .. "/a.lua", "1x\n2\n3\n4\n5\n6\n7\n8x\n") -- two hunks to mark
+        write(root .. "/z.lua", "z1x\nz2\n") -- a second file to stage from the panel
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("a.lua", v.model.path)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        v:stage_hunk() -- mark hunk 1 in place, leaving hunk 2 unstaged
+        assert.is_true(v.staged_hunks[1])
+
+        -- stage a *different* file whole, from the sidebar
+        vim.api.nvim_set_current_win(p.winid)
+        assert.is_true(p:focus_file("z.lua"))
+        p:stage_op("stage")
+        assert.are.equal("z1x\nz2\n", indexed(root, "z.lua")) -- z.lua really is staged
+
+        -- the index write that caused: the watcher fires, and must read it as differ's
+        -- own doing rather than re-sourcing a.lua's diff out from under the marks
+        p.on_external_change()
+
+        assert.are.equal(2, #v.model.hunks) -- still frozen on the same two hunks
+        assert.is_true(v.staged_hunks[1]) -- and hunk 1 is still marked staged
         assert.is_nil(v.staged_hunks[2])
         p:close()
     end)

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1304,6 +1304,19 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
+    -- the panel row for `path`, optionally pinned to its staged or unstaged side
+    local function file_line(p, path, staged)
+        for i, m in ipairs(p.meta) do
+            if
+                m.kind == "file"
+                and m.entry.path == path
+                and (staged == nil or m.entry.staged == staged)
+            then
+                return i
+            end
+        end
+    end
+
     -- answer the revert confirm with `choice` for the duration of `fn`
     local function confirming(choice, fn)
         local orig = vim.fn.confirm
@@ -1552,6 +1565,92 @@ describe(":Differ diff hunk staging", function()
         local after = view_in_origin(p)
         assert.are.equal("keep.lua", after.model.path) -- not left on an empty a.lua
         assert.is_true(#after.model.hunks > 0)
+        p:close()
+    end)
+
+    -- an unstaged deletion is still in the index, and that's what its diff compares
+    -- against, so it must come back from there and not from HEAD
+    it("restores an unstaged deletion from the index, keeping earlier staged edits", function()
+        local root = fresh_repo()
+        write(root .. "/b.lua", "one\ntwo\n")
+        git(root, "add", "b.lua")
+        git(root, "commit", "-q", "-m", "add b")
+        write(root .. "/b.lua", "one\nSTAGED\n") -- an edit staged before the delete
+        git(root, "add", "b.lua")
+        os.remove(root .. "/b.lua")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "b.lua", false), 0 })
+        p:select()
+        local v = view_in_origin(p)
+        assert.are.equal("b.lua", v.model.path)
+        assert.are.equal("restores the file", v.staging.revert_label)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        -- the staged version comes back, not HEAD's
+        assert.are.equal("one\nSTAGED\n", worktree(root, "b.lua"))
+        p:close()
+    end)
+
+    it("restores a staged deletion from HEAD, into the index and worktree", function()
+        local root = fresh_repo()
+        write(root .. "/b.lua", "one\ntwo\n")
+        git(root, "add", "b.lua")
+        git(root, "commit", "-q", "-m", "add b")
+        git(root, "rm", "-q", "b.lua") -- deletion staged
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "b.lua", true), 0 })
+        p:select()
+        local v = view_in_origin(p)
+        assert.are.equal("b.lua", v.model.path)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        confirming(1, function()
+            v:revert_hunk()
+        end)
+
+        assert.are.equal("one\ntwo\n", worktree(root, "b.lua"))
+        assert.are.equal("one\ntwo\n", indexed(root, "b.lua")) -- no staged deletion left
+        p:close()
+    end)
+
+    -- a deleted file has nothing to stage by hunk, so the staging keys stay refused
+    -- even though the revert key now works on it
+    it("offers revert but not hunk staging on a deleted file", function()
+        local root = fresh_repo()
+        write(root .. "/b.lua", "one\ntwo\n")
+        git(root, "add", "b.lua")
+        git(root, "commit", "-q", "-m", "add b")
+        os.remove(root .. "/b.lua")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "b.lua", false), 0 })
+        p:select()
+        local v = view_in_origin(p)
+        assert.are.equal("b.lua", v.model.path)
+
+        assert.is_nil(v.staging.apply) -- no hunk staging
+        assert.is_not_nil(v.staging.revert) -- but it can be brought back
+        assert.is_false(v:_can_stage_hunk())
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+        v:stage_hunk() -- refuses rather than acting
+        assert.are.equal(0, vim.fn.filereadable(root .. "/b.lua"))
+        assert.is_nil(next(v.staged_hunks))
         p:close()
     end)
 

--- a/test/nvim/panel_spec.lua
+++ b/test/nvim/panel_spec.lua
@@ -388,3 +388,61 @@ describe("panel runtime position", function()
         assert.is_nil(Panel.current())
     end)
 end)
+
+describe("panel refresh", function()
+    -- a panel whose reload returns `sections`, recording on_empty fires
+    local function reloadable(entries, sections)
+        local fired = {}
+        local p = panel(entries, {
+            actions = {
+                stage = function() end,
+                unstage = function() end,
+                stage_all = function() end,
+                unstage_all = function() end,
+                discard = function() end,
+                reload = function()
+                    return sections
+                end,
+            },
+            on_empty = function()
+                fired[#fired + 1] = true
+            end,
+        })
+        return p, fired
+    end
+
+    it("fires on_empty when a reload leaves no files", function()
+        local p, fired = reloadable({ fe("a.lua") }, {})
+        p:open()
+        p:refresh()
+        assert.are.equal(1, #fired)
+        assert.are.equal(0, p.file_total)
+        p:close()
+    end)
+
+    it("doesn't fire on_empty while files remain", function()
+        local p, fired = reloadable({ fe("a.lua") }, { { entries = { fe("b.lua") } } })
+        p:open()
+        p:refresh()
+        assert.are.equal(0, #fired)
+        assert.are.same({ "M b.lua" }, lines(p))
+        p:close()
+    end)
+
+    -- a hidden sidebar is still a live session driving a visible diff, so an emptying
+    -- reload has to reach it too; only a closed panel stops refreshing
+    it("refreshes (and can empty) with the sidebar hidden, but not once closed", function()
+        local p, fired = reloadable({ fe("a.lua") }, {})
+        p:open()
+        p:hide()
+        assert.is_false(p:is_open())
+        assert.is_true(p:is_alive())
+        p:refresh()
+        assert.are.equal(1, #fired)
+
+        p:close()
+        assert.is_false(p:is_alive())
+        p:refresh() -- a queued refresh landing after the close is a no-op
+        assert.are.equal(1, #fired)
+    end)
+end)

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -465,7 +465,7 @@ describe("view context controls", function()
         v:close()
     end)
 
-    it("widens/narrows by one and no-ops at whole-file", function()
+    it("widens/narrows by one", function()
         local v = gap_view()
         v:open()
         v:set_context(2)
@@ -473,9 +473,18 @@ describe("view context controls", function()
         assert.are.equal(1, v.context)
         v:adjust_context(1)
         assert.are.equal(2, v.context)
-        v:set_context(math.huge)
-        v:adjust_context(-1) -- can't decrement infinity
+        v:close()
+    end)
+
+    it("narrows down from whole file, and won't widen past it", function()
+        local v = gap_view()
+        v:open()
+        v:adjust_context(1) -- already whole file, nothing wider to go to
         assert.are.equal(math.huge, v.context)
+        v:adjust_context(-1) -- seeds a finite context, so d- works from a fresh open
+        assert.are.equal(10, v.context)
+        v:adjust_context(-1) -- and steps normally from there
+        assert.are.equal(9, v.context)
         v:close()
     end)
 end)


### PR DESCRIPTION
## Summary
- `X` reverts the hunk under the cursor in the diff, the hunk-level counterpart to the panel's file-level discard. it confirms first, since unlike `s`/`u` it destroys the change rather than moving it between the index and the worktree: an unstaged hunk drops from the worktree, a staged one from the index and worktree together. `apply_patch` gained a worktree target to do it
- where a file's whole content is one hunk the confirm names the consequence instead of counting hunks, so reverting a new file says it deletes it and reverting a deleted one says it restores it. deleted files revert without gaining hunk staging, so `s`/`u` still refuse there
- the frozen diff is spliced in place rather than re-read, so the cursor stays where the hunk was; when a revert leaves the file with nothing changed the panel moves you on to the next one
- an uncommitted session ends itself once its file list empties, rather than leaving an empty panel beside a diff of a file that is now clean. the set can empty from either side, the last change reverted in differ or a commit made in another pane; either way the session closes and returns you to the tab you opened it from. rev-pair sessions never reload their list, so they are untouched
- a hidden file panel (`dd`) keeps refreshing with the worktree: refreshes now track whether the session exists rather than whether the sidebar is shown, so a revert with the sidebar hidden hands the diff on instead of stranding it
- **breaking:** `context` defaults to the whole file rather than 10 lines, so a diff opens with no folds in it. folds were always created open, so nothing was ever hidden, but the markers still broke the file up on sight for no gain; the threshold survives through `setup()`, `:Differ context <n>` and `d-`
- `d-` narrows away from whole-file instead of doing nothing. there is no finite threshold to decrement from `math.huge`, so the first step down seeds 10; `d=` at whole-file stays a no-op
- fix: a staging key pressed in the file panel no longer tears down an in-progress hunk review. `s`/`u`/`S`/`U`/`X` write the index like their diff-window counterparts but didn't re-baseline the change signature, so the watcher read the write back as an outside change and re-sourced the frozen diff, losing the in-place staged marks. every list reload now records that state, whatever drove it
- fix: the diff no longer strands on a file that went clean outside differ while other changes remained; it hands over to the nearest surviving change, without stealing focus
- fix: `R` in the panel re-sources the diff as well as the list, matching what the watcher does
- fix: a file discarded from the panel no longer leaves its own buffer showing the discarded content, via a `checktime` on the rewritten file that leaves unsaved edits alone
- fix: the diff's `g?` lists the staging and revert keys per file rather than per session, so a file that can't stage by hunk no longer advertises `s`/`u`
- fix: busted/luassert paths move out of `.luarc.json`'s `workspace.library`, which was breaking jump-to-definition in nvim; that setup lives in the nvim config now

## Test plan
- [x] `make check` (lua + go lint, lua_ls type-check, all suites)
- [x] lua unit 340/0, headless-nvim 366/0, go tests ok
- [x] new specs cover hunk revert across the git layer (worktree/index targets, new and deleted files), the diff model splice, cursor hold, panel refresh and session-empty teardown
- [x] `doc/differ.txt` is `make vimdoc` output
