### PR TITLE
fix: reconcile pr session state, and other silent bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim-version: ["stable", "nightly"]
+        # v0.12.0 is the declared floor, pinned rather than tracked: `stable` rolls to
+        # 0.13 on release and the floor would silently stop being exercised
+        neovim-version: ["v0.12.0", "stable", "nightly"]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.25] — 2026-08-10
+
 ### Fixed
 
 - A failed GitHub request says what GitHub said. The status was mapped before the response body was read, leaving the branch that reads GitHub's own message unreachable: a rejected comment reported `422 Unprocessable Entity` where GitHub had named the line it was not part of, and an expired token reported `401 Unauthorized` rather than `Bad credentials`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Neovim 0.12 is the minimum, documented and enforced at startup. Every diff uses `vim.text.diff`, which 0.10 and 0.11 don't have
+
+### Fixed
+
+- Review actions taken from the overview page (submit, discard, post, delete, resolve) reached GitHub but were ignored by the session, leaving a stale draft id, invisible comments, and conflicts reported nowhere
+- `:Differ pr review` and `resume` dropped the draft when they answered before the diff had loaded, so `ga` posted live comments while the title said draft
+- Switching pull requests mid-request mixed the two: a prefetch, a viewed toggle or a state transition could land on the wrong session
+- Opening two pull requests in quick succession landed on whichever answered last, not the one asked for last
+- A comment posted against whatever file the diff showed at submit time rather than the one it was written on, and closing the diff mid-compose raised an error
+- A comment posted while the thread list was still loading stayed invisible for the rest of the session
+- Outdated review threads stacked on line 1 and read as `path:0`; they now sit where they were written, marked outdated
+- Thread, file and timeline pagination could loop until the token hit a rate limit; a sidecar request that never answers now fails after a minute
+- Closing a diff with `:q` skipped teardown, leaking a buffer, its parsed diff and an autocmd each time
+
 ## [0.1.25] — 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread, file and timeline pagination could loop until the token hit a rate limit; a sidecar request that never answers now fails after a minute
 - Closing a diff with `:q` skipped teardown, leaking a buffer, its parsed diff and an autocmd each time
 - `:Differ pr review resume` failed: the query behind it asked GitHub for a field that doesn't exist on a review comment, so it failed with an internal error, and opening a PR didn't adopt an existing draft either
+- Opening a PR and going straight to the files bounced you back to the overview a moment later: the page's own render was still in flight and took the window back, closing the diff it found there
 
 ## [0.1.25] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Outdated review threads stacked on line 1 and read as `path:0`; they now sit where they were written, marked outdated
 - Thread, file and timeline pagination could loop until the token hit a rate limit; a sidecar request that never answers now fails after a minute
 - Closing a diff with `:q` skipped teardown, leaking a buffer, its parsed diff and an autocmd each time
+- `:Differ pr review resume` failed: the query behind it asked GitHub for a field that doesn't exist on a review comment, so it failed with an internal error, and opening a PR didn't adopt an existing draft either
 
 ## [0.1.25] — 2026-08-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for considering a contribution to differ.nvim.
 
 ## Setup
 
-- Neovim 0.10+, git on `PATH`
+- Neovim 0.12+, git on `PATH`
 - For the Go sidecar: Go + make on `PATH`
 - `make go-build` builds the sidecar into `bin/`. Rerun it after any change under `cmd/` or `internal/` and restart the sidecar process in your running nvim, otherwise you're testing against a stale binary
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ vimdoc: $(PANVIMDOC_BIN) ## Regenerate doc/differ.txt from README.md (needs pand
 		--scripts-dir "$(PANVIMDOC_DIR)/scripts" \
 		--project-name differ \
 		--input-file README.md \
-		--description "For Neovim >= 0.10" \
+		--description "For Neovim >= 0.12" \
 		--toc true \
 		--demojify true \
 		--dedup-subheadings true \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Licence](https://img.shields.io/github/license/undont/differ.nvim?style=flat&label=licence&color=6366F1)](LICENCE)
 [![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?style=flat&logo=lua&logoColor=white)](https://www.lua.org)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go&logoColor=white)](https://go.dev)
-[![Neovim](https://img.shields.io/badge/Neovim-0.10+-57A143?style=flat&logo=neovim&logoColor=white)](https://neovim.io)
+[![Neovim](https://img.shields.io/badge/Neovim-0.12+-57A143?style=flat&logo=neovim&logoColor=white)](https://neovim.io)
 [![macOS](https://img.shields.io/badge/macOS-supported-6e7681?style=flat&logo=apple&logoColor=white)]()
 [![Linux](https://img.shields.io/badge/Linux-supported-6e7681?style=flat&logo=linux&logoColor=white)]()
 
@@ -45,13 +45,13 @@ The GitHub side runs in a separate process rather than the editor, so opening a 
 - 3-way/4-way merge tool, resolved into the working-tree file
 - Word-level highlighting and Treesitter syntax, both on by default
 - Real buffer lines, so search, yank, and motions work as normal
-- One diff engine (`vim.diff()`, histogram) shared by every source
+- One diff engine (`vim.text.diff()`, histogram) shared by every source
 
 ---
 
 ## Requirements
 
-- Neovim 0.10+ (uses `vim.system`, `vim.fs.relpath`, `vim.diff`)
+- Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
 - git on `PATH`
 - A Treesitter parser for the languages you diff (optional)
 - For PR review: Go + make on `PATH`, and `gh` authenticated

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -1,4 +1,4 @@
-*differ.txt*                                                For Neovim >= 0.10
+*differ.txt*                                                For Neovim >= 0.12
 
 ==============================================================================
 Table of Contents                                   *differ-table-of-contents*
@@ -26,14 +26,14 @@ Table of Contents                                   *differ-table-of-contents*
 - 3-way/4-way merge tool, resolved into the working-tree file
 - Word-level highlighting and Treesitter syntax, both on by default
 - Real buffer lines, so search, yank, and motions work as normal
-- One diff engine (`vim.diff()`, histogram) shared by every source
+- One diff engine (`vim.text.diff()`, histogram) shared by every source
 
 ------------------------------------------------------------------------------
 
 ==============================================================================
 2. Requirements                                          *differ-requirements*
 
-- Neovim 0.10+ (uses `vim.system`, `vim.fs.relpath`, `vim.diff`)
+- Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
 - git on `PATH`
 - A Treesitter parser for the languages you diff (optional)
 - For PR review: Go + make on `PATH`, and `gh` authenticated

--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -14,6 +14,10 @@ type cache struct {
 	mu      sync.Mutex
 	blobs   map[string]FileBlob
 	threads map[string][]Thread
+	// bumped on every thread invalidation. a paginating walk captures it up front and
+	// hands it back, so a snapshot assembled before a mutation can't re-seed the cache
+	// after it.
+	threadGen uint64
 }
 
 func newCache() *cache {
@@ -48,9 +52,21 @@ func (c *cache) thread(key string) ([]Thread, bool) {
 	return t, ok
 }
 
-func (c *cache) putThreads(key string, t []Thread) {
+// threadGeneration is captured before a thread walk starts and passed to putThreads.
+func (c *cache) threadGeneration() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.threadGen
+}
+
+// putThreads stores a walk's result unless the cache was invalidated while it ran, in
+// which case the snapshot predates the mutation and is dropped rather than cached.
+func (c *cache) putThreads(key string, t []Thread, gen uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if gen != c.threadGen {
+		return
+	}
 	c.threads[key] = t
 }
 
@@ -61,6 +77,7 @@ func (c *cache) invalidateThreads() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	clear(c.threads)
+	c.threadGen++
 }
 
 func (c *cache) clearAll() {
@@ -68,4 +85,5 @@ func (c *cache) clearAll() {
 	defer c.mu.Unlock()
 	clear(c.blobs)
 	clear(c.threads)
+	c.threadGen++
 }

--- a/internal/github/cache_test.go
+++ b/internal/github/cache_test.go
@@ -91,3 +91,46 @@ func TestClearCacheFlushesBlobs(t *testing.T) {
 		t.Errorf("clear should force a refetch: want 4 content calls, got %d", contentCalls)
 	}
 }
+
+// a mutation invalidating the thread cache mid-pagination must win: the walk in flight
+// assembled its snapshot before the change, so caching it would resurrect the pre-
+// mutation list and hide the new comment for the life of the session.
+func TestInvalidateDuringWalkDropsTheStaleSnapshot(t *testing.T) {
+	var c *Client
+	c = newClient(func(*http.Request) (*http.Response, error) {
+		// invalidate while the walk is mid-flight, as a concurrent mutation would
+		c.cache.invalidateThreads()
+		return resp(200, `{"data":{"repository":{"pullRequest":{"reviewThreads":{`+
+			`"nodes":[{"id":"th_1","path":"a.txt","comments":{"nodes":[]}}],`+
+			`"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`, nil), nil
+	})
+
+	got, err := c.GetThreads(context.Background(), "acme", "widget", 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("the caller still gets the walk's result, got %d", len(got))
+	}
+	if _, ok := c.cache.thread(threadKey("acme", "widget", 7)); ok {
+		t.Error("a snapshot assembled before the invalidation must not be cached")
+	}
+}
+
+// the ordinary path still caches, so the guard hasn't disabled the memo outright
+func TestThreadWalkCachesWhenNothingInvalidates(t *testing.T) {
+	calls := 0
+	c := newClient(func(*http.Request) (*http.Response, error) {
+		calls++
+		return resp(200, `{"data":{"repository":{"pullRequest":{"reviewThreads":{`+
+			`"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`, nil), nil
+	})
+	for i := 0; i < 2; i++ {
+		if _, err := c.GetThreads(context.Background(), "acme", "widget", 7); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("want the second call served from cache, got %d requests", calls)
+	}
+}

--- a/internal/github/dtos.go
+++ b/internal/github/dtos.go
@@ -93,11 +93,10 @@ type threadsGQL struct {
 					StartLine  *int   `json:"startLine"`
 					// where the thread anchored in the diff it was written against.
 					// still present when line/startLine have gone null
-					OriginalLine      *int   `json:"originalLine"`
-					OriginalStartLine *int   `json:"originalStartLine"`
-					DiffSide          string `json:"diffSide"`
-					StartSide         string `json:"startDiffSide"`
-					Comments          struct {
+					OriginalLine *int   `json:"originalLine"`
+					DiffSide     string `json:"diffSide"`
+					StartSide    string `json:"startDiffSide"`
+					Comments     struct {
 						Nodes []commentGQL `json:"nodes"`
 					} `json:"comments"`
 				} `json:"nodes"`
@@ -132,10 +131,8 @@ type pendingReviewGQL struct {
 						Nodes []struct {
 							FullDatabaseID string `json:"fullDatabaseId"`
 							Path           string `json:"path"`
-							DiffSide       string `json:"diffSide"`
 							Line           *int   `json:"line"`
 							StartLine      *int   `json:"startLine"`
-							StartSide      string `json:"startDiffSide"`
 							Body           string `json:"body"`
 						} `json:"nodes"`
 					} `json:"comments"`

--- a/internal/github/dtos.go
+++ b/internal/github/dtos.go
@@ -87,12 +87,17 @@ type threadsGQL struct {
 				Nodes []struct {
 					ID         string `json:"id"`
 					IsResolved bool   `json:"isResolved"`
+					IsOutdated bool   `json:"isOutdated"`
 					Path       string `json:"path"`
 					Line       *int   `json:"line"`
 					StartLine  *int   `json:"startLine"`
-					DiffSide   string `json:"diffSide"`
-					StartSide  string `json:"startDiffSide"`
-					Comments   struct {
+					// where the thread anchored in the diff it was written against.
+					// still present when line/startLine have gone null
+					OriginalLine      *int   `json:"originalLine"`
+					OriginalStartLine *int   `json:"originalStartLine"`
+					DiffSide          string `json:"diffSide"`
+					StartSide         string `json:"startDiffSide"`
+					Comments          struct {
 						Nodes []commentGQL `json:"nodes"`
 					} `json:"comments"`
 				} `json:"nodes"`

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -9,6 +9,19 @@ import (
 	"github.com/undont/differ.nvim/internal/protocol"
 )
 
+// gqlMaxPages bounds every cursor walk, mirroring getPaged's REST cap.
+const gqlMaxPages = 100
+
+// nextCursor reports the cursor to fetch next and whether the walk continues. it stops
+// on the last page, on a null endCursor, and on a cursor that hasn't moved: an empty
+// cursor is omitted from the query variables, so either of those refetches page 1.
+func nextCursor(prev string, info pageInfoGQL) (string, bool) {
+	if !info.HasNextPage || info.EndCursor == "" || info.EndCursor == prev {
+		return "", false
+	}
+	return info.EndCursor, true
+}
+
 // graphql posts a raw GraphQL query (no go-gh, no typed dep) and decodes
 // the data field into out. top-level GraphQL errors map via mapGraphQL even on a
 // 200; HTTP-level failures map via mapHTTP.

--- a/internal/github/prs.go
+++ b/internal/github/prs.go
@@ -64,7 +64,7 @@ func (c *Client) GetPR(ctx context.Context, owner, repo string, number int) (*PR
 	viewed := map[string]string{}
 	var meta prDetailGQL
 	cursor := ""
-	for {
+	for n := 0; n < gqlMaxPages; n++ {
 		var page prDetailGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {
@@ -80,10 +80,11 @@ func (c *Client) GetPR(ctx context.Context, owner, repo string, number int) (*PR
 		for _, n := range files.Nodes {
 			viewed[n.Path] = n.ViewerViewedState
 		}
-		if !files.PageInfo.HasNextPage {
+		next, more := nextCursor(cursor, files.PageInfo)
+		if !more {
 			break
 		}
-		cursor = files.PageInfo.EndCursor
+		cursor = next
 	}
 
 	rawURL := c.restURL + "/repos/" + owner + "/" + repo + "/pulls/" + strconv.Itoa(number) + "/files?per_page=100"

--- a/internal/github/queries.go
+++ b/internal/github/queries.go
@@ -44,9 +44,12 @@ query GetThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String
         nodes {
           id
           isResolved
+          isOutdated
           path
           line
           startLine
+          originalLine
+          originalStartLine
           diffSide
           startDiffSide
           comments(first: 100) {

--- a/internal/github/queries.go
+++ b/internal/github/queries.go
@@ -49,7 +49,6 @@ query GetThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String
           line
           startLine
           originalLine
-          originalStartLine
           diffSide
           startDiffSide
           comments(first: 100) {
@@ -87,10 +86,8 @@ query GetPendingReview($owner: String!, $repo: String!, $number: Int!) {
             nodes {
               fullDatabaseId
               path
-              diffSide
               line
               startLine
-              startDiffSide
               body
             }
           }

--- a/internal/github/read_test.go
+++ b/internal/github/read_test.go
@@ -205,7 +205,7 @@ func TestGetThreadsPagination(t *testing.T) {
 func TestGetPendingReview(t *testing.T) {
 	body := `{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[
       {"id":"REVIEW_1","comments":{"nodes":[
-        {"fullDatabaseId":"5001","path":"a.go","diffSide":"RIGHT","line":10,"startLine":null,"startDiffSide":null,"body":"draft"}
+        {"fullDatabaseId":"5001","path":"a.go","line":10,"startLine":null,"body":"draft"}
       ]}}
     ]}}}}}`
 	c := newClient(func(*http.Request) (*http.Response, error) {
@@ -218,8 +218,13 @@ func TestGetPendingReview(t *testing.T) {
 	if pr.ReviewID == nil || *pr.ReviewID != "REVIEW_1" {
 		t.Fatalf("review id wrong: %+v", pr.ReviewID)
 	}
-	if len(pr.Comments) != 1 || pr.Comments[0].ID != 5001 || pr.Comments[0].Side != "RIGHT" || pr.Comments[0].Body != "draft" {
+	if len(pr.Comments) != 1 || pr.Comments[0].ID != 5001 || pr.Comments[0].Body != "draft" {
 		t.Errorf("draft comment wrong: %+v", pr.Comments)
+	}
+	// PullRequestReviewComment has no diffSide; asking for one made the whole query
+	// invalid, so the fixture must not carry a field GitHub cannot return
+	if pr.Comments[0].Line != 10 || pr.Comments[0].Side != "" {
+		t.Errorf("draft anchor wrong: %+v", pr.Comments[0])
 	}
 }
 

--- a/internal/github/results.go
+++ b/internal/github/results.go
@@ -59,16 +59,21 @@ type FileBlob struct {
 // operates on. Side/StartSide are LEFT/RIGHT; StartSide/StartLine are set
 // only on range threads. IsPending is true for an unsubmitted draft thread.
 type Thread struct {
-	ID        int64           `json:"id"`
-	ThreadID  string          `json:"thread_id"`
-	Path      string          `json:"path"`
-	Side      string          `json:"side"`
-	Line      int             `json:"line"`
-	StartSide string          `json:"start_side,omitempty"`
-	StartLine int             `json:"start_line,omitempty"`
-	Resolved  bool            `json:"resolved"`
-	IsPending bool            `json:"is_pending"`
-	Comments  []ThreadComment `json:"comments"`
+	ID        int64  `json:"id"`
+	ThreadID  string `json:"thread_id"`
+	Path      string `json:"path"`
+	Side      string `json:"side"`
+	Line      int    `json:"line"`
+	StartSide string `json:"start_side,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+	// github nulls line/start_line once a thread's anchor leaves the diff. outdated says
+	// so explicitly, and original_line carries where it used to sit, so the client can
+	// place it deliberately rather than reading the zero as line 0
+	Outdated     bool            `json:"outdated"`
+	OriginalLine int             `json:"original_line,omitempty"`
+	Resolved     bool            `json:"resolved"`
+	IsPending    bool            `json:"is_pending"`
+	Comments     []ThreadComment `json:"comments"`
 }
 
 // ThreadComment is one comment in a Thread. ID is the numeric comment id; NodeID is

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -15,6 +15,9 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 	if t, ok := c.cache.thread(key); ok {
 		return t, nil
 	}
+	// captured before the walk: an invalidation landing mid-pagination must win over the
+	// snapshot this walk is assembling
+	gen := c.cache.threadGeneration()
 	out := []Thread{} // non-nil so an empty PR marshals to [] (null would decode to vim.NIL)
 	cursor := ""
 	for n := 0; n < gqlMaxPages; n++ {
@@ -61,7 +64,7 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 		}
 		cursor = next
 	}
-	c.cache.putThreads(key, out)
+	c.cache.putThreads(key, out, gen)
 	return out, nil
 }
 

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -17,7 +17,7 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 	}
 	out := []Thread{} // non-nil so an empty PR marshals to [] (null would decode to vim.NIL)
 	cursor := ""
-	for {
+	for n := 0; n < gqlMaxPages; n++ {
 		var page threadsGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {
@@ -55,10 +55,11 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 			}
 			out = append(out, t)
 		}
-		if !threads.PageInfo.HasNextPage {
+		next, more := nextCursor(cursor, threads.PageInfo)
+		if !more {
 			break
 		}
-		cursor = threads.PageInfo.EndCursor
+		cursor = next
 	}
 	c.cache.putThreads(key, out)
 	return out, nil

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -87,12 +87,12 @@ func (c *Client) GetPendingReview(ctx context.Context, owner, repo string, numbe
 	id := r.ID
 	out := &PendingReview{ReviewID: &id}
 	for _, cm := range r.Comments.Nodes {
+		// PullRequestReviewComment carries no diff side, so Side/StartSide stay empty
+		// here; a draft's side is only available through the thread it belongs to
 		out.Comments = append(out.Comments, PendingComment{
 			ID:        parseID(cm.FullDatabaseID),
 			Path:      cm.Path,
-			Side:      cm.DiffSide,
 			Line:      deref(cm.Line),
-			StartSide: cm.StartSide,
 			StartLine: deref(cm.StartLine),
 			Body:      cm.Body,
 		})

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -32,14 +32,16 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 		threads := page.Repository.PullRequest.ReviewThreads
 		for _, n := range threads.Nodes {
 			t := Thread{
-				ThreadID:  n.ID,
-				Path:      n.Path,
-				Side:      n.DiffSide,
-				Line:      deref(n.Line),
-				StartSide: n.StartSide,
-				StartLine: deref(n.StartLine),
-				Resolved:  n.IsResolved,
-				Comments:  make([]ThreadComment, 0, len(n.Comments.Nodes)),
+				ThreadID:     n.ID,
+				Path:         n.Path,
+				Side:         n.DiffSide,
+				Line:         deref(n.Line),
+				StartSide:    n.StartSide,
+				StartLine:    deref(n.StartLine),
+				Outdated:     n.IsOutdated,
+				OriginalLine: deref(n.OriginalLine),
+				Resolved:     n.IsResolved,
+				Comments:     make([]ThreadComment, 0, len(n.Comments.Nodes)),
 			}
 			for _, cm := range n.Comments.Nodes {
 				t.Comments = append(t.Comments, ThreadComment{

--- a/internal/github/threads_test.go
+++ b/internal/github/threads_test.go
@@ -54,3 +54,73 @@ func TestResolveThreadMapsGraphQLError(t *testing.T) {
 		t.Fatalf("want not_found, got %v", err)
 	}
 }
+
+// a page that claims hasNextPage while handing back a null (or unmoved) endCursor
+// drops the cursor from the variables, so the walk refetches page 1 and never ends.
+// each loop has to stop on cursor progress, not on hasNextPage alone.
+func TestGraphQLPaginationStopsWithoutCursorProgress(t *testing.T) {
+	cases := []struct {
+		name string
+		// a null cursor stops on the first page; a repeated one only reveals itself on
+		// the second, where the walk sees the cursor it already used
+		wantCalls int
+		body      func() string
+		call      func(c *Client) error
+	}{
+		{
+			name:      "threads/null cursor",
+			wantCalls: 1,
+			body: func() string {
+				return `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],` +
+					`"pageInfo":{"hasNextPage":true,"endCursor":null}}}}}}`
+			},
+			call: func(c *Client) error {
+				_, err := c.GetThreads(context.Background(), "acme", "widget", 7)
+				return err
+			},
+		},
+		{
+			name:      "threads/stuck cursor",
+			wantCalls: 2,
+			body: func() string {
+				return `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],` +
+					`"pageInfo":{"hasNextPage":true,"endCursor":"SAME"}}}}}}`
+			},
+			call: func(c *Client) error {
+				_, err := c.GetThreads(context.Background(), "acme", "widget", 7)
+				return err
+			},
+		},
+		{
+			name:      "timeline/null cursor",
+			wantCalls: 1,
+			body: func() string {
+				return `{"data":{"repository":{"pullRequest":{"comments":{"nodes":[],` +
+					`"pageInfo":{"hasNextPage":true,"endCursor":null}},"reviews":{"nodes":[]}}}}}`
+			},
+			call: func(c *Client) error {
+				_, err := c.GetTimeline(context.Background(), "acme", "widget", 7)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			c := newClient(func(r *http.Request) (*http.Response, error) {
+				calls++
+				if calls > gqlMaxPages+1 {
+					t.Fatalf("pagination did not terminate: %d requests", calls)
+				}
+				return resp(200, tc.body(), nil), nil
+			})
+			if err := tc.call(c); err != nil {
+				t.Fatal(err)
+			}
+			if calls != tc.wantCalls {
+				t.Errorf("want %d requests before the walk stops, got %d", tc.wantCalls, calls)
+			}
+		})
+	}
+}

--- a/internal/github/timeline.go
+++ b/internal/github/timeline.go
@@ -10,7 +10,7 @@ import "context"
 func (c *Client) GetTimeline(ctx context.Context, owner, repo string, number int) (*Timeline, error) {
 	out := &Timeline{Comments: []TimelineComment{}, Reviews: []ReviewSummary{}}
 	cursor := ""
-	for {
+	for n := 0; n < gqlMaxPages; n++ {
 		var page timelineGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {
@@ -39,10 +39,11 @@ func (c *Client) GetTimeline(ctx context.Context, owner, repo string, number int
 				})
 			}
 		}
-		if !pr.Comments.PageInfo.HasNextPage {
+		next, more := nextCursor(cursor, pr.Comments.PageInfo)
+		if !more {
 			break
 		}
-		cursor = pr.Comments.PageInfo.EndCursor
+		cursor = next
 	}
 	return out, nil
 }

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -1360,8 +1360,8 @@ function M.panel(opts)
             if watcher then
                 watcher:stop()
             end
-            if view and view:is_open() then
-                view:close()
+            if view then
+                view:close() -- idempotent, and :q leaves the window already gone
             end
             close_session_tab(session_tab)
         end,
@@ -1492,8 +1492,8 @@ function M.history(opts)
             end
         end,
         on_close = function()
-            if view and view:is_open() then
-                view:close()
+            if view then
+                view:close() -- idempotent, and :q leaves the window already gone
             end
             close_session_tab(session_tab)
         end,
@@ -1563,8 +1563,8 @@ function M.range_history(opts)
             end
         end,
         on_close = function()
-            if view and view:is_open() then
-                view:close()
+            if view then
+                view:close() -- idempotent, and :q leaves the window already gone
             end
             close_session_tab(session_tab)
         end,

--- a/lua/differ/pr/checks.lua
+++ b/lua/differ/pr/checks.lua
@@ -150,6 +150,9 @@ end
 ---@param session table  -- the live pr session ({ pr = { owner, repo, number } })
 function M.show(session)
     client.get_checks(session.pr, function(err, checks)
+        if not require("differ.pr.guard").owns(session) then
+            return -- session torn down (or replaced) while the fetch was in flight
+        end
         if err then
             return require("differ.pr").notify_err(err)
         end

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -192,8 +192,9 @@ function M.delete(session)
         if err then
             return require("differ.pr").notify_err(err)
         end
-        session.threads = nil
-        require("differ.pr.threads").refresh(session)
+        local threads = require("differ.pr.threads")
+        threads.invalidate(session)
+        threads.refresh(session)
         notify(root and "thread deleted" or "comment deleted")
     end)
 end
@@ -278,8 +279,9 @@ function M.post(session, opts, body)
         end
         -- the sidecar invalidated its thread cache on the post, so a fresh fetch carries
         -- the new comment (right author/draft state, correct thread grouping)
-        session.threads = nil
-        require("differ.pr.threads").refresh(session)
+        local threads = require("differ.pr.threads")
+        threads.invalidate(session)
+        threads.refresh(session)
         notify(session.review_id and "comment added to your review draft" or "comment posted")
     end)
 end

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -6,6 +6,7 @@
 -- without nvim; compose/post own the vim + IPC surface
 
 local client = require("differ.pr.client")
+local guard = require("differ.pr.guard")
 
 local M = {}
 
@@ -175,8 +176,8 @@ function M.delete(session)
         return
     end
     client.delete_comment(session.pr, target.node_id, function(err, _)
-        if not (session and session.view and session.view:is_open()) then
-            return -- session torn down while the delete was in flight
+        if not guard.owns(session) then
+            return -- session torn down (or replaced) while the delete was in flight
         end
         if err then
             return require("differ.pr").notify_err(err)
@@ -233,8 +234,8 @@ function M.post(session, opts, body)
         args.review_id = session.review_id
     end
     client.post_comment(session.pr, args, function(err, res)
-        if not (session and session.view and session.view:is_open()) then
-            return -- session torn down while the post was in flight
+        if not guard.owns(session) then
+            return -- session torn down (or replaced) while the post was in flight
         end
         if err then
             if err.code == "conflict" then

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -100,6 +100,16 @@ local function active_column(session)
     end
 end
 
+-- the file the gesture was made against. the compose window is a real split, so the
+-- diff can move (or close) before the body is submitted; the anchor's path is fixed
+-- at the same instant as its side/line
+---@param session table
+---@return string|nil
+local function gesture_path(session)
+    local model = session.view and session.view.model
+    return model and model.path
+end
+
 -- ga (normal): comment on the line under the cursor
 ---@param session table
 function M.comment(session)
@@ -112,7 +122,7 @@ function M.comment(session)
     if not anchor then
         return notify(err or "no commentable line here")
     end
-    M.compose(session, { anchor = anchor, anchor_win = win })
+    M.compose(session, { anchor = anchor, anchor_win = win, path = gesture_path(session) })
 end
 
 -- ga (visual): comment on the selected range. reads the visual marks before leaving
@@ -130,7 +140,7 @@ function M.comment_range(session)
     if not anchor then
         return notify(err or "no commentable line here")
     end
-    M.compose(session, { anchor = anchor, anchor_win = win })
+    M.compose(session, { anchor = anchor, anchor_win = win, path = gesture_path(session) })
 end
 
 -- gp: reply to the thread under the cursor (its node id, from slice 3's overlay index)
@@ -190,12 +200,21 @@ end
 
 -- ── compose + post ────────────────────────────────────────────────────────────────
 
+-- where a comment attaches, and how it composes. anchor + path address a new thread and
+-- are fixed together at gesture time; in_reply_to addresses an existing one instead
+---@class differ.pr.CommentOpts
+---@field anchor table|nil  -- { side, line } or a range's { start_side, start_line, side, line }
+---@field path string|nil  -- the file the anchor is against
+---@field anchor_win integer|nil  -- diff window the compose split opens below
+---@field in_reply_to string|nil  -- thread node id, in place of anchor + path
+---@field initial string|nil  -- pre-filled body (the conflict re-prompt)
+---@field stale boolean|nil  -- the head moved under the original anchor
+
 -- open the compose float for `opts` (a gesture anchor, or a reply target). the title
 -- names the mode so a live post is never mistaken for a draft: draft when a review is
--- active, "posts immediately" otherwise. opts.initial pre-fills the body (the
--- conflict re-prompt), opts.stale flags the head moved
+-- active, "posts immediately" otherwise
 ---@param session table
----@param opts { anchor?: table, anchor_win?: integer, in_reply_to?: string, initial?: string, stale?: boolean }
+---@param opts differ.pr.CommentOpts
 function M.compose(session, opts)
     local base = opts.in_reply_to and "Reply"
         or (session.review_id and "Comment (draft)" or "Comment (posts immediately)")
@@ -218,7 +237,7 @@ end
 -- guard, then re-fetch threads on success so the new comment renders authoritatively.
 -- a conflict means the head moved: refresh + re-anchor + re-prompt, never a silent post
 ---@param session table
----@param opts table
+---@param opts differ.pr.CommentOpts
 ---@param body string
 function M.post(session, opts, body)
     local args = { body = body, expected_head = session.pr_meta.head_sha }
@@ -226,7 +245,10 @@ function M.post(session, opts, body)
         args.in_reply_to = opts.in_reply_to
     else
         local a = opts.anchor
-        args.path = session.view.model.path
+        if not opts.path then
+            return notify("lost track of the file this comment anchors to; nothing posted")
+        end
+        args.path = opts.path
         args.side, args.line = a.side, a.line
         args.start_side, args.start_line = a.start_side, a.start_line
     end

--- a/lua/differ/pr/guard.lua
+++ b/lua/differ/pr/guard.lua
@@ -1,0 +1,23 @@
+-- session guards for the async pr callbacks: identity gates state reconciliation,
+-- window validity gates ui touches. a nil'd view or a hidden sidebar is still a live
+-- session (the overview hop does both), so the two questions answer separately
+
+local M = {}
+
+-- the session that issued the call is still the live one. what state reconciliation
+-- gates on, since it has to run whether or not any window survived
+---@param s table|nil
+---@return boolean
+function M.owns(s)
+    return s ~= nil and require("differ.pr").current_session() == s
+end
+
+-- ours, and the sidebar buffer is still there to repaint: hide() drops the window,
+-- :close wipes the buffer
+---@param s table|nil
+---@return boolean
+function M.panel_alive(s)
+    return s ~= nil and M.owns(s) and s.panel ~= nil and s.panel:is_alive()
+end
+
+return M

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -443,7 +443,7 @@ function M.handle_conflict(on_ready)
         s.pr_meta.head_sha = detail.head_sha
         s.pr_meta.head_ref = detail.head_ref
         s.versions = {} -- the blob memo was pinned to the old shas
-        s.threads = nil -- re-fetch threads against the fresh head
+        require("differ.pr.threads").invalidate(s) -- refetch against the fresh head
         -- the memo drop above is the reconciliation; re-sourcing is a ui touch, so it
         -- waits on a visible sidebar and a hidden one just refetches on re-entry
         local cur = s.panel:is_open() and s.panel:current_entry()

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -127,28 +127,29 @@ end
 local LOOKAHEAD = 1
 ---@param entry differ.FileEntry
 local function prefetch_around(entry)
-    if not session then
+    local s = session
+    if not s then
         return
     end
-    local idx = viewed.index_of(session.entries, entry)
+    local idx = viewed.index_of(s.entries, entry)
     if not idx then
         return
     end
-    session.prefetching = session.prefetching or {}
+    s.prefetching = s.prefetching or {}
     for _, dir in ipairs({ -1, 1 }) do
         for step = 1, LOOKAHEAD do
-            local nb = session.entries[idx + dir * step]
-            if nb and not session.versions[nb.path] and not session.prefetching[nb.path] then
+            local nb = s.entries[idx + dir * step]
+            if nb and not s.versions[nb.path] and not s.prefetching[nb.path] then
                 local path = nb.path
-                session.prefetching[path] = true
-                local refs = { base = session.pr_meta.base_sha, head = session.pr_meta.head_sha }
-                client.get_file_versions(session.pr, path, refs, function(err, vers)
-                    if not session then
-                        return -- session torn down while the prefetch was in flight
+                s.prefetching[path] = true
+                local refs = { base = s.pr_meta.base_sha, head = s.pr_meta.head_sha }
+                client.get_file_versions(s.pr, path, refs, function(err, vers)
+                    if not guard.owns(s) then
+                        return -- session torn down (or replaced) while it was in flight
                     end
-                    session.prefetching[path] = nil
+                    s.prefetching[path] = nil
                     if not err and vers then
-                        session.versions[path] = vers
+                        s.versions[path] = vers
                     end
                 end)
             end
@@ -612,13 +613,14 @@ end
 -- guard on the string type
 ---@param pr { owner: string, repo: string, number: integer }
 local function adopt_pending_review(pr)
+    local s = session
     client.get_pending_review(pr, function(err, res)
-        if err or not (session and session.pr == pr) then
+        if err or not guard.owns(s) then
             return -- fetch failed, or the session was replaced/closed meanwhile
         end
         local review_id = res and res.review_id
         if type(review_id) == "string" and review_id ~= "" then
-            session.review_id = review_id
+            s.review_id = review_id
             notify(
                 "you have a pending review here - comments are drafts (:Differ pr review resume to manage)"
             )
@@ -1145,16 +1147,17 @@ function M.set_state(verb)
         return notify("unknown lifecycle verb: " .. tostring(verb), vim.log.levels.WARN)
     end
     local function run()
-        client.set_pr_state(session.pr, state, function(err, res)
-            if not session then
-                return -- session torn down while the mutation was in flight
+        local s = session
+        client.set_pr_state(s.pr, state, function(err, res)
+            if not guard.owns(s) then
+                return -- session torn down (or replaced) while the mutation was in flight
             end
             if err then
                 return notify_err(err)
             end
             local new_state = (res and res.state) or state
-            session.pr_meta.state = new_state
-            session.pr_meta.draft = new_state == "draft"
+            s.pr_meta.state = new_state
+            s.pr_meta.draft = new_state == "draft"
             notify("pull request " .. new_state)
         end)
     end

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -18,6 +18,11 @@ local M = {}
 ---@type table|nil
 local session = nil
 
+-- monotonic open token. two `:Differ pr` opens in flight together resolve in whatever
+-- order github answers, and response time scales with the file list, so the larger PR
+-- can land last; only the most recent open is allowed to build a session
+local open_gen = 0
+
 ---@param msg string
 ---@param level integer|nil
 local function notify(msg, level)
@@ -876,7 +881,12 @@ end
 ---@param pr { owner: string, repo: string, number: integer }
 ---@param opts { after?: fun(), land?: string, review?: boolean }|nil
 function M.show(pr, opts)
+    open_gen = open_gen + 1
+    local gen = open_gen
     client.get_pr(pr, function(err, detail)
+        if gen ~= open_gen then
+            return -- a later open superseded this one; its error isn't the user's problem
+        end
         if err then
             return notify_err(err)
         end

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -7,6 +7,7 @@
 
 local repo = require("differ.pr.repo")
 local client = require("differ.pr.client")
+local guard = require("differ.pr.guard")
 local viewed = require("differ.pr.viewed")
 
 local M = {}
@@ -231,14 +232,18 @@ local function show_file(entry, focus_line)
     -- the pinned shas skip the sidecar's prRefs round-trip (latency discipline)
     local refs = { base = session.pr_meta.base_sha, head = session.pr_meta.head_sha }
     client.get_file_versions(session.pr, entry.path, refs, function(err, vers)
+        if not guard.owns(s) then
+            return -- session torn down (or replaced) while the blob was in flight
+        end
         if err then
             return notify_err(err)
         end
-        if session ~= s or not (s.panel and s.panel:is_open()) then
-            return -- session torn down (or replaced) while the blob was in flight
-        end
+        -- the memo is keyed on pinned shas, so it stands whether or not the panel is
+        -- showing; only the render waits on a visible sidebar (the overview hop hides it)
         s.versions[entry.path] = vers
-        render(vers)
+        if s.panel and s.panel:is_open() then
+            render(vers)
+        end
     end)
 end
 
@@ -251,23 +256,24 @@ local function mark_viewed(entry, target)
     if not (session and session.panel) or entry.viewed == target then
         return
     end
+    local s = session
     local prev = entry.viewed
     entry.viewed = target
-    session.panel:repaint()
-    client.set_file_viewed(session.pr, entry.path, target, function(err, res)
-        if not (session and session.panel and session.panel:is_open()) then
-            return -- session torn down while the mutation was in flight
+    s.panel:repaint()
+    client.set_file_viewed(s.pr, entry.path, target, function(err, res)
+        if not guard.owns(s) then
+            return -- session torn down (or replaced) while the mutation was in flight
         end
         if err then
             entry.viewed = prev
-            session.panel:repaint()
+            s.panel:repaint()
             return notify_err(err)
         end
         -- reconcile: DISMISSED counts as viewed, like map_files
         local server = res and (res.viewed_state == "VIEWED" or res.viewed_state == "DISMISSED")
         if server ~= nil and server ~= entry.viewed then
             entry.viewed = server
-            session.panel:repaint()
+            s.panel:repaint()
         end
     end)
 end
@@ -395,17 +401,17 @@ function M.resolve()
     target.resolved = new_state
     threads.apply(s)
     client.resolve_thread(s.pr, target.thread_id, new_state, function(err, res)
-        if not (session and session.view and session.view:is_open()) then
-            return -- session torn down while the mutation was in flight
+        if not guard.owns(s) then
+            return -- session torn down (or replaced) while the mutation was in flight
         end
         if err then
             target.resolved = not new_state
-            threads.apply(session)
+            threads.apply(s)
             return notify_err(err)
         end
         if res and res.resolved ~= nil and res.resolved ~= target.resolved then
             target.resolved = res.resolved
-            threads.apply(session)
+            threads.apply(s)
         end
     end)
 end
@@ -419,19 +425,22 @@ function M.handle_conflict(on_ready)
     if not (session and session.panel) then
         return
     end
-    client.get_pr(session.pr, function(err, detail)
-        if not (session and session.panel and session.panel:is_open()) then
-            return
+    local s = session
+    client.get_pr(s.pr, function(err, detail)
+        if not guard.owns(s) then
+            return -- session torn down (or replaced) while the refetch was in flight
         end
         if err then
             return notify_err(err)
         end
-        session.pr_meta.base_sha = detail.base_sha
-        session.pr_meta.head_sha = detail.head_sha
-        session.pr_meta.head_ref = detail.head_ref
-        session.versions = {} -- the blob memo was pinned to the old shas
-        session.threads = nil -- re-fetch threads against the fresh head
-        local cur = session.panel:current_entry()
+        s.pr_meta.base_sha = detail.base_sha
+        s.pr_meta.head_sha = detail.head_sha
+        s.pr_meta.head_ref = detail.head_ref
+        s.versions = {} -- the blob memo was pinned to the old shas
+        s.threads = nil -- re-fetch threads against the fresh head
+        -- the memo drop above is the reconciliation; re-sourcing is a ui touch, so it
+        -- waits on a visible sidebar and a hidden one just refetches on re-entry
+        local cur = s.panel:is_open() and s.panel:current_entry()
         if cur then
             show_file(cur) -- re-source the diff + overlay at the new head
         end
@@ -1099,9 +1108,10 @@ function M.merge(method_arg)
         if not session then
             return
         end
-        client.merge_pr(session.pr, { method = method }, function(err, res)
-            if not session then
-                return -- session torn down while the merge was in flight
+        local s = session
+        client.merge_pr(s.pr, { method = method }, function(err, res)
+            if not guard.owns(s) then
+                return -- session torn down (or replaced) while the merge was in flight
             end
             if err then
                 if err.code == "conflict" then
@@ -1114,9 +1124,9 @@ function M.merge(method_arg)
             end
             local sha = res and res.sha
             notify(("merged" .. (sha and (" (" .. short(sha) .. ")") or "")))
-            session.pr_meta.state = "merged"
-            if session.panel and session.panel:is_open() then
-                session.panel:close() -- the PR is merged; end the session
+            s.pr_meta.state = "merged"
+            if guard.panel_alive(s) then
+                s.panel:close() -- the PR is merged; end the session
             end
         end)
     end)

--- a/lua/differ/pr/overview.lua
+++ b/lua/differ/pr/overview.lua
@@ -75,9 +75,16 @@ function M.owns_buffer(b)
     return b ~= nil and vim.api.nvim_buf_is_valid(b) and vim.api.nvim_buf_get_name(b) == BUFNAME
 end
 
+-- monotonic page token. a page render is several async hops long, and the session can
+-- leave the page while they run: entering the files disarms, and render would otherwise
+-- take the window back, close the diff just built and hide the panel
+local page_gen = 0
+
 -- drop the navigate-away guard. the page window becomes the diff's on entry, so the
--- guard must not fire when the view repurposes it
+-- guard must not fire when the view repurposes it, and any render still in flight is
+-- for a surface the session has already left
 function M.disarm()
+    page_gen = page_gen + 1
     pcall(vim.api.nvim_del_augroup_by_name, GUARD)
 end
 
@@ -367,9 +374,16 @@ function M.open(session)
     if not session then
         return require("differ.pr").notify("open a PR first")
     end
+    -- claim the page: a later open supersedes this one, and so does entering the files
+    page_gen = page_gen + 1
+    local gen = page_gen
+    ---@return boolean
+    local function ours()
+        return still_live(session) and page_gen == gen
+    end
     client.get_timeline(session.pr, function(err, tl)
-        if not still_live(session) then
-            return -- session torn down while the timeline was in flight
+        if not ours() then
+            return -- session torn down, or it left the page, while the timeline was in flight
         end
         if err then
             return require("differ.pr").notify_err(err)
@@ -380,7 +394,7 @@ function M.open(session)
             reviews = type(tl) == "table" and type(tl.reviews) == "table" and tl.reviews or {},
         }
         require("differ.pr.threads").ensure(session, function()
-            if not still_live(session) then
+            if not ours() then
                 return
             end
             if session.checks then
@@ -389,7 +403,9 @@ function M.open(session)
             -- no cached checks: fetch once, cache on the session, then render (degrade
             -- to nil if the fetch fails — the rollup line just reads "n/a")
             client.get_checks(session.pr, function(cerr, checks)
-                if not still_live(session) then
+                -- the checks fetch is the longest hop, so this is the likeliest place to
+                -- find the session already in the files
+                if not ours() then
                     return
                 end
                 if not cerr and type(checks) == "table" then

--- a/lua/differ/pr/review.lua
+++ b/lua/differ/pr/review.lua
@@ -19,7 +19,7 @@ end
 -- sidecar invalidates its thread cache on each mutation)
 ---@param session table
 local function repaint_threads(session)
-    session.threads = nil
+    require("differ.pr.threads").invalidate(session)
     require("differ.pr.threads").refresh(session)
 end
 

--- a/lua/differ/pr/review.lua
+++ b/lua/differ/pr/review.lua
@@ -5,6 +5,7 @@
 -- and reacts to a conflict by refreshing rather than auto-retrying
 
 local client = require("differ.pr.client")
+local guard = require("differ.pr.guard")
 
 local M = {}
 
@@ -12,13 +13,6 @@ local M = {}
 ---@param level integer|nil
 local function notify(msg, level)
     vim.notify("differ: " .. msg, level or vim.log.levels.INFO)
-end
-
--- a session is still live (panel open) when an async mutation returns
----@param session table
----@return boolean
-local function alive(session)
-    return session ~= nil and session.view ~= nil and session.view:is_open()
 end
 
 -- re-fetch threads so the overlay reflects a draft/submit/discard authoritatively (the
@@ -51,7 +45,7 @@ function M.start(session, opts)
         return M.reattach(session, opts)
     end
     client.start_review(session.pr, function(err, res)
-        if not alive(session) then
+        if not guard.owns(session) then
             return
         end
         if err then
@@ -71,7 +65,7 @@ end
 ---@param opts { jump?: boolean }|nil
 function M.reattach(session, opts)
     client.get_pending_review(session.pr, function(err, res)
-        if not alive(session) then
+        if not guard.owns(session) then
             return
         end
         if err then
@@ -132,7 +126,7 @@ function M._do_submit(session, event, body)
         body = body,
         expected_head = session.pr_meta.head_sha,
     }, function(err, _)
-        if not alive(session) then
+        if not guard.owns(session) then
             return
         end
         if err then
@@ -162,7 +156,7 @@ function M.discard(session)
         return
     end
     client.discard_review(session.pr, session.review_id, function(err, _)
-        if not alive(session) then
+        if not guard.owns(session) then
             return
         end
         if err then

--- a/lua/differ/pr/threads.lua
+++ b/lua/differ/pr/threads.lua
@@ -312,38 +312,66 @@ function M.apply_box(session, view, g, reltime)
     })
 end
 
--- ensure the PR's threads are fetched (once, PR-wide), then run cb(err). callers
--- while a fetch is in flight queue behind it; a fetch error notifies once and runs
--- the queue with the error (threads stay nil, so the additive surfaces degrade and a
--- later ensure retries). the overview and the diff overlay share this, so landing on
--- either warms the other
+-- drop the fetched thread list so the next ensure refetches. the generation bump is
+-- what stops a fetch already in flight from being joined, or from landing its
+-- pre-mutation list on top of the change that invalidated it
+---@param session table
+function M.invalidate(session)
+    session.threads = nil
+    session.threads_gen = (session.threads_gen or 0) + 1
+end
+
+-- settle the fetch that started at `gen`: store its list, then run everyone queued
+-- behind it. an error notifies once and leaves threads nil, so the additive surfaces
+-- degrade and a later ensure retries
+---@param session table
+---@param gen integer
+---@param err table|nil
+---@param list any
+local function deliver(session, gen, err, list)
+    if require("differ.pr").current_session() ~= session then
+        return -- session torn down (or replaced) while the fetch was in flight
+    end
+    if session.threads_fetch_gen ~= gen then
+        return -- invalidated meanwhile; the fresh fetch owns the waiters now
+    end
+    local waiters = session.threads_waiters or {}
+    session.threads_waiters = nil
+    if err then
+        require("differ.pr").notify_err(err)
+    else
+        -- a PR with no threads decodes to vim.NIL (userdata, truthy), so guard on
+        -- type rather than `list or {}`
+        session.threads = type(list) == "table" and list or {}
+    end
+    for _, fn in ipairs(waiters) do
+        fn(err)
+    end
+end
+
+-- ensure the PR's threads are fetched (once, PR-wide), then run cb(err). callers while
+-- a fetch is in flight queue behind it. the overview and the diff overlay share this,
+-- so landing on either warms the other
 ---@param session table
 ---@param cb fun(err: table|nil)
 function M.ensure(session, cb)
     if session.threads then
         return cb(nil)
     end
-    if session.threads_waiters then
+    local gen = session.threads_gen or 0
+    -- only a fetch started under the current generation may be shared; one issued before
+    -- an invalidation is carrying a pre-mutation list, so joining it would miss the change
+    if session.threads_waiters and session.threads_fetch_gen == gen then
         table.insert(session.threads_waiters, cb)
         return
     end
-    session.threads_waiters = { cb }
+    -- a superseded fetch's waiters still want an answer, so they roll onto this one
+    local queued = session.threads_waiters or {}
+    queued[#queued + 1] = cb
+    session.threads_waiters = queued
+    session.threads_fetch_gen = gen
     client.get_threads(session.pr, function(err, list)
-        if require("differ.pr").current_session() ~= session then
-            return -- session torn down (or replaced) while the fetch was in flight
-        end
-        local waiters = session.threads_waiters or {}
-        session.threads_waiters = nil
-        if err then
-            require("differ.pr").notify_err(err)
-        else
-            -- a PR with no threads decodes to vim.NIL (userdata, truthy), so guard on
-            -- type rather than `list or {}`
-            session.threads = type(list) == "table" and list or {}
-        end
-        for _, fn in ipairs(waiters) do
-            fn(err)
-        end
+        deliver(session, gen, err, list)
     end)
 end
 

--- a/lua/differ/pr/threads.lua
+++ b/lua/differ/pr/threads.lua
@@ -31,11 +31,17 @@ end
 
 -- the derived buffer row for source line `line` in `index` (a from_old/from_new map).
 -- an out-of-context anchor (no exact key) degrades to the nearest rendered line rather
--- than being dropped; nil only when nothing is rendered on that side
+-- than being dropped; nil only when nothing is rendered on that side, or when `line` is
+-- not a real line number. degrading is for a near miss, so a thread with no anchor at
+-- all (github nulls the line once it leaves the diff, and the wire carries 0) is
+-- refused rather than dragged to whichever row happens to be lowest
 ---@param index table<integer, integer>
----@param line integer
+---@param line integer|nil
 ---@return integer|nil
 function M.anchor_row(index, line)
+    if type(line) ~= "number" or line < 1 then
+        return nil
+    end
     if index[line] then
         return index[line]
     end
@@ -47,6 +53,18 @@ function M.anchor_row(index, line)
         end
     end
     return best_row
+end
+
+-- the source line a thread anchors by. github nulls `line` once the anchor leaves the
+-- diff (the wire carries 0), and original_line is then the only record of where it sat,
+-- so an outdated thread falls back to that: near where it was written, or nowhere
+---@param t table
+---@return integer|nil
+function M.anchor_line(t)
+    local function real(n)
+        return type(n) == "number" and n >= 1 and n or nil
+    end
+    return real(t.line) or real(t.original_line)
 end
 
 -- a thread's ordering key: its first comment's creation time. ISO-8601/RFC3339 UTC
@@ -172,7 +190,7 @@ function M.apply(session)
             local side = M.side_of(t)
             local col = view:column_for(side)
             local index = col and (side == "old" and col.map.from_old or col.map.from_new)
-            local row = index and M.anchor_row(index, t.line)
+            local row = index and M.anchor_row(index, M.anchor_line(t))
             if col and row then
                 local key = col.bufnr .. ":" .. row
                 groups[key] = groups[key]

--- a/lua/differ/sidecar/init.lua
+++ b/lua/differ/sidecar/init.lua
@@ -10,6 +10,10 @@ local PROTOCOL = 1
 local BASE_BACKOFF_MS = 200
 local MAX_BACKOFF_MS = 8000
 local MAX_ATTEMPTS = 5
+-- ceiling on one request. the Go client's 30s timeout is per HTTP call, so a handler
+-- that paginates (or never returns) outlives it; generous enough for a large PR's file
+-- walk, since firing early would fail a request that was going to succeed
+local REQUEST_TIMEOUT_MS = 60000
 
 local M = {}
 
@@ -20,7 +24,7 @@ local M = {}
 ---@field ready boolean        -- hello handshake completed
 ---@field stopping boolean     -- intentional stop; suppress restart
 ---@field next_id integer
----@field pending table<integer, fun(err: table|nil, result: any)>
+---@field pending table<integer, { cb: fun(err: table|nil, result: any), timer: any }>
 ---@field queue { method: string, params: any, cb: fun(err: table|nil, result: any) }[]
 ---@field stdout_buf string
 ---@field attempts integer     -- consecutive restart attempts (backoff)
@@ -82,14 +86,53 @@ local function send(obj)
     end
 end
 
+-- take a pending entry off the map and disarm its timer, returning its callback for the
+-- caller to run. nil when the id already went (a response racing its own timeout).
+local function take(id)
+    local entry = client and client.pending[id]
+    if not entry then
+        return nil
+    end
+    client.pending[id] = nil
+    entry.timer:stop()
+    if not entry.timer:is_closing() then
+        entry.timer:close()
+    end
+    return entry.cb
+end
+
+-- register `cb` under `id` with a timeout, so a handler that never answers rejects the
+-- caller instead of stranding it. the sidecar has no cancel frame, so a late response
+-- to a timed-out id finds no pending entry and is dropped.
+local function await(id, cb)
+    local self = client
+    local timer = vim.uv.new_timer()
+    client.pending[id] = { cb = cb, timer = timer }
+    timer:start(REQUEST_TIMEOUT_MS, 0, function()
+        vim.schedule(function()
+            if client ~= self then
+                return -- this client was replaced; its pending map went with it
+            end
+            local fn = take(id)
+            if fn then
+                fn(mkerr("network", "the sidecar did not answer in time"))
+            end
+        end)
+    end)
+end
+
 -- fail in-flight (sent, awaiting response) requests; queued-but-unsent ones are left
 -- for a restart to flush after re-handshake.
 local function fail_pending(err)
     local pend = client.pending
     client.pending = {}
-    for _, cb in pairs(pend) do
+    for _, entry in pairs(pend) do
+        entry.timer:stop()
+        if not entry.timer:is_closing() then
+            entry.timer:close()
+        end
         vim.schedule(function()
-            cb(err)
+            entry.cb(err)
         end)
     end
 end
@@ -110,7 +153,7 @@ end
 function do_request(method, params, cb)
     local id = client.next_id
     client.next_id = id + 1
-    client.pending[id] = cb
+    await(id, cb)
     send({ id = id, method = method, params = params or vim.empty_dict() })
 end
 
@@ -126,7 +169,7 @@ function handshake()
     local self = client
     local id = client.next_id
     client.next_id = id + 1
-    client.pending[id] = function(err, result)
+    await(id, function(err, result)
         if client ~= self then
             return -- this client was stopped/replaced; its handshake result is moot
         end
@@ -156,7 +199,7 @@ function handshake()
         client.attempts = 0
         client.binary = result.binary
         flush_queue()
-    end
+    end)
     send({ id = id, method = "hello", params = { client = "differ.nvim", protocol = PROTOCOL } })
 end
 
@@ -179,8 +222,7 @@ function on_stdout(err, data)
         if line ~= "" then
             local ok, msg = pcall(vim.json.decode, line)
             if ok and type(msg) == "table" and msg.id ~= nil and client.pending[msg.id] then
-                local cb = client.pending[msg.id]
-                client.pending[msg.id] = nil
+                local cb = take(msg.id)
                 local e, result
                 if msg.error then
                     e = {

--- a/lua/differ/ui/overview.lua
+++ b/lua/differ/ui/overview.lua
@@ -114,6 +114,14 @@ local function timeline(tl)
             state = r.state,
         }
     end
+    -- an outdated thread has no line in the current diff, only the one it was written
+    -- against; nil when even that is gone, so the row says so instead of claiming line 0
+    local function anchor_of(t)
+        local function real(n)
+            return type(n) == "number" and n >= 1 and n or nil
+        end
+        return real(t.line) or real(t.original_line)
+    end
     for _, t in ipairs(tl.threads or {}) do
         if not t.is_pending then
             local first = (t.comments or {})[1] or {}
@@ -124,7 +132,8 @@ local function timeline(tl)
                 ts = first.created_at,
                 path = t.path,
                 side = t.side,
-                line = t.line,
+                line = anchor_of(t),
+                outdated = t.outdated == true, -- vim.NIL-safe
                 diff_hunk = first.diff_hunk, -- the root comment's, rendered under the header
                 resolved = t.resolved == true, -- vim.NIL-safe
                 replies = math.max(0, #(t.comments or {}) - 1),
@@ -243,17 +252,24 @@ function M.build(data, opts)
     ---@param item table
     local function render_thread(item)
         local row_start = #lines + 1
-        push({
+        local header = {
             { TOP, "differOverviewMeta" },
             { "@" .. (item.author or "?"), "differOverviewAuthor" },
             { " commented on ", "differOverviewMeta" },
-            { (item.path or "?") .. ":" .. (item.line or 0), "differOverviewBody" },
             {
-                item.resolved and " · resolved" or " · unresolved",
-                item.resolved and "differOverviewMeta" or "differOverviewChanges",
+                (item.path or "?") .. (item.line and (":" .. item.line) or ""),
+                "differOverviewBody",
             },
-            { " · " .. reltime(item.ts or ""), "differOverviewMeta" },
-        })
+        }
+        if item.outdated then
+            header[#header + 1] = { " · outdated", "differOverviewMeta" }
+        end
+        header[#header + 1] = {
+            item.resolved and " · resolved" or " · unresolved",
+            item.resolved and "differOverviewMeta" or "differOverviewChanges",
+        }
+        header[#header + 1] = { " · " .. reltime(item.ts or ""), "differOverviewMeta" }
+        push(header)
         -- the code the comment anchors to, github-style, on spine rows between header and
         -- body. +/- rows carry the diff's full-width line tints (recorded directly, since
         -- push only emits column spans); code rows are collected marker-stripped for the

--- a/plugin/differ.lua
+++ b/plugin/differ.lua
@@ -5,4 +5,14 @@ if vim.g.loaded_differ then
 end
 vim.g.loaded_differ = true
 
+-- 0.12 is a hard floor: model/diff.lua calls vim.text.diff on the path of every diff
+-- bail before registering, so the message is the only thing the user gets
+if vim.fn.has("nvim-0.12") ~= 1 then
+    vim.notify(
+        ("differ.nvim requires nvim 0.12+ (vim.text.diff); this is %s"):format(vim.version()),
+        vim.log.levels.ERROR
+    )
+    return
+end
+
 require("differ.command").register("Differ", "differ diff viewer")

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -3239,3 +3239,61 @@ describe(":Differ session supersession (cross-kind)", function()
         assert.is_nil(History.current())
     end)
 end)
+
+-- :q on the diff window is the most natural way to leave a session, and it means the
+-- window is already gone when the panel's on_close runs. the teardown has to happen
+-- anyway, or every cycle strands a buffer holding a whole DiffModel, the armed
+-- WinClosed autocmd, and the canonical differ:// name the next session wants
+describe("git session teardown after :q on the diff", function()
+    local function differ_bufs()
+        local n = 0
+        for _, b in ipairs(vim.api.nvim_list_bufs()) do
+            if
+                vim.api.nvim_buf_is_valid(b)
+                and vim.api.nvim_buf_get_name(b):find("differ://", 1, true)
+            then
+                n = n + 1
+            end
+        end
+        return n
+    end
+
+    local function viewclose_autocmds()
+        local n = 0
+        for _, a in ipairs(vim.api.nvim_get_autocmds({ event = "WinClosed" })) do
+            if
+                type(a.group_name) == "string" and a.group_name:find("differ.viewclose", 1, true)
+            then
+                n = n + 1
+            end
+        end
+        return n
+    end
+
+    it("leaks no buffers or autocmds across repeated open/:q cycles", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "1\n2\n")
+        git(root, "add", "a.lua")
+        git(root, "commit", "-q", "-am", "seed")
+        write(root .. "/a.lua", "1x\n2\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        local bufs_before, aus_before = differ_bufs(), viewclose_autocmds()
+
+        for _ = 1, 3 do
+            git_src.panel({ rev = {}, open_first = true })
+            local v = require("differ.view").current()
+            assert.is_not_nil(v)
+            local win = v.columns[1].winid
+            assert.is_true(vim.api.nvim_win_is_valid(win))
+
+            -- the gesture: the window is gone before on_close runs. nvim_win_close
+            -- rather than :quit, which would take headless nvim down with it
+            vim.api.nvim_win_close(win, false)
+            require("differ.git").close()
+        end
+
+        assert.are.equal(bufs_before, differ_bufs())
+        assert.are.equal(aus_before, viewclose_autocmds())
+    end)
+end)

--- a/test/nvim/pr_nav_spec.lua
+++ b/test/nvim/pr_nav_spec.lua
@@ -248,6 +248,49 @@ describe("pr overview <-> review navigation loop", function()
         restore()
     end)
 
+    -- the page render is several async hops long, and `:Differ pr <n>` straight into
+    -- `:Differ pr view` leaves the session in the files while the last hop is still out.
+    -- rendering then would take the window back and close the diff just built
+    it("an overview render still in flight doesn't take the window back", function()
+        local responses = default_responses()
+        local release -- the held get_checks callback, the last hop before render
+        local real = sidecar.request
+        sidecar.request = function(method, params, cb)
+            if method == "get_checks" and not release then
+                release = function()
+                    vim.schedule(function()
+                        cb(nil, responses.get_checks.result)
+                    end)
+                end
+                return
+            end
+            vim.schedule(function()
+                local r = responses[method]
+                cb(r and r.err or nil, (r and r.result) or {})
+            end)
+        end
+
+        pr.show(PR, { land = "overview" })
+        assert.is_true(vim.wait(2000, function()
+            return release ~= nil -- the page is one hop from rendering
+        end))
+
+        pr.view({ number = PR.number }) -- enter the files while that hop is outstanding
+        local s = pr.current_session()
+        assert.is_true(vim.wait(2000, function()
+            return s.view ~= nil and s.view:is_open()
+        end))
+
+        release() -- the superseded page render lands
+        vim.wait(300)
+
+        assert.is_truthy(s.view and s.view:is_open()) -- the diff survived it
+        assert.is_true(s.panel:is_open())
+        assert.are.equal(s, pr.current_session())
+
+        sidecar.request = real
+    end)
+
     -- a mutation submitted from the overview can conflict, and its refetch lands with
     -- the view nil'd and the sidebar hidden: state has to reconcile, but re-sourcing the
     -- diff there would build a fresh view over the page the user is reading

--- a/test/nvim/pr_nav_spec.lua
+++ b/test/nvim/pr_nav_spec.lua
@@ -248,6 +248,37 @@ describe("pr overview <-> review navigation loop", function()
         restore()
     end)
 
+    -- a mutation submitted from the overview can conflict, and its refetch lands with
+    -- the view nil'd and the sidebar hidden: state has to reconcile, but re-sourcing the
+    -- diff there would build a fresh view over the page the user is reading
+    it("a conflict refetch on the overview reconciles state without rebuilding the diff", function()
+        local responses = default_responses()
+        local restore = open_overview(responses)
+        enter_at_thread()
+
+        local s = pr.current_session()
+        local diff_buf = s.view:column_for("new").bufnr
+        local before = overview_tick()
+        assert.is_true(fire(diff_buf, "PR overview")) -- go-hop
+        wait_overview(before)
+        assert.is_nil(s.view)
+        assert.is_false(s.panel:is_open())
+
+        s.versions["a.txt"] = { base = {}, head = {} } -- a memo pinned to the old head
+        responses.get_pr = { result = get_pr_result({ head_sha = "ccc3333" }) }
+        pr.handle_conflict()
+
+        assert.is_true(vim.wait(1000, function()
+            return s.pr_meta.head_sha == "ccc3333"
+        end))
+        assert.are.same({}, s.versions) -- the stale memo dropped
+        assert.is_nil(s.threads)
+        assert.is_nil(s.view) -- and nothing drawn over the page
+        assert.are.equal(overview_buf(), vim.api.nvim_win_get_buf(s.overview_win))
+
+        restore()
+    end)
+
     it("re-entering via e restores the stashed diff position", function()
         local restore = open_overview(default_responses())
 

--- a/test/nvim/pr_review_spec.lua
+++ b/test/nvim/pr_review_spec.lua
@@ -1,6 +1,7 @@
 -- runs under headless nvim: the pending-review draft lifecycle. stubs pr.client (the
 -- one seam review.lua reaches the sidecar through), so a fake session with a fake panel
 -- is enough to drive start / reattach without a real PR session
+---@diagnostic disable: duplicate-set-field  -- the stubs reassign module fields by design
 local client = require("differ.pr.client")
 local review = require("differ.pr.review")
 
@@ -17,10 +18,14 @@ local function stub(pending, live)
         get_pending_review = client.get_pending_review,
         current_session = pr.current_session,
     }
+    -- TODO: type busted properly (and remove those disables)
+
+    ---@diagnostic disable-next-line: unused-local
     client.start_review = function(_pr, cb)
         calls[#calls + 1] = "start_review"
         cb(nil, { review_id = "fresh" })
     end
+    ---@diagnostic disable-next-line: unused-local
     client.get_pending_review = function(_pr, cb)
         calls[#calls + 1] = "get_pending_review"
         cb(nil, pending)

--- a/test/nvim/pr_review_spec.lua
+++ b/test/nvim/pr_review_spec.lua
@@ -4,13 +4,18 @@
 local client = require("differ.pr.client")
 local review = require("differ.pr.review")
 
--- swap the client calls out for the duration of a test. `calls` records which client
--- methods fired; the fake panel records the path reattach landed on
-local function stub(pending)
+-- swap the client calls out for the duration of a test, and make `live` the session the
+-- guards see. `calls` records which client methods fired; the fake panel records the
+-- path reattach landed on
+---@param pending table|nil  -- what get_pending_review answers
+---@param live table|nil  -- the session pr.current_session() reports, nil for none
+local function stub(pending, live)
     local calls = {}
+    local pr = require("differ.pr")
     local real = {
         start_review = client.start_review,
         get_pending_review = client.get_pending_review,
+        current_session = pr.current_session,
     }
     client.start_review = function(_pr, cb)
         calls[#calls + 1] = "start_review"
@@ -20,10 +25,14 @@ local function stub(pending)
         calls[#calls + 1] = "get_pending_review"
         cb(nil, pending)
     end
+    pr.current_session = function()
+        return live
+    end
     return calls,
         function()
             client.start_review = real.start_review
             client.get_pending_review = real.get_pending_review
+            pr.current_session = real.current_session
         end
 end
 
@@ -40,13 +49,8 @@ local function fake_session(review_id, entries)
                 self.landed[#self.landed + 1] = path
             end,
         },
-        -- alive() only asks the view whether it's still open
-        view = {
-            is_open = function()
-                return true
-            end,
-            columns = {},
-        },
+        -- no view: the draft lifecycle keys off session identity, so it works before
+        -- the diff's async blob fetch has built one
     }
 end
 
@@ -59,8 +63,8 @@ local FILES = {
 
 describe("review.start", function()
     it("starts a fresh draft when the session has none", function()
-        local calls, restore = stub({})
         local s = fake_session(nil, FILES)
+        local calls, restore = stub({}, s)
         review.start(s)
         assert.are.same({ "start_review" }, calls)
         assert.are.equal("fresh", s.review_id)
@@ -68,46 +72,69 @@ describe("review.start", function()
     end)
 
     it("reattaches instead of refusing when a draft is already in progress", function()
-        local calls, restore = stub({ review_id = "existing" })
         local s = fake_session("existing", FILES)
+        local calls, restore = stub({ review_id = "existing" }, s)
         review.start(s)
         -- the point: no second start_review, and it doesn't dead-end on a notice
         assert.are.same({ "get_pending_review" }, calls)
+        restore()
+    end)
+
+    -- the diff's blob fetch and start_review race, and either can land first
+    it("adopts the draft when the response beats the diff window", function()
+        local s = fake_session(nil, FILES)
+        local _, restore = stub({}, s)
+        assert.is_nil(s.view) -- show_file hasn't built one yet
+        _G.notifs = {}
+        review.start(s)
+        assert.are.equal("fresh", s.review_id)
+        assert.are.equal(
+            "differ: review started - comments are drafts until you submit",
+            _G.notifs[#_G.notifs].msg
+        )
+        restore()
+    end)
+
+    it("drops the draft when the session was replaced mid-flight", function()
+        local s = fake_session(nil, FILES)
+        local _, restore = stub({}, fake_session(nil, FILES)) -- a different live session
+        review.start(s)
+        assert.is_nil(s.review_id) -- the superseded session keeps no draft id
         restore()
     end)
 end)
 
 describe("review.reattach", function()
     it("lands on the first file still unviewed", function()
-        local _, restore = stub({ review_id = "existing" })
         local s = fake_session("existing", FILES)
+        local _, restore = stub({ review_id = "existing" }, s)
         review.reattach(s)
         assert.are.same({ "c.lua" }, s.panel.landed)
         restore()
     end)
 
     it("leaves the cursor alone when the caller already positioned", function()
-        local _, restore = stub({ review_id = "existing" })
         local s = fake_session("existing", FILES)
+        local _, restore = stub({ review_id = "existing" }, s)
         review.reattach(s, { jump = false })
         assert.are.same({}, s.panel.landed) -- the overview's thread anchor stands
         restore()
     end)
 
     it("stays put when every file has been viewed", function()
-        local _, restore = stub({ review_id = "existing" })
         local s = fake_session("existing", {
             { path = "a.lua", viewed = true },
             { path = "b.lua", viewed = true },
         })
+        local _, restore = stub({ review_id = "existing" }, s)
         review.reattach(s)
         assert.are.same({}, s.panel.landed)
         restore()
     end)
 
     it("notifies and lands nowhere when the PR has no draft", function()
-        local _, restore = stub({ review_id = nil })
         local s = fake_session(nil, FILES)
+        local _, restore = stub({ review_id = nil }, s)
         _G.notifs = {}
         review.reattach(s)
         assert.are.equal(
@@ -115,6 +142,16 @@ describe("review.reattach", function()
             _G.notifs[#_G.notifs].msg
         )
         assert.are.same({}, s.panel.landed)
+        restore()
+    end)
+
+    -- resume's whole purpose is re-entering draft mode, so it can't wait on the diff
+    it("reattaches with no diff window built yet", function()
+        local s = fake_session(nil, FILES)
+        local _, restore = stub({ review_id = "existing" }, s)
+        review.reattach(s)
+        assert.are.equal("existing", s.review_id)
+        assert.are.same({ "c.lua" }, s.panel.landed)
         restore()
     end)
 end)

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -86,6 +86,56 @@ describe("pr session notifies", function()
         end
     end)
 
+    -- the neighbour prefetch is speculative and outlives the session that issued it, so
+    -- its callback has to prove the session is still the live one before writing the memo
+    it("a prefetch landing after a PR switch stays out of the new session's memo", function()
+        -- disjoint file sets, so b.txt can only reach PR 8's memo by contamination
+        local function files_for(number)
+            local names = number == 7 and { "a.txt", "b.txt" } or { "c.txt", "d.txt" }
+            local out = {}
+            for _, path in ipairs(names) do
+                out[#out + 1] = { path = path, status = "modified", additions = 1, deletions = 1 }
+            end
+            return out
+        end
+        local held -- b.txt's blob, released by hand after the switch
+        local real = sidecar.request
+        sidecar.request = function(method, params, cb)
+            if method == "get_file_versions" and params.path == "b.txt" and not held then
+                held = function()
+                    cb(nil, { base = { content = "stale\n" }, head = { content = "STALE\n" } })
+                end
+                return
+            end
+            vim.schedule(function()
+                if method == "get_pr" then
+                    return cb(nil, get_pr_result({ files = files_for(params.number) }))
+                elseif method == "get_file_versions" then
+                    return cb(nil, { base = { content = "a\n" }, head = { content = "A\n" } })
+                end
+                cb(nil, {})
+            end)
+        end
+
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            return held ~= nil -- the first session issued the neighbour prefetch
+        end))
+        local first = pr.current_session()
+
+        pr.show({ owner = "acme", repo = "widget", number = 8 })
+        assert.is_true(vim.wait(1000, function()
+            local s = pr.current_session()
+            return s ~= nil and s ~= first
+        end))
+        local second = pr.current_session()
+
+        held() -- the superseded session's blob finally lands
+        assert.is_nil(second.versions["b.txt"])
+
+        sidecar.request = real
+    end)
+
     it("warns when opening a check with no url from the checks float", function()
         local restore = stub_sidecar({
             get_pr = { result = get_pr_result() },

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -86,6 +86,38 @@ describe("pr session notifies", function()
         end
     end)
 
+    -- get_pr fetches the whole file list, so a big PR answers slower than a small one
+    -- asked for after it. the open the user made last is the one they meant
+    it("lands on the PR opened last even when its response arrives first", function()
+        local pending = {} -- get_pr callbacks, released by hand
+        local real = sidecar.request
+        sidecar.request = function(method, params, cb)
+            if method == "get_pr" then
+                pending[params.number] = function()
+                    cb(nil, get_pr_result({ title = "pr " .. params.number }))
+                end
+                return
+            end
+            vim.schedule(function()
+                cb(nil, method == "get_file_versions" and { base = {}, head = {} } or {})
+            end)
+        end
+
+        pr.show({ owner = "acme", repo = "widget", number = 10 })
+        pr.show({ owner = "acme", repo = "widget", number = 20 })
+        assert.is_truthy(pending[10] and pending[20])
+
+        pending[20]() -- the one the user asked for last answers first
+        pending[10]() -- the superseded, slower one lands after
+
+        assert.is_true(vim.wait(1000, function()
+            return pr.current_session() ~= nil
+        end))
+        assert.are.equal(20, pr.current_session().pr.number)
+
+        sidecar.request = real
+    end)
+
     -- the neighbour prefetch is speculative and outlives the session that issued it, so
     -- its callback has to prove the session is still the live one before writing the memo
     it("a prefetch landing after a PR switch stays out of the new session's memo", function()

--- a/test/nvim/pr_threads_ensure_spec.lua
+++ b/test/nvim/pr_threads_ensure_spec.lua
@@ -28,13 +28,14 @@ describe("pr.threads.ensure (in-flight coalescing)", function()
         local real_cs = pr.current_session
         local real_get = client.get_threads
         local real_notify = pr.notify_err
-        local sent, notified, captured = 0, 0, nil
+        local sent, notified = 0, 0
+        local captured = {} -- every get_threads cb, in issue order
         pr.current_session = function()
             return session
         end
         client.get_threads = function(_pr, cb)
             sent = sent + 1
-            captured = cb
+            captured[#captured + 1] = cb
         end
         pr.notify_err = function()
             notified = notified + 1
@@ -51,8 +52,10 @@ describe("pr.threads.ensure (in-flight coalescing)", function()
             notified = function()
                 return notified
             end,
-            fire = function(err, list)
-                captured(err, list)
+            -- fire the nth fetch's callback (default the first), so a test can land an
+            -- older fetch after a newer one
+            fire = function(err, list, nth)
+                captured[nth or 1](err, list)
             end,
         }
     end
@@ -80,6 +83,41 @@ describe("pr.threads.ensure (in-flight coalescing)", function()
         assert.are.equal(1, h.sent()) -- still one request total
         assert.are.equal(1, #session.threads) -- the list is stored on the session
         assert.is_nil(session.threads_waiters) -- the queue is drained
+    end)
+
+    -- posting a comment while the first fetch is still running: the mutation invalidates,
+    -- and the refresh behind it must not join a fetch that predates the comment
+    it("refuses to piggyback a fetch issued before an invalidation", function()
+        local session = { pr = PR, threads = nil }
+        local h = harness(session)
+
+        local before, after = 0, 0
+        threads.ensure(session, function()
+            before = before + 1
+        end)
+        assert.are.equal(1, h.sent())
+
+        threads.invalidate(session) -- a comment posted mid-fetch
+        threads.ensure(session, function()
+            after = after + 1
+        end)
+        assert.are.equal(2, h.sent()) -- a fresh fetch, not a queue-up
+
+        -- the stale fetch lands first, carrying the pre-comment list
+        h.fire(nil, { { thread_id = "old", path = "a.txt", line = 2, comments = {} } }, 1)
+        assert.is_nil(session.threads) -- its snapshot is dropped, not stored
+        assert.are.equal(0, before)
+        assert.are.equal(0, after)
+
+        h.fire(nil, {
+            { thread_id = "old", path = "a.txt", line = 2, comments = {} },
+            { thread_id = "new", path = "a.txt", line = 4, comments = {} },
+        }, 2)
+        assert.are.equal(2, #session.threads) -- the post-comment list wins
+        assert.are.equal("new", session.threads[2].thread_id)
+        assert.are.equal(1, before) -- the superseded fetch's waiter is still answered
+        assert.are.equal(1, after)
+        assert.is_nil(session.threads_waiters)
     end)
 
     it("on error notifies once but still runs both queued callbacks with the err", function()

--- a/test/nvim/sidecar_spec.lua
+++ b/test/nvim/sidecar_spec.lua
@@ -11,13 +11,22 @@ local function has_binary()
     return vim.fn.executable(root .. "/bin/differ-sidecar") == 1
 end
 
--- live sidecar processes, so the lifecycle tests can assert on what is actually running
--- rather than on client state alone. matched by executable name (-x), not command line
--- (-f): the client resolves the binary relative or absolute depending on the rtp, and a
--- -f match also counts any unrelated process whose arguments merely mention the path,
--- an editor, a grep, or the very shell that launched the suite
+-- live sidecar processes *this nvim spawned*, so the lifecycle tests can assert on what
+-- is actually running rather than on client state alone. matched by executable name
+-- (-x), not command line (-f): the client resolves the binary relative or absolute
+-- depending on the rtp, and a -f match also counts any unrelated process whose arguments
+-- merely mention the path, an editor, a grep, or the very shell that launched the suite.
+-- scoped to our own children (-P), since the counts here are absolute: a differ session
+-- open in another editor, or a second suite running alongside, is a sidecar by the same
+-- name and would otherwise be counted as ours
 local function running_sidecars()
-    local out = vim.fn.system({ "pgrep", "-x", "differ-sidecar" })
+    local out = vim.fn.system({
+        "pgrep",
+        "-P",
+        tostring(vim.uv.os_getpid()),
+        "-x",
+        "differ-sidecar",
+    })
     local n = 0
     for _ in out:gmatch("%d+") do
         n = n + 1

--- a/test/unit/overview_spec.lua
+++ b/test/unit/overview_spec.lua
@@ -98,6 +98,52 @@ describe("ui.overview.timeline (merge + sort)", function()
         assert.are.equal(1, items[1].replies)
     end)
 
+    -- an outdated thread carries line 0 from the wire; the row has to say where it was
+    -- written and that it's outdated, never "line 0"
+    it("anchors an outdated thread to where it was written", function()
+        local items = overview.timeline({
+            comments = {},
+            reviews = {},
+            threads = {
+                {
+                    path = "a.txt",
+                    side = "RIGHT",
+                    line = 0,
+                    original_line = 42,
+                    outdated = true,
+                    resolved = false,
+                    comments = {
+                        { author = "t", body = "stale", created_at = "2026-01-01T00:00:00Z" },
+                    },
+                },
+            },
+        })
+        assert.are.equal(42, items[1].line)
+        assert.is_true(items[1].outdated)
+    end)
+
+    it("leaves an unanchorable thread with no line at all", function()
+        local items = overview.timeline({
+            comments = {},
+            reviews = {},
+            threads = {
+                {
+                    path = "a.txt",
+                    side = "RIGHT",
+                    line = 0,
+                    original_line = 0,
+                    outdated = true,
+                    resolved = false,
+                    comments = {
+                        { author = "t", body = "gone", created_at = "2026-01-01T00:00:00Z" },
+                    },
+                },
+            },
+        })
+        assert.is_nil(items[1].line) -- never 0, which would read as line 0
+        assert.is_true(items[1].outdated)
+    end)
+
     it("drops a pending draft thread", function()
         local items = overview.timeline({
             comments = {},

--- a/test/unit/pr_comment_spec.lua
+++ b/test/unit/pr_comment_spec.lua
@@ -69,3 +69,62 @@ describe("pr.comment.range_anchor", function()
         assert.is_nil(comment.range_anchor(UNIFIED, 3, 4, "unified")) -- row 4 is meta
     end)
 end)
+
+-- the compose window is a real split, not a modal, so the diff can be navigated (or
+-- closed) between the gesture and the submit. the anchor's path is fixed with its
+-- side/line at gesture time, and post reads that rather than whatever the view shows now
+describe("pr.comment.post anchors to the gesture's file", function()
+    local client = require("differ.pr.client")
+
+    ---@return table args, fun() restore
+    local function capture()
+        local real = client.post_comment
+        local box = {}
+        ---@diagnostic disable-next-line: duplicate-set-field
+        client.post_comment = function(_pr, args, _cb)
+            box.args = args
+        end
+        return box, function()
+            client.post_comment = real
+        end
+    end
+
+    local function session(view_path)
+        return {
+            pr = { owner = "acme", repo = "widget", number = 7 },
+            pr_meta = { head_sha = "bbb2222" },
+            view = view_path and { model = { path = view_path } } or nil,
+        }
+    end
+
+    it("posts to the gestured file even after the diff moved on", function()
+        local box, restore = capture()
+        local opts = { anchor = { side = "RIGHT", line = 2 }, path = "a.txt" }
+        comment.post(session("b.txt"), opts, "looks wrong") -- view now shows b.txt
+        assert.are.equal("a.txt", box.args.path)
+        assert.are.equal("RIGHT", box.args.side)
+        assert.are.equal(2, box.args.line)
+        restore()
+    end)
+
+    it("posts to the gestured file even after the diff closed", function()
+        local box, restore = capture()
+        local opts = { anchor = { side = "RIGHT", line = 2 }, path = "a.txt" }
+        comment.post(session(nil), opts, "still fine") -- no view at all
+        assert.are.equal("a.txt", box.args.path)
+        restore()
+    end)
+
+    it("carries the path through the conflict re-prompt's opts", function()
+        local box, restore = capture()
+        local opts = { anchor = { side = "RIGHT", line = 2 }, path = "a.txt" }
+        -- the shape tbl_extend produces in the conflict path, built without vim here
+        local reprompt = { initial = "body", stale = true }
+        for k, v in pairs(opts) do
+            reprompt[k] = v
+        end
+        comment.post(session("b.txt"), reprompt, "body")
+        assert.are.equal("a.txt", box.args.path)
+        restore()
+    end)
+end)

--- a/test/unit/pr_threads_spec.lua
+++ b/test/unit/pr_threads_spec.lua
@@ -31,6 +31,30 @@ describe("pr.threads.anchor_row", function()
     it("returns nil when nothing is rendered on that side", function()
         assert.is_nil(threads.anchor_row({}, 5))
     end)
+
+    -- github nulls the line once a thread's anchor leaves the diff and the wire carries
+    -- 0. degrading is for a near miss, so a non-line must not be dragged to the lowest
+    -- rendered row, which would stack every outdated thread on the top of the file
+    it("refuses a line that isn't a real line rather than degrading it", function()
+        assert.is_nil(threads.anchor_row(index, 0))
+        assert.is_nil(threads.anchor_row(index, nil))
+        assert.is_nil(threads.anchor_row(index, -3))
+    end)
+end)
+
+describe("pr.threads.anchor_line", function()
+    it("uses the current line when the thread still anchors in the diff", function()
+        assert.are.equal(12, threads.anchor_line({ line = 12, original_line = 4 }))
+    end)
+
+    it("falls back to where an outdated thread was written", function()
+        assert.are.equal(4, threads.anchor_line({ line = 0, original_line = 4, outdated = true }))
+    end)
+
+    it("is nil when neither line survives", function()
+        assert.is_nil(threads.anchor_line({ line = 0, original_line = 0 }))
+        assert.is_nil(threads.anchor_line({}))
+    end)
 end)
 
 describe("pr.threads.stack_sort", function()


### PR DESCRIPTION
## Summary
- fix: async pr callbacks reconcile on session identity, never on window visibility. `pr/guard.lua` answers the two questions separately (`owns` for state, `is_open()` for ui only), because the overview hop deliberately nils the view and hides the panel: submit, discard, post, delete, resolve and mark-viewed all reached github while the session ignored what came back. a submitted review kept its draft id so the next submit failed against a review that was no longer pending, a posted comment never appeared, a deleted one stayed on screen, and a conflict was swallowed with no message. six defects, one pattern
- fix: `:Differ pr review` and `resume` key off session identity, so they adopt the draft even when the review call answers before the diff's blob fetch has built a view. the old guard wasn't reliably broken, it was nondeterministic: when the draft won the race it was dropped silently, leaving `ga` posting live comments while the title said draft
- fix: every `client.*` callback in `pr/` captures its own session. the neighbour prefetch and `set_pr_state` guarded and wrote through the module upvalue, so switching PRs mid-flight wrote one PR's blobs (under its pinned shas) and lifecycle state into another's session
- fix: a comment posts against the file it was written on. `path` was read at submit time while `side`/`line` came from the gesture, and the compose window is an ordinary split: glancing at another file mid-compose posted there, at the line you meant elsewhere. closing the diff mid-compose raised instead of posting, losing the body
- fix: a monotonic token on `M.show`, so the `:Differ pr <n>` you asked for last is the one you land on. get_pr carries the whole file list, so the larger PR tends to answer last and `10` then `20` reliably left you in #10
- fix: the three graphql cursor walks are bounded, by a page cap and a cursor-progress guard. a page claiming `hasNextPage` with a null `endCursor` dropped the cursor from the variables and refetched page 1 until the token hit a secondary rate limit. separately, a sidecar request that never answers now rejects after 60s rather than stranding its caller for the session
- fix: the thread cache is generation-stamped on both sides. a sidecar walk that straddles an invalidation no longer re-seeds the cache with its pre-mutation snapshot, and `ensure` refuses to join a fetch issued before an invalidation, so a comment posted while the initial thread fetch is still running can't stay invisible
- fix: outdated threads anchor where they were written, marked outdated. github nulls `line` once a thread's anchor leaves the diff, which is every thread on a branch pushed to since review; the wire's 0 was read as a line number and the nearest-match scan dragged them all onto row 1. the query now asks for `isOutdated`/`originalLine`, and a non-line is refused rather than degraded
- fix: `get_pending_review` asks github for fields that exist. `diffSide`/`startDiffSide` are on `PullRequestReviewThread`, not `PullRequestReviewComment` one level down, so the query always failed with `internal`: `:Differ pr review resume` and draft adoption on open have never worked
- fix: a page render still in flight can't take the window back. `:Differ pr <n>` straight into `:Differ pr view` built the diff and then bounced you back to the overview when the page's last hop landed
- fix: `:q` on the diff tears the session down. teardown ran only while the window was still open, so the most natural exit leaked a buffer holding a whole DiffModel, an armed autocmd and the canonical `differ://` name, every cycle
- fix: nvim 0.12 is the declared floor, in all six doc sites, enforced at startup with an actionable message, and pinned into the ci matrix so it stays exercised
- test: `sidecar_spec` counts only the sidecars it spawned itself, so the suite no longer fails for anyone with differ open in another editor

## Test plan
- [x] `make check` (lua + go lint, lua_ls type-check, `go vet`, all suites)
- [x] lua unit 370/0, headless-nvim 420/0, go tests ok
- [x] every fix proven against a reverted control, in an isolated tree copy where the run needed one
- [x] live end-to-end against real PRs on a throwaway private repo, through the real plugin and sidecar: 5.5 (13 assertions fail on a control with only the guards flipped back, 0 on head), 5.7, 5.9, 5.10, 5.6, 5.11, 5.12
- [x] both pr-switching races and 5.12 need forced timing to reproduce: against small fixtures github answers in request order, so the unforced passes are not evidence on their own
- [x] every graphql document validated against the live schema; the check catches the `get_pending_review` defect when reinstated
- [x] outdated-thread fixture built by pushing a line-shifting commit, giving real `line: null` / `originalLine` threads
