### PR TITLE
fix: keep take-base on its own conflict, and off CRLF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The merge tool could splice a different conflict's ancestor into the file. Take-base looked the ancestor up by position in a map that reset whenever the number of conflict regions changed, which happens when you hand-resolve one or undo a resolve: the text landed silently, `:w` staged it, and it was committable with no warning. Only under git's default `merge.conflictStyle`, where differ has to recover the ancestor itself
+- The merge tool wrote a doubled carriage return on CRLF files. Take-base's ancestor came from the raw stage blob, so its lines kept the CR the buffer had already stripped, and saving added a second one. The base pane rendered the stray `^M` too
+
+## [0.1.26] — 2026-08-10
+
 ### Changed
 
 - Neovim 0.12 is the minimum, documented and enforced at startup. Every diff uses `vim.text.diff`, which 0.10 and 0.11 don't have

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -23,6 +23,12 @@ local M = {}
 
 local merge_ns = vim.api.nvim_create_namespace("differ.merge")
 local flash_ns = vim.api.nvim_create_namespace("differ.merge.flash")
+-- take-base recovers the ancestor from a slab keyed by the conflict's *original* index, so
+-- the live -> original mapping has to survive edits, resolves and undo. one extmark per
+-- original conflict, spanning its block: it rides edits, `invalidate` retires it when its
+-- block is spliced away, and undo restores both text and mark together. its own namespace,
+-- since paint_result clears merge_ns on every repaint
+local anchor_ns = vim.api.nvim_create_namespace("differ.merge.anchor")
 
 local FOLDTEXT_EXPR = 'v:lua.require("differ.ui.foldtext").render()'
 
@@ -49,7 +55,7 @@ local INPUT_HL = {
 ---@field root string
 ---@field path string
 ---@field regions differ.merge.Region[]   -- re-derived from the live result buffer
----@field order integer[]                 -- live region position -> original conflict index
+---@field anchors table<integer, integer> -- anchor extmark id -> original conflict index
 ---@field base_slabs table<integer, string[]> -- original conflict index -> recovered base slab
 ---@field total integer                   -- original conflict count (for the winbar N/M)
 ---@field active_index integer|nil        -- live index of the conflict under the cursor
@@ -92,6 +98,23 @@ local function restore_timeout()
         vim.o.timeoutlen = saved_timeoutlen
         saved_timeoutlen = nil
     end
+end
+
+-- the recovered base comes from raw stage blobs, so on a CRLF repo every line ends `\r`.
+-- the result buffer is the worktree file as nvim loaded it, and nvim strips the CR into
+-- fileformat=dos, so splicing a slab carrying its own would have :w write a second one.
+-- ours/theirs need no such thing: they are re-parsed from the buffer at resolve time
+---@param slab string[]|nil
+---@return string[]|nil
+local function strip_cr(slab)
+    if not slab then
+        return slab
+    end
+    local out = {}
+    for i, line in ipairs(slab) do
+        out[i] = (line:gsub("\r$", ""))
+    end
+    return out
 end
 
 ---@param msg string
@@ -318,6 +341,41 @@ local function live_regions()
     return require("differ.git.conflict").parse(lines), lines
 end
 
+-- the original conflict index a live region belongs to, by the surviving anchor sitting on
+-- its `<<<<<<<` line. nil when no anchor is there or more than one has collapsed onto it:
+-- callers refuse rather than guess, since guessing here writes another conflict's ancestor
+-- into the file
+---@param result_start integer  -- 1-based line of the region's `<<<<<<<`
+---@return integer|nil
+local function original_index(result_start)
+    local s = assert(session)
+    local row = result_start - 1
+    local found
+    for _, m in
+        ipairs(vim.api.nvim_buf_get_extmarks(s.result_buf, anchor_ns, { row, 0 }, {
+            row,
+            -1,
+        }, { details = true }))
+    do
+        if not m[4].invalid then
+            if found then
+                return nil -- ambiguous
+            end
+            found = s.anchors[m[1]]
+        end
+    end
+    return found
+end
+
+-- the original index of the conflict at live position `pos`, or nil
+---@param pos integer|nil
+---@return integer|nil
+local function original_at(pos)
+    local s = assert(session)
+    local region = pos and s.regions[pos]
+    return region and original_index(region.result_start) or nil
+end
+
 -- the live index of the conflict under the result cursor, else nil
 ---@return integer|nil
 local function active_index()
@@ -340,14 +398,7 @@ end
 -- the identity so the pane sync stays consistent (degrading to live-index = original-index)
 local function repaint_result()
     local s = assert(session)
-    local regions = live_regions()
-    s.regions = regions
-    if not s.order or #s.order ~= #regions then
-        s.order = {}
-        for i = 1, #regions do
-            s.order[i] = i
-        end
-    end
+    s.regions = live_regions()
     s.active_index = active_index()
     paint_result(s.active_index)
 end
@@ -422,7 +473,7 @@ local function on_cursor_moved()
     end
     session.active_index = active
     paint_result(active)
-    sync_inputs(active and session.order[active])
+    sync_inputs(original_at(active))
 end
 
 -- jump the result cursor to the next/prev conflict block (wrapping at the ends), repaint
@@ -480,7 +531,7 @@ local function resolve_choice(choice)
     if not session then
         return
     end
-    local regions, lines = live_regions()
+    local regions = live_regions()
     if #regions == 0 then
         return notify("no conflicts remain")
     end
@@ -492,18 +543,33 @@ local function resolve_choice(choice)
     -- the live buffer parse carries no base under the default conflictStyle, so take-base
     -- reads the slab recovered at build time, mapped live index -> original via `order`
     if choice == "base" and not region.base then
-        region.base = session.base_slabs[session.order[region.index]]
+        local original = original_index(region.result_start)
+        if not original then
+            return notify(
+                "this conflict's markers were edited, so its ancestor can't be identified; "
+                    .. "run :Differ mergetool again to re-read them",
+                vim.log.levels.WARN
+            )
+        end
+        region.base = session.base_slabs[original]
     end
-    local new_lines, delta = require("differ.merge.resolve").splice(lines, region, choice)
-    if not new_lines then
+    local slab = require("differ.merge.resolve").slab(region, choice)
+    if not slab then
         return notify("no base version in this conflict", vim.log.levels.WARN)
     end
     local anchor = region.result_start
-    local block_len = region.result_end - region.result_start + 1
-    local slab_count = delta + block_len -- the chosen slab's line count (0 for `none`)
+    local slab_count = #slab -- 0 for `none`
     vim.bo[session.result_buf].modifiable = true
-    vim.api.nvim_buf_set_lines(session.result_buf, 0, -1, false, new_lines)
-    table.remove(session.order, region.index) -- drop the resolved conflict's mapping
+    -- replace just the conflict's own lines, not the whole buffer: a whole-buffer set
+    -- deletes every line and takes the anchors with it, and the surviving conflicts' marks
+    -- are exactly what take-base needs afterwards
+    vim.api.nvim_buf_set_lines(
+        session.result_buf,
+        region.result_start - 1,
+        region.result_end,
+        false,
+        slab
+    )
     repaint_result()
     flash(session.result_buf, anchor, slab_count)
     -- land on the next remaining conflict at or after where this one was
@@ -543,7 +609,7 @@ local function base_label()
     if s.no_ancestor then
         return label .. " · no common ancestor"
     end
-    if #s.regions > 0 and not s.base_slabs[s.order[active_pos()]] then
+    if #s.regions > 0 and not s.base_slabs[original_at(active_pos())] then
         return label .. " · none for this conflict"
     end
     return label
@@ -775,7 +841,7 @@ function lay_out(root, relpath, model, layout)
         root = root,
         path = relpath,
         regions = model.regions,
-        order = {},
+        anchors = {},
         base_slabs = {},
         total = #model.regions,
         active_index = nil,
@@ -798,14 +864,19 @@ function lay_out(root, relpath, model, layout)
         diag_aug = suppress_diagnostics(result_buf), -- the markers aren't valid source
         saved_markdown_render = quiet_markdown_render(result_buf), -- don't conceal the markers
     }
-    for i = 1, #model.regions do
-        session.order[i] = i
+    -- one anchor per original conflict, spanning its block so a splice retires it
+    for _, r in ipairs(model.regions) do
+        local id = vim.api.nvim_buf_set_extmark(result_buf, anchor_ns, r.result_start - 1, 0, {
+            end_row = r.result_end - 1,
+            invalidate = true,
+        })
+        session.anchors[id] = r.index
     end
     -- recovered base slabs by original conflict index: the default conflictStyle leaves no
     -- base in the live result parse, so take-base looks the slab up here (nil where the
     -- re-merge couldn't recover one, which take-base reports as no base version)
     for _, r in ipairs(model.regions) do
-        session.base_slabs[r.index] = r.base
+        session.base_slabs[r.index] = strip_cr(r.base)
     end
 
     -- paint the panes + lay down the (latent) folds

--- a/lua/differ/render/merge.lua
+++ b/lua/differ/render/merge.lua
@@ -77,6 +77,20 @@ end
 
 -- build the merge columns. base is shown only under the diff4 layout (it's read
 -- + carried regardless, so the toggle costs nothing); the result column is always last
+-- the input panes are built from raw stage blobs, so on a CRLF repo every line ends `\r`
+-- and renders as a trailing `^M`. strip it for display only, after the regions have been
+-- located: the located spans are line indices and the line count is unchanged, and the
+-- model keeps the raw text its slab matching depends on
+---@param lines string[]
+---@return string[]
+local function strip_cr(lines)
+    local out = {}
+    for i, line in ipairs(lines) do
+        out[i] = (line:gsub("\r$", ""))
+    end
+    return out
+end
+
 ---@param model differ.MergeModel
 ---@param opts { layout?: "default"|"diff4" }|nil
 ---@return differ.merge.RenderResult
@@ -92,7 +106,7 @@ function M.render(model, opts)
     local columns = {
         {
             side = "ours",
-            lines = ours,
+            lines = strip_cr(ours),
             regions = ours_regions,
             folds = fold_ranges(#ours, ours_regions),
         },
@@ -102,7 +116,7 @@ function M.render(model, opts)
         local base_regions = locate_regions(base, model.regions, "base")
         columns[#columns + 1] = {
             side = "base",
-            lines = base,
+            lines = strip_cr(base),
             regions = base_regions,
             folds = fold_ranges(#base, base_regions),
         }
@@ -110,7 +124,7 @@ function M.render(model, opts)
     local theirs_regions = locate_regions(theirs, model.regions, "theirs")
     columns[#columns + 1] = {
         side = "theirs",
-        lines = theirs,
+        lines = strip_cr(theirs),
         regions = theirs_regions,
         folds = fold_ranges(#theirs, theirs_regions),
     }

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -862,3 +862,210 @@ describe(":Differ mergetool diff4 base pane", function()
         assert.is_true(has_marker(s.result_buf)) -- the third conflict is still open
     end)
 end)
+
+-- take-base recovers the ancestor from a slab table keyed by the conflict's *original*
+-- index, so the live->original map has to survive anything that changes the region count.
+-- when it doesn't, take-base splices a different conflict's ancestor into the file, and
+-- :w stages it: wrong bytes in a tracked file with no warning
+describe(":Differ mergetool take-base anchoring", function()
+    after_each(function()
+        if merge.current() then
+            merge.close()
+        end
+    end)
+
+    -- three conflicts in one file, ancestors base5 / base15 / base25, far enough apart that
+    -- a mis-mapped slab is unmistakable. default conflictStyle: the markers carry no base,
+    -- so take-base goes through the recovered slabs
+    local function three_conflict_repo()
+        local function body(a, b, c)
+            local out = {}
+            for i = 1, 4 do
+                out[#out + 1] = "line" .. i
+            end
+            out[#out + 1] = a
+            for i = 6, 14 do
+                out[#out + 1] = "line" .. i
+            end
+            out[#out + 1] = b
+            for i = 16, 24 do
+                out[#out + 1] = "line" .. i
+            end
+            out[#out + 1] = c
+            out[#out + 1] = "tail"
+            return table.concat(out, "\n") .. "\n"
+        end
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git_ok(root, "init", "-q")
+        write(root .. "/f.txt", body("base5", "base15", "base25"))
+        git_ok(root, "add", "f.txt")
+        git_ok(root, "commit", "-q", "-m", "base")
+        git_ok(root, "checkout", "-q", "-b", "feature")
+        write(root .. "/f.txt", body("THEIRS5", "THEIRS15", "THEIRS25"))
+        git_ok(root, "commit", "-q", "-am", "theirs")
+        git_ok(root, "checkout", "-q", "main")
+        write(root .. "/f.txt", body("OURS5", "OURS15", "OURS25"))
+        git_ok(root, "commit", "-q", "-am", "ours")
+        git(root, "merge", "feature")
+        return root
+    end
+
+    -- the line the cursor must sit on for `region_at` to pick conflict `n` (1-based)
+    local function nth_marker_row(buf, n)
+        local seen = 0
+        for i, l in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
+            if l:sub(1, 7) == "<<<<<<<" then
+                seen = seen + 1
+                if seen == n then
+                    return i
+                end
+            end
+        end
+    end
+
+    local function body_of(buf)
+        return table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+    end
+
+    -- hand-resolving an *earlier* conflict changes the region count, which is what
+    -- collapses the map; take-base on what is now the first region must still recover
+    -- that region's own ancestor
+    it("recovers the right ancestor after an earlier conflict is hand-resolved", function()
+        local root = three_conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = assert(merge.current())
+
+        -- hand-resolve conflict 1: replace its whole block with OURS5
+        local first = nth_marker_row(s.result_buf, 1)
+        local last = first
+        local lines = vim.api.nvim_buf_get_lines(s.result_buf, 0, -1, false)
+        while lines[last]:sub(1, 7) ~= ">>>>>>>" do
+            last = last + 1
+        end
+        vim.bo[s.result_buf].modifiable = true
+        vim.api.nvim_buf_set_lines(s.result_buf, first - 1, last, false, { "OURS5" })
+
+        vim.api.nvim_win_set_cursor(s.result_win, { nth_marker_row(s.result_buf, 1), 0 })
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+
+        local out = body_of(s.result_buf)
+        assert.is_truthy(out:find("base15", 1, true)) -- its own ancestor
+        assert.is_nil(out:find("base5\n", 1, true)) -- not conflict 1's
+
+        -- and through to the index: :w auto-stages once no markers remain, so the wrong
+        -- bytes were committable without another gesture
+        vim.api.nvim_win_set_cursor(s.result_win, { nth_marker_row(s.result_buf, 1), 0 })
+        fire(s.result_buf, "differ: take ours")
+        vim.api.nvim_set_current_win(s.result_win)
+        vim.cmd("silent write")
+        local staged = git_ok(root, "show", ":f.txt")
+        assert.is_truthy(staged:find("base15", 1, true))
+        assert.is_nil(staged:find("base5\n", 1, true))
+    end)
+
+    -- no hand-editing at all: two keymap resolves then one undo restores a region, so the
+    -- count no longer matches what the splices left behind
+    it("recovers the right ancestor after a resolve is undone", function()
+        local root = three_conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = assert(merge.current())
+
+        vim.api.nvim_set_current_win(s.result_win)
+        vim.api.nvim_win_set_cursor(s.result_win, { nth_marker_row(s.result_buf, 1), 0 })
+        fire(s.result_buf, "differ: take ours")
+        -- force a new undo block, the way returning to the keyboard between two real
+        -- keystrokes does; without it both splices coalesce and one undo reverts both
+        vim.api.nvim_buf_call(s.result_buf, function()
+            vim.cmd("let &l:undolevels = &l:undolevels")
+        end)
+        vim.api.nvim_win_set_cursor(s.result_win, { nth_marker_row(s.result_buf, 1), 0 })
+        fire(s.result_buf, "differ: take ours")
+        vim.cmd("silent undo")
+
+        vim.api.nvim_win_set_cursor(s.result_win, { nth_marker_row(s.result_buf, 1), 0 })
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+
+        -- the restored conflict is the middle one, so its ancestor is base15; any other
+        -- conflict's ancestor appearing means the map handed back the wrong slab
+        local out = body_of(s.result_buf)
+        assert.is_truthy(out:find("base15", 1, true))
+        assert.is_nil(out:find("base25", 1, true))
+        assert.is_nil(out:find("base5\n", 1, true))
+    end)
+end)
+
+-- the stages are raw blob bytes, so on a CRLF repo each line ends `\r`. nvim strips that
+-- into fileformat=dos when it loads the worktree file, so a base slab carrying its own CR
+-- makes :w write two — wrong bytes in a tracked file, silently staged
+describe(":Differ mergetool take-base on CRLF", function()
+    after_each(function()
+        if merge.current() then
+            merge.close()
+        end
+    end)
+
+    local function crlf_conflict_repo()
+        local function body(mid)
+            local out = {}
+            for i = 1, 5 do
+                out[#out + 1] = "line" .. i
+            end
+            out[#out + 1] = mid
+            out[#out + 1] = "line7"
+            return table.concat(out, "\r\n") .. "\r\n"
+        end
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git_ok(root, "init", "-q")
+        write(root .. "/f.txt", body("base6"))
+        git_ok(root, "add", "f.txt")
+        git_ok(root, "commit", "-q", "-m", "base")
+        git_ok(root, "checkout", "-q", "-b", "feature")
+        write(root .. "/f.txt", body("THEIRS6"))
+        git_ok(root, "commit", "-q", "-am", "theirs")
+        git_ok(root, "checkout", "-q", "main")
+        write(root .. "/f.txt", body("OURS6"))
+        git_ok(root, "commit", "-q", "-am", "ours")
+        git(root, "merge", "feature")
+        return root
+    end
+
+    local function bytes_of(path)
+        local fd = assert(io.open(path, "rb"))
+        local data = fd:read("*a")
+        fd:close()
+        return data
+    end
+
+    it("writes one CR per line, not two", function()
+        local root = crlf_conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = assert(merge.current())
+        assert.are.equal("dos", vim.bo[s.result_buf].fileformat)
+
+        assert.is_true(fire(s.result_buf, "differ: take base"))
+        vim.api.nvim_set_current_win(s.result_win)
+        vim.cmd("silent write")
+
+        local data = bytes_of(root .. "/f.txt")
+        assert.is_nil(data:find("\r\r", 1, true)) -- the doubled CR
+        assert.is_truthy(data:find("base6\r\n", 1, true)) -- the ancestor, cleanly terminated
+    end)
+
+    it("renders the input panes without a trailing ^M", function()
+        local root = crlf_conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({ layout = "diff4" })
+        local s = assert(merge.current())
+        for _, inp in ipairs(s.inputs) do
+            local buf = vim.api.nvim_win_get_buf(inp.win)
+            for _, line in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
+                assert.is_nil(line:find("\r", 1, true), inp.side .. " pane carries a CR")
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
## Summary
- fix: take-base spliced **another conflict's ancestor** into the file, silently, and `:w` auto-staged it. the live→original map reset to identity whenever the conflict-region count changed: a hand-resolve, or an undo after a resolve, which needs no hand-editing at all. only under git's default `merge.conflictStyle`
- fix: that map is anchored to extmarks now rather than positions, so it survives edits, resolves and undo
- fix: a resolve replaces only the conflict's own lines; the whole-buffer rewrite was deleting every anchor
- fix: take-base refuses when it can't identify the conflict instead of guessing
- fix: take-base no longer doubles the CR on CRLF repos (`base6\r\r\n`, staged silently)
- fix: the input panes render CRLF stages without a trailing `^M`

## Test plan
- [x] `make check` — lua unit 370/0, headless-nvim 424/0, go ok
- [x] 4 new tests, each proven to fail before the fix
- [x] the hand-resolve test asserts through to `git show :f.txt`, where the damage actually lands
- [x] verified live against real local conflicts first; diff3/zdiff3 escape the corruption but not the pane desync
