### PR TITLE
fix: surface github's error message, and stop leaking the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- A failed GitHub request says what GitHub said. The status was mapped before the response body was read, leaving the branch that reads GitHub's own message unreachable: a rejected comment reported `422 Unprocessable Entity` where GitHub had named the line it was not part of, and an expired token reported `401 Unauthorized` rather than `Bad credentials`
+- A secondary rate limit is reported as a rate limit rather than as a permissions problem. GitHub signals one with a 403 carrying only a message, no rate-limit headers and usually no `Retry-After`, so it read as a denied scope and sent you looking for a permission you already had. It is now recognised by that message, which the fix above is what makes readable
+- A failing GitHub request no longer leaks its connection. The body was left unclosed on every non-2xx path, so each failure opened a fresh connection instead of reusing the pooled one. It bit hardest where failures arrive in bulk: a wall of 403s at a rate limit, or a repeated 401 on an expired token
+
+## [0.1.24] — 2026-08-10
+
+### Fixed
+
 - A pull request's head branch name can no longer run commands on checkout. `:Differ pr checkout` handed it to `git fetch` as a positional argument, and git reads one beginning with `-` as an option rather than as a ref: a branch named `--upload-pack=<command>` had its value run through a shell. Branch names are now checked against git's own ref-name rules before any git call. A `--` separator is not the fix here, since it would turn the `checkout` that follows into a pathspec restore
 - Staging a hunk at the end of a file with no trailing newline no longer corrupts the index. The `\ No newline at end of file` marker attaches to a line, and a zero-context hunk has none on the side that owns the terminator, so it was dropped: appending to such a file staged its last two lines merged into one, and `git apply` reported success. The hunk is widened by the line that owns the terminator, the way git's own diff does it, and deleting a file's tail is the mirror. Any file without a final newline was affected, which editors and generated files produce routinely
 - `:Differ pr checkout` works on a pull request from a fork. A cross-repo PR's head branch lives on the contributor's own repository and never reaches `origin`, so fetching it by name failed outright with `couldn't find remote ref`. It falls back to `refs/pull/<number>/head`, the ref `origin` does publish for such a PR, and lands on a local branch named for the head ref. An existing local branch of that name is checked out as it stands rather than moved, so nothing on it is lost

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/undont/differ.nvim/internal/protocol"
@@ -36,6 +37,9 @@ func mapHTTP(resp *http.Response, body []byte, transportErr error) *protocol.Err
 	case http.StatusForbidden:
 		if ra, ok := rateLimited(resp); ok {
 			return protocol.RateLimited(msg, ra)
+		}
+		if secondaryLimit(msg) {
+			return protocol.RateLimited(msg, 0)
 		}
 		return protocol.NewError(protocol.CodeAuth, msg)
 	case http.StatusTooManyRequests:
@@ -72,6 +76,15 @@ func rateLimited(resp *http.Response) (int, bool) {
 		return 0, true
 	}
 	return 0, false
+}
+
+// a secondary rate limit arrives as a 403 carrying only a message: no X-RateLimit
+// headers and usually no Retry-After, so rateLimited can't see it. left as an auth
+// error it sends the user hunting for a scope they already have, when the answer is
+// to wait. github has used both wordings; match either
+func secondaryLimit(msg string) bool {
+	l := strings.ToLower(msg)
+	return strings.Contains(l, "secondary rate limit") || strings.Contains(l, "abuse detection")
 }
 
 func githubMessage(body []byte, fallback string) string {

--- a/internal/github/files.go
+++ b/internal/github/files.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -85,23 +84,15 @@ func (c *Client) rawBlob(ctx context.Context, owner, repo, path, ref string) (Fi
 	req.Header.Set("Accept", "application/vnd.github.raw+json")
 	req.Header.Set("X-GitHub-Api-Version", apiVersion)
 
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return FileBlob{}, protocol.NewError(protocol.CodeNetwork, "network error: "+err.Error())
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusNotFound {
+	resp, body, err := c.send(req)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		// a missing path at a sha is itself immutable, so cache it too.
 		blob := FileBlob{Missing: true}
 		c.cache.putBlob(key, blob)
 		return blob, nil
 	}
-	body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
-	if perr := mapHTTP(resp, body, nil); perr != nil {
-		return FileBlob{}, perr
-	}
-	if rerr != nil {
-		return FileBlob{}, protocol.NewError(protocol.CodeNetwork, "reading response: "+rerr.Error())
+	if err != nil {
+		return FileBlob{}, err
 	}
 	blob := FileBlob{Content: string(body)}
 	c.cache.putBlob(key, blob)

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -3,9 +3,14 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/undont/differ.nvim/internal/protocol"
@@ -21,26 +26,65 @@ func newClient(f rtFunc) *Client {
 	return New(&http.Client{Transport: f}, "test-token", nil)
 }
 
+// bodies tallies every response body resp() hands out against every Close() on one.
+// wrapping bodies in io.NopCloser made a leak structurally invisible: the client
+// could return before closing and every test still passed. atomic because the
+// concurrent-blob path hands out two bodies from two goroutines
+var bodies struct{ opened, closed atomic.Int64 }
+
+type countingBody struct{ io.Reader }
+
+func (countingBody) Close() error { bodies.closed.Add(1); return nil }
+
+// TestMain is the package-wide net: any test that leaves a body open fails the
+// package, whether or not it went looking. trackBodies localises it to one test
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if opened, closed := bodies.opened.Load(), bodies.closed.Load(); code == 0 && opened != closed {
+		fmt.Fprintf(os.Stderr, "response body leak: %d handed out, %d closed\n", opened, closed)
+		code = 1
+	}
+	os.Exit(code)
+}
+
+// trackBodies fails t if any body handed out during it outlives it.
+func trackBodies(t *testing.T) {
+	t.Helper()
+	opened, closed := bodies.opened.Load(), bodies.closed.Load()
+	t.Cleanup(func() {
+		got, want := bodies.closed.Load()-closed, bodies.opened.Load()-opened
+		if got != want {
+			t.Errorf("%d of %d response bodies closed", got, want)
+		}
+	})
+}
+
 func resp(status int, body string, headers map[string]string) *http.Response {
 	h := http.Header{}
 	for k, v := range headers {
 		h.Set(k, v)
 	}
+	bodies.opened.Add(1)
 	return &http.Response{
 		StatusCode: status,
 		Status:     http.StatusText(status),
-		Body:       io.NopCloser(strings.NewReader(body)),
+		Body:       countingBody{strings.NewReader(body)},
 		Header:     h,
 	}
 }
 
-func codeOf(t *testing.T, err error) string {
+func perrOf(t *testing.T, err error) *protocol.Error {
 	t.Helper()
 	var pe *protocol.Error
 	if !errors.As(err, &pe) {
 		t.Fatalf("want *protocol.Error, got %T: %v", err, err)
 	}
-	return pe.Code
+	return pe
+}
+
+func codeOf(t *testing.T, err error) string {
+	t.Helper()
+	return perrOf(t, err).Code
 }
 
 // ── list_prs ────────────────────────────────────────────────────────────────
@@ -233,6 +277,9 @@ func TestGetPRGraphQLFilesPagination(t *testing.T) {
 
 // ── error mapping ───────────────────────────────────────────────────────────
 
+// the message half matters as much as the code: "403 Forbidden" sends the user
+// looking for a missing scope, where GitHub's own body says which secondary limit
+// they hit or which line of the diff a 422 rejected
 func TestErrorMappingTable(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -240,26 +287,110 @@ func TestErrorMappingTable(t *testing.T) {
 		body    string
 		headers map[string]string
 		want    string
+		wantMsg string
 	}{
-		{"unauthorized", 401, `{"message":"Bad credentials"}`, nil, protocol.CodeAuth},
-		{"forbidden_perms", 403, `{"message":"Forbidden"}`, nil, protocol.CodeAuth},
-		{"forbidden_ratelimit", 403, `{"message":"rate limit"}`, map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "9999999999"}, protocol.CodeRateLimited},
-		{"too_many", 429, `{"message":"slow down"}`, map[string]string{"Retry-After": "30"}, protocol.CodeRateLimited},
-		{"not_found", 404, `{"message":"Not Found"}`, nil, protocol.CodeNotFound},
-		{"conflict", 409, `{"message":"conflict"}`, nil, protocol.CodeConflict},
-		{"unprocessable", 422, `{"message":"Validation Failed"}`, nil, protocol.CodeBadRequest},
-		{"server", 500, `{"message":"boom"}`, nil, protocol.CodeInternal},
+		{"unauthorized", 401, `{"message":"Bad credentials"}`, nil, protocol.CodeAuth, "Bad credentials"},
+		{"forbidden_perms", 403, `{"message":"Resource not accessible by integration"}`, nil, protocol.CodeAuth, "Resource not accessible by integration"},
+		{"forbidden_ratelimit", 403, `{"message":"API rate limit exceeded"}`, map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "9999999999"}, protocol.CodeRateLimited, "API rate limit exceeded"},
+		{"forbidden_secondary", 403, `{"message":"You have exceeded a secondary rate limit"}`, nil, protocol.CodeRateLimited, "You have exceeded a secondary rate limit"},
+		{"forbidden_abuse", 403, `{"message":"You have triggered an abuse detection mechanism"}`, nil, protocol.CodeRateLimited, "You have triggered an abuse detection mechanism"},
+		{"too_many", 429, `{"message":"slow down"}`, map[string]string{"Retry-After": "30"}, protocol.CodeRateLimited, "slow down"},
+		{"not_found", 404, `{"message":"Not Found"}`, nil, protocol.CodeNotFound, "Not Found"},
+		{"conflict", 409, `{"message":"conflict"}`, nil, protocol.CodeConflict, "conflict"},
+		{"unprocessable", 422, `{"message":"Validation Failed: line must be part of the diff"}`, nil, protocol.CodeBadRequest, "Validation Failed: line must be part of the diff"},
+		{"server", 500, `{"message":"boom"}`, nil, protocol.CodeInternal, "boom"},
+		// no envelope to read: the status line is all there is to say
+		{"empty_body", 404, ``, nil, protocol.CodeNotFound, http.StatusText(http.StatusNotFound)},
+		{"non_json_body", 502, `<html>bad gateway</html>`, nil, protocol.CodeInternal, http.StatusText(http.StatusBadGateway)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			trackBodies(t)
 			c := newClient(func(*http.Request) (*http.Response, error) {
 				return resp(tc.status, tc.body, tc.headers), nil
 			})
-			err := c.getJSON(context.Background(), c.restURL+"/x", nil)
-			if got := codeOf(t, err); got != tc.want {
-				t.Fatalf("status %d → %q, want %q", tc.status, got, tc.want)
+			pe := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
+			if pe.Code != tc.want {
+				t.Fatalf("status %d → %q, want %q", tc.status, pe.Code, tc.want)
+			}
+			if pe.Message != tc.wantMsg {
+				t.Fatalf("status %d message = %q, want %q", tc.status, pe.Message, tc.wantMsg)
 			}
 		})
+	}
+}
+
+// a permissions 403 and a secondary-limit 403 are the same status with the same
+// (absent) headers; only the message tells them apart, so this is the case that
+// dies first if the body ever stops reaching mapHTTP again
+func TestSecondaryRateLimitIsNotAnAuthError(t *testing.T) {
+	c := newClient(func(*http.Request) (*http.Response, error) {
+		return resp(403, `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}`, nil), nil
+	})
+	err := c.getJSON(context.Background(), c.restURL+"/x", nil)
+	if got := codeOf(t, err); got != protocol.CodeRateLimited {
+		t.Fatalf("secondary rate limit → %q, want rate_limited", got)
+	}
+}
+
+// a mapped status must not skip the body's Close: every path through send has one
+// registered, and each caller below reaches it differently (paged, graphql, the
+// blob path with its own 404 special case)
+func TestErrorPathsCloseTheBody(t *testing.T) {
+	paths := map[string]func(*Client) error{
+		"getJSON": func(c *Client) error {
+			return c.getJSON(context.Background(), c.restURL+"/x", nil)
+		},
+		"getPaged": func(c *Client) error {
+			_, err := getPaged[PRFile](context.Background(), c, c.restURL+"/x")
+			return err
+		},
+		"graphql": func(c *Client) error {
+			return c.graphql(context.Background(), "query{}", nil, nil)
+		},
+		"rawBlob": func(c *Client) error {
+			_, err := c.rawBlob(context.Background(), "o", "r", "a.go", "sha")
+			return err
+		},
+	}
+	for name, call := range paths {
+		t.Run(name, func(t *testing.T) {
+			trackBodies(t)
+			c := newClient(func(*http.Request) (*http.Response, error) {
+				return resp(403, `{"message":"nope"}`, nil), nil
+			})
+			if err := call(c); err == nil {
+				t.Fatal("want an error from a 403")
+			}
+		})
+	}
+}
+
+// the connection is only reusable if the body was drained and closed; a real
+// transport is the only thing that can prove it, so this one skips the fake
+func TestRepeatedFailuresReuseTheConnection(t *testing.T) {
+	var conns atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"nope"}`))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			conns.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := New(srv.Client(), "test-token", nil)
+	c.restURL = srv.URL
+	for range 10 {
+		if err := c.getJSON(context.Background(), c.restURL+"/x", nil); err == nil {
+			t.Fatal("want an error from a 403")
+		}
+	}
+	if n := conns.Load(); n != 1 {
+		t.Fatalf("10 failing requests opened %d connections, want 1 (bodies unclosed)", n)
 	}
 }
 
@@ -267,9 +398,8 @@ func TestRetryAfterPropagates(t *testing.T) {
 	c := newClient(func(*http.Request) (*http.Response, error) {
 		return resp(429, `{"message":"slow"}`, map[string]string{"Retry-After": "30"}), nil
 	})
-	err := c.getJSON(context.Background(), c.restURL+"/x", nil)
-	var pe *protocol.Error
-	if !errors.As(err, &pe) || pe.RetryAfter != 30 {
+	pe := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
+	if pe.RetryAfter != 30 {
 		t.Fatalf("want retry_after=30, got %+v", pe)
 	}
 }

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/undont/differ.nvim/internal/protocol"
@@ -30,18 +29,9 @@ func (c *Client) graphql(ctx context.Context, query string, vars map[string]any,
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Api-Version", apiVersion)
 
-	resp, err := c.http.Do(req)
-	if perr := mapHTTP(resp, nil, err); perr != nil {
-		return perr
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
+	_, body, err := c.send(req)
 	if err != nil {
-		return protocol.NewError(protocol.CodeNetwork, "reading response: "+err.Error())
-	}
-	if perr := mapHTTP(resp, body, nil); perr != nil {
-		return perr
+		return err
 	}
 
 	var envelope struct {

--- a/internal/github/rest.go
+++ b/internal/github/rest.go
@@ -13,6 +13,33 @@ import (
 
 const maxResponse = 32 * 1024 * 1024 // bound a single response body
 
+// send performs req and returns the response alongside its already-read, already-
+// closed body. the transport error is handled on its own, before anything else, so
+// `defer Close` is registered on every path that has a body to close: a non-2xx must
+// not leak the connection, which is exactly when the leak compounds (a wall of 403s
+// at a rate limit, a 401 on an expired token). the status then maps with the body in
+// hand, so GitHub's own message survives instead of a bare status line. resp is
+// returned even on a mapped error, for callers that special-case a status; its body
+// is spent, so only headers and the status line are readable from it
+func (c *Client) send(req *http.Request) (*http.Response, []byte, error) {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, nil, protocol.NewError(protocol.CodeNetwork, "network error: "+err.Error())
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
+	// the status outranks a truncated read: a 403 that also failed to read is still a
+	// 403, and its message is the useful half
+	if perr := mapHTTP(resp, body, nil); perr != nil {
+		return resp, body, perr
+	}
+	if rerr != nil {
+		return resp, body, protocol.NewError(protocol.CodeNetwork, "reading response: "+rerr.Error())
+	}
+	return resp, body, nil
+}
+
 // getJSON does an authenticated REST GET, maps the status to a protocol code, and
 // decodes the body into out.
 func (c *Client) getJSON(ctx context.Context, rawURL string, out any) error {
@@ -25,18 +52,9 @@ func (c *Client) getJSON(ctx context.Context, rawURL string, out any) error {
 	}
 	c.setRESTHeaders(req)
 
-	resp, err := c.http.Do(req)
-	if perr := mapHTTP(resp, nil, err); perr != nil {
-		return perr
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
+	_, body, err := c.send(req)
 	if err != nil {
-		return protocol.NewError(protocol.CodeNetwork, "reading response: "+err.Error())
-	}
-	if perr := mapHTTP(resp, body, nil); perr != nil {
-		return perr
+		return err
 	}
 	if out == nil {
 		return nil
@@ -62,26 +80,16 @@ func getPaged[T any](ctx context.Context, c *Client, rawURL string) ([]T, error)
 		}
 		c.setRESTHeaders(req)
 
-		resp, err := c.http.Do(req)
-		if perr := mapHTTP(resp, nil, err); perr != nil {
-			return nil, perr
-		}
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
-		next := nextLink(resp.Header.Get("Link"))
-		_ = resp.Body.Close()
-
-		if perr := mapHTTP(resp, body, nil); perr != nil {
-			return nil, perr
-		}
-		if readErr != nil {
-			return nil, protocol.NewError(protocol.CodeNetwork, "reading response: "+readErr.Error())
+		resp, body, err := c.send(req)
+		if err != nil {
+			return nil, err
 		}
 		var pageItems []T
 		if err := json.Unmarshal(body, &pageItems); err != nil {
 			return nil, protocol.NewError(protocol.CodeInternal, "decoding response: "+err.Error())
 		}
 		all = append(all, pageItems...)
-		rawURL = next
+		rawURL = nextLink(resp.Header.Get("Link"))
 	}
 	return all, nil
 }

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -381,6 +381,73 @@ describe("git.apply_patch (target)", function()
     end)
 end)
 
+-- the missing-final-newline bug was never that the patch text looked wrong: it looked
+-- plausible, git apply reported success, and the index silently gained a joined line.
+-- the unit fixtures pin the text; only real git can pin the bytes it writes, and under
+-- `--unidiff-zero` a side with no lines leaves git trusting the header rather than
+-- failing loudly. every shape here round-trips, so an over-eager widening is caught
+-- too: unstaging has to land back on the original blob byte-for-byte
+describe("git hunk staging round-trip (real git apply, EOF terminators)", function()
+    local patch = require("differ.git.patch")
+    local INDEX = { kind = "index", label = "INDEX" }
+    local WT = { kind = "worktree", label = "WORKTREE" }
+
+    -- raw stdout, no text=true: that collapses the very terminators under test
+    local function indexed(root, path)
+        local res = vim.system({ "git", "cat-file", "blob", ":" .. path }, { cwd = root }):wait()
+        assert(res.code == 0, res.stderr)
+        return res.stdout
+    end
+
+    -- committed, so the index starts equal to HEAD, with the worktree carrying the edit
+    local function repo_with(base, edited)
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git(root, "init", "-q")
+        write(root .. "/f.txt", base)
+        git(root, "add", "f.txt")
+        git(root, "commit", "-q", "-m", "base")
+        write(root .. "/f.txt", edited)
+        return root
+    end
+
+    -- stage the hunk, then unstage the same patch, checking the index blob at each
+    -- step. one hunk, so no offset: `reverse` only picks which way git reads it, which
+    -- is exactly what the staging keys do
+    local function round_trip(base, edited)
+        local root = repo_with(base, edited)
+        local model = git_src.model({ old = INDEX, new = WT }, root, { path = "f.txt" })
+        assert.are.equal(1, #model.hunks)
+        local p = patch.hunk("f.txt", model.hunks[1], model.old_text, model.new_text, 0, "old")
+
+        local ok, err = git_src.apply_patch(root, p, false)
+        assert.is_true(ok, "stage failed: " .. tostring(err) .. "\n" .. p)
+        assert.are.equal(edited, indexed(root, "f.txt"))
+
+        ok, err = git_src.apply_patch(root, p, true)
+        assert.is_true(ok, "unstage failed: " .. tostring(err) .. "\n" .. p)
+        assert.are.equal(base, indexed(root, "f.txt"))
+    end
+
+    it("appends past an unterminated last line, giving it its newline", function()
+        round_trip("a\nb", "a\nb\nc\n")
+    end)
+
+    it("deletes the tail, leaving the new last line unterminated", function()
+        round_trip("a\nb\nc\n", "a\nb")
+    end)
+
+    it("appends unterminated onto unterminated", function()
+        round_trip("a\nb", "a\nb\nc")
+    end)
+
+    -- the control: an unterminated file whose hunk stops short of EOF must not widen,
+    -- and must not quietly acquire a trailing newline on the way through
+    it("leaves an unterminated file unterminated when the hunk is mid-file", function()
+        round_trip("a\nb", "a\nX\nb")
+    end)
+end)
+
 describe("git.file_entries (rev-pair sources)", function()
     it("unions in untracked files for a worktree new-side, but not a rev new-side", function()
         local root = fresh_repo()


### PR DESCRIPTION
## Summary
- fix: a failed GitHub request surfaces GitHub's own message. `mapHTTP` ran on the transport error before the body was read, so it returned non-nil for any non-2xx and the body-carrying call was dead code: a rejected comment reported `422 Unprocessable Entity` where GitHub had named the line, an expired token `401 Unauthorized` rather than `Bad credentials`. all four HTTP sites now route through one `Client.send` that reads and closes the body before mapping
- fix: a failing request no longer leaks its connection. `return perr` fired before `defer Close` was registered, so each non-2xx opened a fresh connection instead of reusing the pooled one, worst exactly where failures arrive in bulk (a wall of 403s at a rate limit, a repeated 401 on a dead token)
- fix: a secondary rate limit (403, message-only, no rate headers) is classified `rate_limited` rather than `auth`, so the hint reads "retry shortly" instead of sending you after a scope you already have. only reachable once the message survives, per the fix above
- test: the missing-final-newline patches round-trip through real `git apply`. the unit fixtures pin the patch text, but the §4.1 corruption was never that the text looked wrong: git accepted it and merged two lines. four terminator shapes x stage and unstage, index blob compared byte-for-byte
- test: the `resp()` helper counts `Close()` via a package-wide tally, so a body leak fails the package rather than staying invisible behind `io.NopCloser`

## Test plan
- [x] `make check` (lua + go lint, lua_ls type-check, `go vet`, all suites)
- [x] lua unit 361/0, headless-nvim 411/0, go tests ok
- [x] `go test -race ./...` clean (caught a real data race in the new body counter: the concurrent-blob path closes two bodies from two goroutines, now atomic)
- [x] both defects proven against the tests by reinstating the old ordering: every `.Message` assertion and every close assertion fails
- [x] round-trip proven against §4.1 by stubbing `widen_at_eof` out: 3 of 4 shapes fail, reproducing the exact `a\nbc\n` merge
- [x] §4.2 confirmed end-to-end against a throwaway private repo: GitHub hosts a `--upload-pack=…` branch name and returns it verbatim as `head.ref`
