### PR TITLE
fix: hold the destructive verbs to the prompt, and the pr to its own repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Reverting a hunk with `X` could destroy a different hunk, or a hunk in another file, when anything changed the repo while the confirm prompt was up
+
+## [0.1.27] — 2026-08-11
+
+### Fixed
+
 - The merge tool could splice a different conflict's ancestor into the file. Take-base looked the ancestor up by position in a map that reset whenever the number of conflict regions changed, which happens when you hand-resolve one or undo a resolve: the text landed silently, `:w` staged it, and it was committable with no warning. Only under git's default `merge.conflictStyle`, where differ has to recover the ancestor itself
 - The merge tool wrote a doubled carriage return on CRLF files. Take-base's ancestor came from the raw stage blob, so its lines kept the CR the buffer had already stripped, and saving added a second one. The base pane rendered the stray `^M` too
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Reverting a hunk with `X` could destroy a different hunk, or a hunk in another file, when anything changed the repo while the confirm prompt was up
+- Discarding a file with `X` on the panel could delete it while leaving its staged copy in the index, if something staged it while the confirm prompt was up
 - `:Differ pr owner/repo#n` from an unrelated checkout treated your own files as the pull request's: `df`/`de` opened and saved them under its name, and `:Differ pr checkout` fetched into your repo. Both now need the current directory to be a clone of that repo
 
 ## [0.1.27] — 2026-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Reverting a hunk with `X` could destroy a different hunk, or a hunk in another file, when anything changed the repo while the confirm prompt was up
+- `:Differ pr owner/repo#n` from an unrelated checkout treated your own files as the pull request's: `df`/`de` opened and saved them under its name, and `:Differ pr checkout` fetched into your repo. Both now need the current directory to be a clone of that repo
 
 ## [0.1.27] — 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ On top of the diff + panel keys.
 | `gS` | Submit the review (pick a verdict, then write a summary) |
 | `gD` | Discard the review and its draft comments (confirms) |
 
-`df`/`de` edit the worktree file on disk, not the reviewed blob, so keep your checkout on the PR's head branch (`:Differ pr checkout`) or the two can drift; differ warns once a session if they don't match.
+`df`/`de` edit the worktree file on disk, not the reviewed blob, so keep your checkout on the PR's head branch (`:Differ pr checkout`) or the two can drift; differ warns once a session if they don't match. Both verbs, and `:Differ pr checkout` itself, need the current directory to be a clone of the PR's own repo - either side of a fork counts. Reviewing another repo's PR from your own checkout is read-only.
 
 #### PR overview
 

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -310,7 +310,10 @@ On top of the diff + panel keys.
   -----------------------------------------------------------------------
 `df`/`de` edit the worktree file on disk, not the reviewed blob, so keep your
 checkout on the PR’s head branch (`:Differ pr checkout`) or the two can
-drift; differ warns once a session if they don’t match.
+drift; differ warns once a session if they don’t match. Both verbs, and
+`:Differ pr checkout` itself, need the current directory to be a clone of the
+PR’s own repo - either side of a fork counts. Reviewing another repo’s PR
+from your own checkout is read-only.
 
 
 PR OVERVIEW ~

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -721,13 +721,39 @@ local function remove_ok(abs)
     return true
 end
 
+-- the entry's status as git reports it now, or nil when the path has no changes left.
+-- the panel's entries are a snapshot taken before the confirm, and the same side of
+-- the file the entry came from is the side to re-read
+---@param root string
+---@param entry differ.FileEntry
+---@return string|nil status
+local function live_status(root, entry)
+    local out = git({ "status", "--porcelain=v1", "-z", "-uall", "--", entry.path }, root)
+    for _, s in ipairs(rev.parse_status(out or "")) do
+        if s.path == entry.path then
+            return s.x == "?" and "?" or (entry.staged and s.x or s.y)
+        end
+    end
+    return nil
+end
+
 -- discard a file's changes: untracked or a staged-add drops the file (unstaging
 -- first if needed); anything tracked in HEAD reverts index + worktree to HEAD.
--- destructive, so the panel confirms before calling this
+-- destructive, so the panel confirms before calling this. confirm() drains scheduled
+-- callbacks while it blocks, so the status the caller holds can have moved under the
+-- prompt: the three branches differ in whether they delete the file, so a status that
+-- no longer matches refuses rather than picking by the stale one
 ---@param root string
 ---@param entry differ.FileEntry
 ---@return boolean ok
 function M.discard(root, entry)
+    if live_status(root, entry) ~= entry.status then
+        notify(
+            ("discard skipped: %s changed since the prompt"):format(entry.path),
+            vim.log.levels.WARN
+        )
+        return false
+    end
     local abs = root .. "/" .. entry.path
     local ok
     if entry.status == "?" then

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -55,6 +55,19 @@ local function short(sha)
     return sha and sha:sub(1, 7) or "?"
 end
 
+-- the cwd's repo, but only when it is a clone of the pr's own repo. an unrelated
+-- checkout has its own files at the same paths, so the edit verbs would open those as
+-- "the real file" and checkout would fetch into it; nil disables both instead
+---@param coords { owner: string, repo: string }
+---@return string|nil
+local function local_root(coords)
+    local root = require("differ.git").root(vim.fn.getcwd())
+    if root and require("differ.pr.repo").has_remote(root, coords) then
+        return root
+    end
+    return nil
+end
+
 -- run a session in its own tabpage (like git/init.lua): the invoking tab is never
 -- touched, so ending the session drops the tab and returns there
 ---@return integer return_tab, integer session_tab
@@ -505,7 +518,13 @@ local function editable_view()
         return nil
     end
     if not session.root then
-        notify("editing needs a local checkout of this repo", vim.log.levels.WARN)
+        notify(
+            ("editing needs a local clone of %s/%s"):format(
+                session.coords.owner,
+                session.coords.repo
+            ),
+            vim.log.levels.WARN
+        )
         return nil
     end
     warn_head_mismatch()
@@ -680,7 +699,7 @@ local function open_session(pr, detail, opts)
             draft = detail.draft,
             mergeable = detail.mergeable,
         },
-        root = require("differ.git").root(vim.fn.getcwd()), -- optional; for jump-to-file
+        root = local_root(pr), -- optional; for jump-to-file
         entries = entries, -- flat FileEntry[] (single section), shared by ref with the panel
         versions = {}, -- per-path blob memo; valid for the session (shas are pinned)
         prefetching = {}, -- paths with an in-flight predictive prefetch (dedupe guard)
@@ -1187,9 +1206,14 @@ function M.checkout()
             return notify("no head branch to check out", vim.log.levels.WARN)
         end
         local git = require("differ.git")
-        local root = s.root or git.root(vim.fn.getcwd())
+        -- no cwd fallback: fetching the pr's refs into an unrelated repo lands whatever
+        -- its own refs/pull/<n>/head happens to be, under this pr's branch name
+        local root = s.root
         if not root then
-            return notify("not inside a git repository", vim.log.levels.WARN)
+            return notify(
+                ("checkout needs a local clone of %s/%s"):format(s.coords.owner, s.coords.repo),
+                vim.log.levels.WARN
+            )
         end
         local ok, err = git.checkout(root, ref, s.pr.number)
         if not ok then

--- a/lua/differ/pr/repo.lua
+++ b/lua/differ/pr/repo.lua
@@ -125,4 +125,21 @@ function M.resolve(opts, cb)
     return cb({ code = "bad_request", message = msg })
 end
 
+-- whether `root` is a clone of `coords`. every github remote is checked, not just the
+-- one resolve() would pick: on a fork both sides are legitimate local checkouts, and
+-- which of them wins the precedence order says nothing about the pr being opened
+---@param root string
+---@param coords { owner: string, repo: string }
+---@return boolean
+function M.has_remote(root, coords)
+    for _, name in ipairs(list_remotes(root)) do
+        local url = remote_url(name, root)
+        local c = url and url ~= "" and M.parse_remote(url) or nil
+        if c and c.owner == coords.owner and c.repo == coords.repo then
+            return true
+        end
+    end
+    return false
+end
+
 return M

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -1299,8 +1299,19 @@ function View:revert_hunk()
     local label = self.staging.revert_label
     local prompt = label and ("Revert all of %s? This %s."):format(self.model.path, label)
         or ("Revert hunk %d/%d in %s?"):format(idx, #self.model.hunks, self.model.path)
+    -- confirm() drains scheduled callbacks while it blocks, so the fs-watcher can
+    -- re-source the view mid-prompt. idx and the prompt name the model that was on
+    -- screen when it was asked; against a new one they'd take a different hunk, or a
+    -- hunk in whatever file the panel moved to
+    local asked_on = self.model
     if vim.fn.confirm(prompt, "&Yes\n&No", 2) ~= 1 then
         return
+    end
+    if self.model ~= asked_on then
+        return vim.notify(
+            "differ: the diff changed while the prompt was up; nothing was reverted",
+            vim.log.levels.WARN
+        )
     end
 
     local offset = self.model.new_rev == "INDEX" and self:_unstage_offset(idx) or 0

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1869,6 +1869,107 @@ describe(":Differ diff hunk staging", function()
         p:close()
     end)
 
+    -- confirm() drains scheduled callbacks while it blocks, so a watcher fire can
+    -- re-source the view between the prompt and the revert. the stub stands in for that
+    -- drain by doing what refresh_external ends at: a set_source under the open prompt
+    it("reverts nothing when the same file is re-sourced under the prompt", function()
+        local root = fresh_repo()
+        local base = {}
+        for i = 1, 30 do
+            base[i] = ("line%02d"):format(i)
+        end
+        write(root .. "/a.lua", table.concat(base, "\n") .. "\n")
+        git(root, "commit", "-q", "-am", "30 lines")
+        local edited = vim.deepcopy(base)
+        edited[5], edited[15], edited[25] = "CHANGED05", "CHANGED15", "CHANGED25"
+        write(root .. "/a.lua", table.concat(edited, "\n") .. "\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal(3, #v.model.hunks)
+        local asked_on = v.model
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { hunk_line(v, 2), 0 }) -- the CHANGED15 hunk
+
+        _G.notifs = {}
+        local swapped -- read inside the stub, so it holds however the revert goes on
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function()
+            -- the first hunk goes away outside differ, so hunk 2 is now CHANGED25
+            local dropped = vim.deepcopy(edited)
+            dropped[5] = base[5]
+            write(root .. "/a.lua", table.concat(dropped, "\n") .. "\n")
+            p:refresh()
+            vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "a.lua"), 0 })
+            p:select()
+            swapped = v.model ~= asked_on
+            return 1
+        end
+        local ok, err = pcall(function()
+            v:revert_hunk()
+        end)
+        vim.fn.confirm = orig
+        assert(ok, err)
+
+        assert.is_true(swapped) -- the re-source landed, so this isn't vacuous
+        local after = worktree(root, "a.lua")
+        assert.is_not_nil(after:find("CHANGED15", 1, true)) -- the hunk the prompt named
+        assert.is_not_nil(after:find("CHANGED25", 1, true)) -- the one index 2 slid onto
+        assert.are.equal(
+            "differ: the diff changed while the prompt was up; nothing was reverted",
+            _G.notifs[#_G.notifs].msg
+        )
+        p:close()
+    end)
+
+    -- when the shown file goes clean mid-prompt the watcher hands the window to another
+    -- file, and revert is path-agnostic: it would patch whatever model it was handed
+    it("reverts nothing when a different file is re-sourced under the prompt", function()
+        local root = fresh_repo()
+        write(root .. "/z.lua", "local z = 9\nreturn z\n")
+        git(root, "add", "z.lua")
+        git(root, "commit", "-q", "-m", "add z")
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        write(root .. "/z.lua", "local z = 99\nreturn z\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        local v = view_in_origin(p)
+        assert.are.equal("a.lua", v.model.path)
+
+        vim.api.nvim_set_current_win(p.origin_win)
+        vim.api.nvim_win_set_cursor(p.origin_win, { 1, 0 })
+
+        _G.notifs = {}
+        local swapped_to -- read inside the stub, so it holds however the revert goes on
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function()
+            vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "z.lua"), 0 })
+            p:select()
+            swapped_to = v.model.path
+            return 1
+        end
+        local ok, err = pcall(function()
+            v:revert_hunk()
+        end)
+        vim.fn.confirm = orig
+        assert(ok, err)
+
+        assert.are.equal("z.lua", swapped_to) -- the re-source landed
+        -- the prompt named a.lua, so z.lua was never in the question
+        assert.are.equal("local z = 99\nreturn z\n", worktree(root, "z.lua"))
+        assert.are.equal("local x = 2\nreturn x\n", worktree(root, "a.lua"))
+        assert.are.equal(
+            "differ: the diff changed while the prompt was up; nothing was reverted",
+            _G.notifs[#_G.notifs].msg
+        )
+        p:close()
+    end)
+
     it("reverts a staged hunk out of the index and the worktree together", function()
         local root = fresh_repo()
         write(root .. "/a.lua", "1\n2\n3\n4\n5\n6\n7\n8\n")

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -1162,6 +1162,33 @@ describe(":Differ panel staging (slice C)", function()
         p:close()
     end)
 
+    -- confirm() drains scheduled callbacks while it blocks, so the entry's status can
+    -- move under the prompt. an untracked file staged from outside is the sharp case:
+    -- the "?" branch deletes it while the index keeps the add
+    it("refuses to discard a file whose status moved under the prompt", function()
+        local root = fresh_repo()
+        write(root .. "/u.lua", "untracked\n")
+        vim.cmd.edit(root .. "/a.lua")
+        git_src.panel({})
+        local p = Panel.current()
+        vim.api.nvim_win_set_cursor(p.winid, { file_line(p, "u.lua"), 0 })
+
+        _G.notifs = {}
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function()
+            git(root, "add", "u.lua") -- "?" -> a staged add, from outside differ
+            return 1
+        end
+        p:discard()
+        vim.fn.confirm = orig
+
+        assert.are.equal(1, vim.fn.filereadable(root .. "/u.lua"))
+        -- and the index still has the add, so the two can't disagree
+        assert.are.equal("untracked\n", git(root, "show", ":u.lua"))
+        assert.is_truthy(_G.notifs[#_G.notifs].msg:find("discard skipped: u.lua", 1, true))
+        p:close()
+    end)
+
     it("stages and unstages every file under a directory row", function()
         local root = fresh_repo()
         -- two files under src/, plus a sibling at the root so src/ stays a foldable

--- a/test/nvim/pr_nav_spec.lua
+++ b/test/nvim/pr_nav_spec.lua
@@ -454,7 +454,8 @@ local function enter_review()
 end
 
 -- a throwaway worktree holding `rel` on disk, so the edit verbs (which open the real
--- file at model.root/path) have something readable. redirect the view's model.root here
+-- file at model.root/path) have something readable. point session.root and the view's
+-- model.root here: the session's own root is nil under a cwd that isn't the pr's repo
 ---@param rel string
 ---@param content string
 local function make_worktree_file(rel, content)
@@ -562,7 +563,7 @@ describe("pr edit verbs (df/de)", function()
         local restore = open_overview(default_responses())
         local s = enter_review()
         local tmp = make_worktree_file("a.txt", "a\nB\nc\n")
-        s.view.model.root = tmp.root
+        s.root, s.view.model.root = tmp.root, tmp.root
 
         local view = s.view
         local diff_buf = view:column_for("new").bufnr
@@ -591,7 +592,7 @@ describe("pr edit verbs (df/de)", function()
         local restore = open_overview(default_responses())
         local s = enter_review()
         local tmp = make_worktree_file("a.txt", "a\nB\nc\n")
-        s.view.model.root = tmp.root
+        s.root, s.view.model.root = tmp.root, tmp.root
         review_tab = vim.api.nvim_get_current_tabpage()
 
         local view = s.view
@@ -618,7 +619,7 @@ describe("pr edit verbs (df/de)", function()
         local restore = open_overview(default_responses())
         local s = enter_review()
         local tmp = make_worktree_file("a.txt", "a\nB\nc\n")
-        s.view.model.root = tmp.root
+        s.root, s.view.model.root = tmp.root, tmp.root
         review_tab = vim.api.nvim_get_current_tabpage()
 
         local view = s.view
@@ -656,12 +657,14 @@ describe("pr edit verbs (df/de)", function()
     it("df without a local checkout (no session.root) notifies and no-ops", function()
         local restore = open_overview(default_responses())
         local s = enter_review()
-        s.root = nil -- simulate a repo with no local checkout
+        assert.is_nil(s.root) -- the test cwd is differ.nvim, not acme/widget
 
         local before = #_G.notifs
         pr.edit_split()
 
-        assert.is_truthy(_G.notifs[#_G.notifs].msg:find("editing needs a local checkout", 1, true))
+        assert.is_truthy(
+            _G.notifs[#_G.notifs].msg:find("editing needs a local clone of acme/widget", 1, true)
+        )
         assert.is_nil(s.view.edit_win) -- no edit window opened
         assert.is_true(#_G.notifs > before)
 

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -290,3 +290,118 @@ describe("pr review lifecycle keymaps", function()
         restore()
     end)
 end)
+
+describe("pr session root", function()
+    local function git(cwd, ...)
+        local args = { "git", "-c", "user.email=t@t", "-c", "user.name=t" }
+        vim.list_extend(args, { ... })
+        local res = vim.system(args, { cwd = cwd, text = true }):wait()
+        assert(res.code == 0, "git failed: " .. table.concat({ ... }, " "))
+        return res.stdout
+    end
+
+    -- a repo whose remotes are `urls` keyed by remote name
+    ---@param urls table<string, string>
+    local function repo_with_remotes(urls)
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        git(root, "init", "-q")
+        for name, url in pairs(urls) do
+            git(root, "remote", "add", name, url)
+        end
+        return root
+    end
+
+    local repo = require("differ.pr.repo")
+
+    it("matches a clone of the pr's repo, whichever remote carries it", function()
+        local root = repo_with_remotes({
+            origin = "git@github.com:me/widget.git",
+            upstream = "https://github.com/acme/widget",
+        })
+        -- a fork checkout is a legitimate local clone of either side, so both match
+        -- even though resolve() would only ever return upstream
+        assert.is_true(repo.has_remote(root, { owner = "acme", repo = "widget" }))
+        assert.is_true(repo.has_remote(root, { owner = "me", repo = "widget" }))
+        assert.is_false(repo.has_remote(root, { owner = "acme", repo = "other" }))
+        assert.is_false(repo.has_remote(root, { owner = "other", repo = "widget" }))
+    end)
+
+    it("ignores non-github and unparsable remotes", function()
+        local root = repo_with_remotes({
+            origin = "https://gitlab.com/acme/widget.git",
+            weird = "not a url",
+        })
+        assert.is_false(repo.has_remote(root, { owner = "acme", repo = "widget" }))
+    end)
+
+    -- session.root drives the edit verbs (which open root/path as "the real file") and
+    -- :Differ pr checkout (which fetches into it), so an unrelated cwd must not set it
+    local function show_from(cwd)
+        vim.cmd.cd(vim.fn.fnameescape(cwd)) -- global: after_each puts it back
+        local restore = stub_sidecar({
+            get_pr = { result = get_pr_result() },
+            get_file_versions = {
+                result = { base = { content = "a\n" }, head = { content = "b\n" } },
+            },
+            get_threads = { result = {} },
+        })
+        pr.show(PR)
+        assert.is_true(vim.wait(1000, function()
+            local s = pr.current_session()
+            return s and s.view and s.view:is_open()
+        end))
+        local s = pr.current_session()
+        restore()
+        return s
+    end
+
+    -- the spec files resolve `require` against a relative package.path, so a leaked cwd
+    -- breaks every suite loaded after this one
+    local saved_cwd
+    before_each(function()
+        saved_cwd = vim.fn.getcwd()
+    end)
+    after_each(function()
+        if pr.current_session() then
+            pr.end_session()
+        end
+        vim.cmd.cd(vim.fn.fnameescape(saved_cwd))
+    end)
+
+    it("takes the cwd's repo when it is a clone of the pr's repo", function()
+        local root = repo_with_remotes({ origin = "git@github.com:acme/widget.git" })
+        assert.are.equal(vim.fn.resolve(root), vim.fn.resolve(show_from(root).root))
+    end)
+
+    it("leaves root nil in an unrelated repo, rather than adopting its files", function()
+        local root = repo_with_remotes({ origin = "git@github.com:acme/mine.git" })
+        assert.is_nil(show_from(root).root)
+    end)
+
+    it(
+        "refuses :Differ pr checkout without a local clone, rather than fetching into the cwd",
+        function()
+            -- origin is a local bare repo, so a fetch that shouldn't happen fails here
+            -- rather than reaching github: the refusal is what's under test, not the fetch
+            local bare = vim.fn.tempname()
+            vim.fn.mkdir(bare, "p")
+            git(bare, "init", "-q", "--bare")
+            local root = repo_with_remotes({ origin = bare })
+            local s = show_from(root)
+            assert.is_nil(s.root)
+
+            _G.notifs = {}
+            pr.checkout()
+            assert.is_truthy(
+                _G.notifs[#_G.notifs].msg:find(
+                    "checkout needs a local clone of acme/widget",
+                    1,
+                    true
+                )
+            )
+            -- the unrelated repo is untouched: no branch created, no FETCH_HEAD
+            assert.are.equal("", vim.trim(git(root, "branch", "--list", "feature")))
+        end
+    )
+end)


### PR DESCRIPTION
## Summary

- fix: `X` on a hunk could destroy **a different hunk, or one in another file**, silently and reporting success. `confirm()` drains scheduled callbacks while it blocks, so a watcher fire re-sources the view between the captured index and the revert; the prompt names one hunk and another goes
- fix: the revert now captures the model before the prompt and refuses if it moved after. that also covers the uncaught `E5108` when the index outran a shorter hunk list
- fix: `X` on a panel file could delete it while leaving its staged copy in the index (`AD`), if something staged it while the prompt was up. discard re-reads the status from git and refuses when it has moved
- fix: `:Differ pr owner/repo#n` from an unrelated checkout treated your own files as the pull request's. `df`/`de` opened and saved them under its name, and `:Differ pr checkout` fetched into your repo, checking out its own `refs/pull/<n>/head` under the other repo's branch name
- fix: `session.root` is set only when the cwd is a clone of the pr's repo, matched on any github remote so both sides of a fork count. cross-repo review is read-only, documented in the readme

## Test plan

- [x] `make check` — lua unit 370/0, headless-nvim 432/0, luacheck 0, lua_ls clean, go ok
- [x] 8 new tests; the 6 regression ones each proven to fail on a faithful revert, the other 2 cover the new remote match
- [x] the revert tests drive the real `set_source` the watcher reaches, and assert on bytes on disk
- [x] verified live first: 4/4 repros of the hunk case, one with no instrumentation loaded
- [x] `make vimdoc` regenerated for the readme change
