### PR TITLE
fix: aim gx and gp at the comment they name

### DIFF
--- a/.demo/fake-sidecar/fixtures.go
+++ b/.demo/fake-sidecar/fixtures.go
@@ -140,6 +140,14 @@ func (f *fixture) GetThreads(_ context.Context, _, _ string, _ int) ([]github.Th
 	defer f.mu.Unlock()
 	out := make([]github.Thread, len(f.threads))
 	copy(out, f.threads)
+	// nothing here is capped, so the last comment is the newest; the real client selects
+	// it separately because its list isn't
+	for i, t := range out {
+		if n := len(t.Comments); n > 0 {
+			last := t.Comments[n-1]
+			out[i].NewestComment = &github.NewestComment{NodeID: last.NodeID, Body: last.Body}
+		}
+	}
 	return out, nil
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build
         run: make go-build
 
+      - name: Build demo fixture sidecar
+        run: make demo-build
+
   stylua:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `gx` on a thread with more than 100 comments deleted the wrong one, which could be another author's published comment rather than your own draft. It now asks GitHub for the thread's newest comment instead of taking the last one it had read
+- `gx` and `gp` on a line carrying more than one thread silently acted on the oldest, so you could delete from or reply to a thread you weren't reading. They now ask which one
 
 ## [0.1.28] — 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `gx` on a thread with more than 100 comments deleted the wrong one, which could be another author's published comment rather than your own draft. It now asks GitHub for the thread's newest comment instead of taking the last one it had read
+
+## [0.1.28] — 2026-08-11
+
+### Fixed
+
 - Reverting a hunk with `X` could destroy a different hunk, or a hunk in another file, when anything changed the repo while the confirm prompt was up
 - Discarding a file with `X` on the panel could delete it while leaving its staged copy in the index, if something staged it while the confirm prompt was up
 - `:Differ pr owner/repo#n` from an unrelated checkout treated your own files as the pull request's: `df`/`de` opened and saved them under its name, and `:Differ pr checkout` fetched into your repo. Both now need the current directory to be a clone of that repo

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ PANDOC_VERSION    := 3.10.1
 
 .PHONY: help \
 	lua-test lua-test-unit lua-test-nvim lua-lint lua-typecheck lua-fmt lua-fmt-check \
-	go-build go-test go-vet go-lint go-fmt go-fmt-check \
+	go-build demo-build go-test go-vet go-lint go-fmt go-fmt-check \
 	test lint fmt fmt-check check clean \
 	vimdoc \
 	demo demo-fixtures
@@ -98,6 +98,12 @@ go-build: ## Build the differ-sidecar binary into bin/
 	@go build -ldflags "$(GO_LDFLAGS)" -o $(GO_BIN) $(GO_PKG)
 	@$(OK) "Built $(GO_BIN)"
 
+# the demo's fixture sidecar compiles against internal/github, so a type change there can
+# break it. `./...` never expands into a dot-directory, so it needs the explicit path
+demo-build: ## Type-check the demo fixture sidecar (.demo is invisible to ./...)
+	@go build -o /dev/null ./.demo/fake-sidecar
+	@$(OK) "Demo fixture sidecar builds"
+
 go-test: ## Run Go tests
 	@go test ./...
 
@@ -110,11 +116,11 @@ go-lint: ## Run golangci-lint over the module
 	@$(OK) "Go lint clean"
 
 go-fmt: ## Format Go sources with gofmt
-	@gofmt -w cmd internal
+	@gofmt -w cmd internal .demo
 	@$(OK) "Go formatted"
 
 go-fmt-check: ## Verify Go formatting without writing
-	@out=$$(gofmt -l cmd internal); \
+	@out=$$(gofmt -l cmd internal .demo); \
 	if [ -n "$$out" ]; then \
 		printf "$(RED)gofmt needed:$(NC)\n%s\n" "$$out"; \
 		exit 1; \
@@ -176,7 +182,7 @@ fmt: lua-fmt go-fmt ## Format the whole codebase (Lua + Go)
 
 fmt-check: lua-fmt-check go-fmt-check ## Verify formatting across the codebase
 
-check: lint lua-typecheck go-vet test ## Run the full quality gate
+check: fmt-check lint lua-typecheck go-vet demo-build test ## Run the full quality gate
 
 clean: ## Remove build artefacts
 	@rm -rf bin differ-sidecar

--- a/README.md
+++ b/README.md
@@ -463,53 +463,6 @@ require("differ").goto_hunk("next", {
 
 <!-- panvimdoc-ignore-start -->
 
-## Architecture
-
-A monorepo: a Lua renderer core (`lua/differ/`) and a Go sidecar (`cmd/differ-sidecar/`), so protocol changes land atomically across both. The hunk model is canonical and buffers are projections of it; renderers are pure functions over hunks, which is why a layout toggle is just a re-render.
-
-```
-frontends            core (lua/differ)
-┌──────────────┐     ┌──────────────────────────────┐
-│ local diff   │────▶│  hunk model (canonical)      │
-│ (git + diff) │     │  ├─ renderer: stacked        │
-├──────────────┤     │  ├─ renderer: side-by-side   │
-│ PR review    │────▶│  ├─ word-level highlight pass│
-│ (sidecar)    │     │  ├─ syntax pass (treesitter) │
-└──────┬───────┘     │  └─ line map (bidirectional) │
-       │             └──────────────────────────────┘
-       │ JSON over stdio
-       ▼
-┌──────────────────┐         ┌─────────────┐
-│ differ-sidecar   │────────▶│ GitHub API  │
-│ (Go, gh auth)    │         │ (REST+GQL)  │
-└──────────────────┘         └─────────────┘
-```
-
-<details>
-<summary><b>Repository layout</b></summary>
-
-```
-lua/differ/
-  init.lua          # setup() + public API (diff / open)
-  config.lua        # option defaults and merge
-  command.lua       # :Differ subcommand router
-  view.lua          # per-view state, windows, in-view keymaps
-  model/diff.lua    # hunk model from vim.diff
-  render/           # walk, line map, stacked + split renderers
-  worddiff/         # tokenizer, line pairing, span computation
-  syntax/           # treesitter pass projected through the line map
-  ui/               # statuscolumn rail, paint, highlight groups
-  git/              # local source: rev-spec grammar + git I/O
-cmd/differ-sidecar/ # go github sidecar
-test/
-  unit/             # pure-Lua busted specs (no Neovim runtime)
-  nvim/             # headless-nvim specs (extmark/window assertions)
-```
-
-</details>
-
----
-
 ## Licence
 
 [MIT](LICENCE)

--- a/internal/github/dtos.go
+++ b/internal/github/dtos.go
@@ -99,6 +99,12 @@ type threadsGQL struct {
 					Comments     struct {
 						Nodes []commentGQL `json:"nodes"`
 					} `json:"comments"`
+					NewestComment struct {
+						Nodes []struct {
+							ID   string `json:"id"`
+							Body string `json:"body"`
+						} `json:"nodes"`
+					} `json:"newestComment"`
 				} `json:"nodes"`
 				PageInfo pageInfoGQL `json:"pageInfo"`
 			} `json:"reviewThreads"`

--- a/internal/github/queries.go
+++ b/internal/github/queries.go
@@ -31,11 +31,15 @@ query GetPR($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   }
 }`
 
+// the inner comments cap in getThreadsQuery, kept in step by TestThreadCommentsPage
+const threadCommentsPage = 100
+
 // getThreadsQuery fetches the PR's review threads (paginated) with their comments.
 // diffSide/startDiffSide carry the LEFT/RIGHT anchor; the comment state
 // distinguishes a submitted thread from an unsubmitted draft (is_pending); diffHunk
 // is the diff context each comment anchors to (the root's feeds the overview). inner
-// comments are capped at 100 (threads rarely exceed that).
+// comments are capped at threadCommentsPage; newestComment selects the last one, which
+// the cap may exclude.
 const getThreadsQuery = `
 query GetThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
@@ -60,6 +64,12 @@ query GetThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String
               createdAt
               state
               diffHunk
+            }
+          }
+          newestComment: comments(last: 1) {
+            nodes {
+              id
+              body
             }
           }
         }

--- a/internal/github/queries_lint_test.go
+++ b/internal/github/queries_lint_test.go
@@ -1,0 +1,130 @@
+package github
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// a connection taking first:/last: with no pageInfo beside it truncates silently, and
+// nothing downstream can tell a full page from a capped one. valid graphql, so no schema
+// check sees it. the two lists below are the only exemptions, and each entry carries why
+
+var queryConstants = []struct {
+	name string
+	body string
+}{
+	{"getPRQuery", getPRQuery},
+	{"getThreadsQuery", getThreadsQuery},
+	{"getPendingReviewQuery", getPendingReviewQuery},
+	{"getTimelineQuery", getTimelineQuery},
+	{"getChecksQuery", getChecksQuery},
+}
+
+// bounded to one node by their own arguments, so there is no page to miss
+var singularSelections = map[string]string{
+	"getThreadsQuery.newestComment": "last: 1; the thread's newest comment, which the capped comments field beside it may exclude",
+	"getPendingReviewQuery.reviews": "first: 1; a viewer has at most one pending review per pr",
+	"getChecksQuery.commits":        "last: 1; the head commit only",
+}
+
+// known to truncate, with nowhere on the wire to say so: the dtos carry only Nodes, so
+// asking for pageInfo would change nothing until they grow a carrier. this list only
+// shrinks — an entry earns its place by naming what the overflow costs
+var truncatingSelections = map[string]string{
+	"getThreadsQuery.comments":       "100 of a thread's comments render in order with no marker, and the collapsed line reports 100",
+	"getPendingReviewQuery.comments": "read by nothing today; traced from the dto through to both lua callers, which take review_id only",
+	"getTimelineQuery.reviews":       "the oldest 100 verdicts render on the overview timeline; nothing derives state from them",
+	"getChecksQuery.contexts":        "100 checks under a server-computed rollup, so the badge stays correct while the rows are short",
+}
+
+// alias, field name, and the argument list of a field that takes arguments
+var argumentedField = regexp.MustCompile(`(?:(\w+)\s*:\s*)?(\w+)\s*\(([^)]*)\)`)
+
+var paginationArg = regexp.MustCompile(`\b(?:first|last)\s*:`)
+
+func TestPaginatedSelectionsCarryPageInfo(t *testing.T) {
+	seen := map[string]bool{}
+	for _, q := range queryConstants {
+		for _, m := range argumentedField.FindAllStringSubmatchIndex(q.body, -1) {
+			if !paginationArg.MatchString(q.body[m[6]:m[7]]) {
+				continue
+			}
+			key := q.name + "." + fieldLabel(q.body, m)
+			seen[key] = true
+			if _, ok := singularSelections[key]; ok {
+				continue
+			}
+			set, ok := selectionSet(q.body[m[1]:])
+			if !ok {
+				continue
+			}
+			checkPageInfo(t, key, hasTopLevelField(set, "pageInfo"))
+		}
+	}
+	checkStale(t, seen)
+}
+
+func checkPageInfo(t *testing.T, key string, present bool) {
+	t.Helper()
+	_, filed := truncatingSelections[key]
+	switch {
+	case present && filed:
+		t.Errorf("%s now asks for pageInfo; drop it from truncatingSelections", key)
+	case !present && !filed:
+		t.Errorf("%s takes first:/last: with no pageInfo in its selection set.\n"+
+			"add pageInfo, or list it in singularSelections/truncatingSelections with a reason", key)
+	}
+}
+
+func checkStale(t *testing.T, seen map[string]bool) {
+	t.Helper()
+	for _, list := range []map[string]string{singularSelections, truncatingSelections} {
+		for key := range list {
+			if !seen[key] {
+				t.Errorf("%s is listed but no longer exists in the queries; drop it", key)
+			}
+		}
+	}
+}
+
+// the alias when there is one, since it is what tells two selections of the same field apart
+func fieldLabel(body string, m []int) string {
+	if m[2] >= 0 {
+		return body[m[2]:m[3]]
+	}
+	return body[m[4]:m[5]]
+}
+
+// the body of the block opening after a field's arguments, or false when it selects nothing
+func selectionSet(after string) (string, bool) {
+	open := strings.Index(after, "{")
+	if open < 0 || strings.TrimSpace(after[:open]) != "" {
+		return "", false
+	}
+	depth := 0
+	for i, r := range after[open:] {
+		switch r {
+		case '{':
+			depth++
+		case '}':
+			if depth--; depth == 0 {
+				return after[open+1 : open+i], true
+			}
+		}
+	}
+	return "", false
+}
+
+func hasTopLevelField(set, name string) bool {
+	for _, field := range identifiers.FindAllStringIndex(set, -1) {
+		prefix := set[:field[0]]
+		depth := strings.Count(prefix, "{") - strings.Count(prefix, "}")
+		if depth == 0 && set[field[0]:field[1]] == name {
+			return true
+		}
+	}
+	return false
+}
+
+var identifiers = regexp.MustCompile(`\w+`)

--- a/internal/github/results.go
+++ b/internal/github/results.go
@@ -69,11 +69,19 @@ type Thread struct {
 	// github nulls line/start_line once a thread's anchor leaves the diff. outdated says
 	// so explicitly, and original_line carries where it used to sit, so the client can
 	// place it deliberately rather than reading the zero as line 0
-	Outdated     bool            `json:"outdated"`
-	OriginalLine int             `json:"original_line,omitempty"`
-	Resolved     bool            `json:"resolved"`
-	IsPending    bool            `json:"is_pending"`
-	Comments     []ThreadComment `json:"comments"`
+	Outdated          bool            `json:"outdated"`
+	OriginalLine      int             `json:"original_line,omitempty"`
+	Resolved          bool            `json:"resolved"`
+	IsPending         bool            `json:"is_pending"`
+	Comments          []ThreadComment `json:"comments"`
+	CommentsTruncated bool            `json:"comments_truncated"` // comments hit the cap
+	NewestComment     *NewestComment  `json:"newest_comment,omitempty"`
+}
+
+// NewestComment is a thread's last comment, which Comments may be too short to include.
+type NewestComment struct {
+	NodeID string `json:"node_id"`
+	Body   string `json:"body"`
 }
 
 // ThreadComment is one comment in a Thread. ID is the numeric comment id; NodeID is

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -6,10 +6,10 @@ import (
 )
 
 // GetThreads returns the PR's review threads with their comments, paginating the
-// thread list. inner comment lists are capped at 100 (threads rarely exceed that;
-// the cap is revisited with caching). per thread, ID is the root comment's numeric
-// id (the reply anchor), ThreadID is the GraphQL node id resolve_thread targets,
-// and IsPending marks an unsubmitted draft (root comment in PENDING state).
+// thread list. inner comment lists are capped at threadCommentsPage and flagged when
+// they hit it. per thread, ID is the root comment's numeric id (the reply anchor),
+// ThreadID is the GraphQL node id resolve_thread targets, and IsPending marks an
+// unsubmitted draft (root comment in PENDING state).
 func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int) ([]Thread, error) {
 	key := threadKey(owner, repo, number)
 	if t, ok := c.cache.thread(key); ok {
@@ -32,16 +32,20 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 		threads := page.Repository.PullRequest.ReviewThreads
 		for _, n := range threads.Nodes {
 			t := Thread{
-				ThreadID:     n.ID,
-				Path:         n.Path,
-				Side:         n.DiffSide,
-				Line:         deref(n.Line),
-				StartSide:    n.StartSide,
-				StartLine:    deref(n.StartLine),
-				Outdated:     n.IsOutdated,
-				OriginalLine: deref(n.OriginalLine),
-				Resolved:     n.IsResolved,
-				Comments:     make([]ThreadComment, 0, len(n.Comments.Nodes)),
+				ThreadID:          n.ID,
+				Path:              n.Path,
+				Side:              n.DiffSide,
+				Line:              deref(n.Line),
+				StartSide:         n.StartSide,
+				StartLine:         deref(n.StartLine),
+				Outdated:          n.IsOutdated,
+				OriginalLine:      deref(n.OriginalLine),
+				Resolved:          n.IsResolved,
+				Comments:          make([]ThreadComment, 0, len(n.Comments.Nodes)),
+				CommentsTruncated: len(n.Comments.Nodes) >= threadCommentsPage,
+			}
+			if newest := n.NewestComment.Nodes; len(newest) > 0 {
+				t.NewestComment = &NewestComment{NodeID: newest[0].ID, Body: newest[0].Body}
 			}
 			for _, cm := range n.Comments.Nodes {
 				t.Comments = append(t.Comments, ThreadComment{

--- a/internal/github/threads_test.go
+++ b/internal/github/threads_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -122,5 +123,113 @@ func TestGraphQLPaginationStopsWithoutCursorProgress(t *testing.T) {
 				t.Errorf("want %d requests before the walk stops, got %d", tc.wantCalls, calls)
 			}
 		})
+	}
+}
+
+// the cap is a literal in the query text and a const in Go; keep them in step
+func TestThreadCommentsPage(t *testing.T) {
+	want := fmt.Sprintf("comments(first: %d)", threadCommentsPage)
+	if !strings.Contains(getThreadsQuery, want) {
+		t.Errorf("getThreadsQuery does not ask for %q; threadCommentsPage has drifted", want)
+	}
+}
+
+// a full page is the only overflow signal the connection gives
+func TestGetThreadsReportsClippedComments(t *testing.T) {
+	trackBodies(t)
+	threadWith := func(n int) string {
+		nodes := make([]string, 0, n)
+		for i := 1; i <= n; i++ {
+			nodes = append(nodes, fmt.Sprintf(
+				`{"id":"NODE_%d","fullDatabaseId":"%d","author":{"login":"u"},"body":"c%d",`+
+					`"createdAt":"t","state":"SUBMITTED","diffHunk":""}`, i, 1000+i, i))
+		}
+		return `{"id":"T","isResolved":false,"isOutdated":false,"path":"a.go","line":1,` +
+			`"startLine":null,"originalLine":1,"diffSide":"RIGHT","startDiffSide":"RIGHT",` +
+			`"comments":{"nodes":[` + strings.Join(nodes, ",") + `]}}`
+	}
+
+	cases := []struct {
+		name  string
+		count int
+		want  bool
+	}{
+		{"short list is complete", 3, false},
+		{"one short of the cap is complete", threadCommentsPage - 1, false},
+		{"a full page is clipped", threadCommentsPage, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[` +
+				threadWith(tc.count) + `],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+			c := newClient(func(*http.Request) (*http.Response, error) {
+				return resp(200, body, nil), nil
+			})
+			threads, err := c.GetThreads(context.Background(), "o", "r", 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(threads) != 1 || len(threads[0].Comments) != tc.count {
+				t.Fatalf("fixture wrong: %d threads, %d comments", len(threads), len(threads[0].Comments))
+			}
+			if threads[0].CommentsTruncated != tc.want {
+				t.Errorf("comments_truncated = %v, want %v for %d comments",
+					threads[0].CommentsTruncated, tc.want, tc.count)
+			}
+		})
+	}
+}
+
+// the delete target has to be the thread's last comment even when the capped list stops
+// short of it, which is the whole reason newestComment is selected separately
+func TestGetThreadsNewestCommentPastTheCap(t *testing.T) {
+	trackBodies(t)
+	nodes := make([]string, 0, threadCommentsPage)
+	for i := 1; i <= threadCommentsPage; i++ {
+		nodes = append(nodes, fmt.Sprintf(
+			`{"id":"NODE_%d","fullDatabaseId":"%d","author":{"login":"u"},"body":"c%d",`+
+				`"createdAt":"t","state":"SUBMITTED","diffHunk":""}`, i, 1000+i, i))
+	}
+	body := `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+      {"id":"T","isResolved":false,"isOutdated":false,"path":"a.go","line":1,
+       "startLine":null,"originalLine":1,"diffSide":"RIGHT","startDiffSide":"RIGHT",
+       "comments":{"nodes":[` + strings.Join(nodes, ",") + `]},
+       "newestComment":{"nodes":[{"id":"NODE_101","body":"the newest one"}]}}
+    ],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+	c := newClient(func(*http.Request) (*http.Response, error) { return resp(200, body, nil), nil })
+	threads, err := c.GetThreads(context.Background(), "o", "r", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := threads[0]
+	if !got.CommentsTruncated || len(got.Comments) != threadCommentsPage {
+		t.Fatalf("fixture wrong: truncated=%v comments=%d", got.CommentsTruncated, len(got.Comments))
+	}
+	if got.Comments[len(got.Comments)-1].NodeID != "NODE_100" {
+		t.Fatalf("the capped list should still end at the cap: %s", got.Comments[len(got.Comments)-1].NodeID)
+	}
+	if got.NewestComment == nil || got.NewestComment.NodeID != "NODE_101" {
+		t.Errorf("newest comment = %+v, want NODE_101", got.NewestComment)
+	}
+	if got.NewestComment.Body != "the newest one" {
+		t.Errorf("newest comment body = %q", got.NewestComment.Body)
+	}
+}
+
+// a thread always has a root comment, but a malformed page must not panic
+func TestGetThreadsNewestCommentAbsent(t *testing.T) {
+	trackBodies(t)
+	body := `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+      {"id":"T","isResolved":false,"isOutdated":false,"path":"a.go","line":1,
+       "startLine":null,"originalLine":1,"diffSide":"RIGHT","startDiffSide":"RIGHT",
+       "comments":{"nodes":[]},"newestComment":{"nodes":[]}}
+    ],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+	c := newClient(func(*http.Request) (*http.Response, error) { return resp(200, body, nil), nil })
+	threads, err := c.GetThreads(context.Background(), "o", "r", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if threads[0].NewestComment != nil {
+		t.Errorf("want nil newest comment, got %+v", threads[0].NewestComment)
 	}
 }

--- a/lua/differ/pr/client.lua
+++ b/lua/differ/pr/client.lua
@@ -64,9 +64,10 @@ function M.set_file_viewed(pr, path, viewed, cb)
 end
 
 -- get_threads result: [{id, thread_id, path, side, line, start_side?, start_line?,
--- resolved, is_pending, comments:[{id, node_id, author, body, created_at}]}]. PR-wide;
--- the frontend keeps it per session and filters to the current file's path when
--- painting. node_id is the per-comment graphql id delete_comment targets
+-- resolved, is_pending, comments_truncated, newest_comment?:{node_id, body},
+-- comments:[{id, node_id, author, body, created_at}]}]. PR-wide; the frontend keeps it
+-- per session and filters to the current file's path when painting. comments is capped
+-- (comments_truncated says so); newest_comment is the thread's last one regardless
 ---@param pr { owner: string, repo: string, number: integer }
 ---@param cb fun(err: table|nil, result: any)
 function M.get_threads(pr, cb)

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -169,8 +169,10 @@ function M.delete(session)
     if not anchor then
         return notify("no thread under the cursor to delete from")
     end
-    local comments = anchor.threads[1].comments or {}
-    local target = comments[#comments] -- the most recent comment on the thread
+    local thread = anchor.threads[1]
+    local comments = thread.comments or {}
+    -- comments is capped; newest_comment is the thread's last one whatever its length
+    local target = thread.newest_comment
     if not (target and target.node_id and target.node_id ~= "") then
         return notify("this comment can't be deleted")
     end

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -143,6 +143,54 @@ function M.comment_range(session)
     M.compose(session, { anchor = anchor, anchor_win = win, path = gesture_path(session) })
 end
 
+-- ── thread gestures (reply / delete) ──────────────────────────────────────────────
+
+-- a body's first line, clipped for a prompt or a picker label
+---@param body string|nil
+---@return string
+local function snippet(body)
+    local first = (body or ""):match("[^\n]*") or ""
+    if #first > 40 then
+        first = first:sub(1, 39) .. "…"
+    end
+    return first
+end
+
+-- the picker label for one thread, mirroring the collapsed box line the user reads
+---@param t table
+---@return string
+local function thread_label(t)
+    local comments = t.comments or {}
+    local first = comments[1] or {}
+    local tag = (t.is_pending and " (draft)") or (t.resolved and " (resolved)") or ""
+    return ('%d %s · @%s: "%s"%s'):format(
+        #comments,
+        #comments == 1 and "comment" or "comments",
+        first.author or "?",
+        snippet(first.body),
+        tag
+    )
+end
+
+-- the thread a cursor-row gesture acts on. a row can stack several threads and they
+-- render as one block oldest first, so there is no cursor position inside it to read:
+-- anything past the first asks instead of guessing, which matters most for gx. `cb`
+-- goes unrun on a cancelled pick
+---@param anchor table  -- { threads }
+---@param prompt string
+---@param cb fun(thread: table)
+local function pick_thread(anchor, prompt, cb)
+    local threads = anchor.threads
+    if #threads == 1 then
+        return cb(threads[1])
+    end
+    vim.ui.select(threads, { prompt = prompt, format_item = thread_label }, function(choice)
+        if choice then
+            cb(choice)
+        end
+    end)
+end
+
 -- gp: reply to the thread under the cursor (its node id, from slice 3's overlay index)
 ---@param session table
 function M.reply(session)
@@ -153,36 +201,29 @@ function M.reply(session)
     if not anchor then
         return notify("no thread under the cursor to reply to")
     end
-    M.compose(session, { in_reply_to = anchor.threads[1].thread_id, anchor_win = win })
+    pick_thread(anchor, "Reply to which thread?", function(thread)
+        if not guard.owns(session) then
+            return -- the picker can be async; the session may have gone under it
+        end
+        M.compose(session, { in_reply_to = thread.thread_id, anchor_win = win })
+    end)
 end
 
--- gx: delete the most recent comment of the thread under the
--- cursor (usually a draft you just wrote). deleting the only/root comment removes the
+-- delete `thread`'s most recent comment. deleting the only/root comment removes the
 -- whole thread; a later comment deletes just that reply. confirms first (destructive),
 -- then re-fetches so the overlay updates
 ---@param session table
-function M.delete(session)
-    local win = vim.api.nvim_get_current_win()
-    local buf = vim.api.nvim_win_get_buf(win)
-    local row = vim.api.nvim_win_get_cursor(win)[1]
-    local anchor = require("differ.pr.threads").anchor_at(session, buf, row)
-    if not anchor then
-        return notify("no thread under the cursor to delete from")
-    end
-    local thread = anchor.threads[1]
+---@param thread table
+local function delete_from(session, thread)
     local comments = thread.comments or {}
     -- comments is capped; newest_comment is the thread's last one whatever its length
     local target = thread.newest_comment
     if not (target and target.node_id and target.node_id ~= "") then
         return notify("this comment can't be deleted")
     end
-    local snippet = (target.body or ""):match("[^\n]*") or ""
-    if #snippet > 40 then
-        snippet = snippet:sub(1, 39) .. "…"
-    end
     local root = #comments == 1
     local prompt = (root and 'Delete this thread? "' or 'Delete the last reply? "')
-        .. snippet
+        .. snippet(target.body)
         .. '"'
     if vim.fn.confirm(prompt, "&Yes\n&No", 2) ~= 1 then
         return
@@ -198,6 +239,25 @@ function M.delete(session)
         threads.invalidate(session)
         threads.refresh(session)
         notify(root and "thread deleted" or "comment deleted")
+    end)
+end
+
+-- gx: delete the most recent comment of the thread under the cursor (usually a draft
+-- you just wrote), asking which one when the row stacks more than a single thread
+---@param session table
+function M.delete(session)
+    local win = vim.api.nvim_get_current_win()
+    local buf = vim.api.nvim_win_get_buf(win)
+    local row = vim.api.nvim_win_get_cursor(win)[1]
+    local anchor = require("differ.pr.threads").anchor_at(session, buf, row)
+    if not anchor then
+        return notify("no thread under the cursor to delete from")
+    end
+    pick_thread(anchor, "Delete from which thread?", function(thread)
+        if not guard.owns(session) then
+            return -- the picker can be async; the session may have gone under it
+        end
+        delete_from(session, thread)
     end)
 end
 

--- a/test/nvim/pr_nav_spec.lua
+++ b/test/nvim/pr_nav_spec.lua
@@ -767,3 +767,204 @@ describe("pr overview cheatsheet (g?)", function()
         restore()
     end)
 end)
+
+local REPLY = "reply to thread"
+local DELETE_COMMENT = "delete comment"
+
+-- two threads on the same new-side line. the overlay stacks them into one block ordered
+-- oldest first, so neither gp nor gx has a cursor position inside it to read
+local function stacked_threads_result()
+    local threads = threads_result()
+    threads[1].newest_comment = { node_id = "gid1", body = "please fix" }
+    threads[2] = {
+        id = "t2",
+        thread_id = "th_2",
+        path = "a.txt",
+        side = "RIGHT",
+        line = THREAD_LINE,
+        resolved = false,
+        is_pending = true,
+        comments = {
+            {
+                id = "c2",
+                node_id = "gid2",
+                author = "me",
+                body = "my draft",
+                created_at = "2026-02-02T00:00:00Z",
+            },
+        },
+        newest_comment = { node_id = "gid2", body = "my draft" },
+    }
+    return threads
+end
+
+-- swap vim.ui.select for one that records what it was offered and answers with
+-- `choose(items)`; returning nil from `choose` is the cancelled pick
+---@param choose fun(items: table[]): table|nil
+local function stub_select(choose)
+    local real = vim.ui.select
+    local box = { calls = 0 }
+    ---@diagnostic disable-next-line: duplicate-set-field
+    vim.ui.select = function(items, opts, cb)
+        box.calls = box.calls + 1
+        box.items = items
+        box.labels = vim.tbl_map(opts.format_item, items)
+        cb(choose(items))
+    end
+    return box, function()
+        vim.ui.select = real
+    end
+end
+
+-- put the cursor on the stacked overlay's anchor row, in the window showing it
+---@param s table
+---@return integer bufnr
+local function focus_thread_anchor(s)
+    local a = (s.thread_anchors or {})[1]
+    assert.is_truthy(a)
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        if vim.api.nvim_win_get_buf(win) == a.bufnr then
+            vim.api.nvim_set_current_win(win)
+            vim.api.nvim_win_set_cursor(win, { a.row, 0 })
+            return a.bufnr
+        end
+    end
+    error("no window shows the anchored buffer")
+end
+
+describe("stacked-row thread gestures pick a thread rather than assuming the first", function()
+    local comment = require("differ.pr.comment")
+    local client = require("differ.pr.client")
+
+    local restore_all = {}
+
+    local function track(restore)
+        restore_all[#restore_all + 1] = restore
+    end
+
+    after_each(function()
+        for i = #restore_all, 1, -1 do
+            restore_all[i]()
+        end
+        restore_all = {}
+        if pr.current_session() then
+            pr.end_session()
+        end
+    end)
+
+    -- a live session sitting on the stacked anchor row, with confirm() answering yes
+    ---@return table session, integer bufnr
+    local function stacked_session()
+        local responses = default_responses()
+        responses.get_threads = { result = stacked_threads_result() }
+        track(open_overview(responses))
+        local s = enter_review()
+        assert.is_true(vim.wait(1000, function()
+            local a = (pr.current_session().thread_anchors or {})[1]
+            return a ~= nil and #a.threads == 2
+        end))
+        local orig = vim.fn.confirm
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = function()
+            return 1
+        end
+        track(function()
+            vim.fn.confirm = orig
+        end)
+        return s, focus_thread_anchor(s)
+    end
+
+    ---@return table box  -- { node_id }
+    local function capture_delete()
+        local real = client.delete_comment
+        local box = {}
+        ---@diagnostic disable-next-line: duplicate-set-field
+        client.delete_comment = function(_pr, node_id, _cb)
+            box.node_id = node_id
+        end
+        track(function()
+            client.delete_comment = real
+        end)
+        return box
+    end
+
+    it("gx offers both threads and deletes from the one chosen, not threads[1]", function()
+        local _, buf = stacked_session()
+        local deleted = capture_delete()
+        -- pick the newer draft, which is threads[2] under the oldest-first stack order
+        local picked = stub_select(function(items)
+            return items[2]
+        end)
+
+        assert.is_true(fire(buf, DELETE_COMMENT))
+
+        -- the load-bearing one: threads[1] is the older "please fix" (gid1)
+        assert.are.equal("gid2", deleted.node_id)
+        assert.are.equal(1, picked.calls)
+        assert.are.equal(2, #picked.items)
+        -- the labels name the author and state so the choice is readable
+        assert.is_truthy(picked.labels[1]:find("@reviewer", 1, true))
+        assert.is_truthy(picked.labels[2]:find("(draft)", 1, true))
+    end)
+
+    it("gx deletes nothing when the pick is cancelled", function()
+        local _, buf = stacked_session()
+        local deleted = capture_delete()
+        local picked = stub_select(function()
+            return nil
+        end)
+
+        assert.is_true(fire(buf, DELETE_COMMENT))
+
+        assert.are.equal(1, picked.calls)
+        assert.is_nil(deleted.node_id)
+    end)
+
+    it("gp replies to the thread chosen, not the oldest on the row", function()
+        local _, buf = stacked_session()
+        local real = comment.compose
+        local box = {}
+        ---@diagnostic disable-next-line: duplicate-set-field
+        comment.compose = function(_s, opts)
+            box.opts = opts
+        end
+        track(function()
+            comment.compose = real
+        end)
+        local picked = stub_select(function(items)
+            return items[2]
+        end)
+
+        assert.is_true(fire(buf, REPLY))
+
+        assert.are.equal(1, picked.calls)
+        assert.are.equal("th_2", box.opts.in_reply_to)
+    end)
+
+    it("a row with one thread acts straight away, without a picker", function()
+        track(open_overview(default_responses()))
+        local s = enter_review()
+        assert.is_true(vim.wait(1000, function()
+            return (pr.current_session().thread_anchors or {})[1] ~= nil
+        end))
+        s.threads[1].newest_comment = { node_id = "gid1", body = "please fix" }
+        local buf = focus_thread_anchor(s)
+        local deleted = capture_delete()
+        local picked = stub_select(function(items)
+            return items[1]
+        end)
+        local orig = vim.fn.confirm
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = function()
+            return 1
+        end
+        track(function()
+            vim.fn.confirm = orig
+        end)
+
+        assert.is_true(fire(buf, DELETE_COMMENT))
+
+        assert.are.equal(0, picked.calls)
+        assert.are.equal("gid1", deleted.node_id)
+    end)
+end)

--- a/test/nvim/pr_spec.lua
+++ b/test/nvim/pr_spec.lua
@@ -405,3 +405,121 @@ describe("pr session root", function()
         end
     )
 end)
+
+-- gx deletes a thread's newest comment, which on a long thread is not in the capped
+-- list the overlay renders from
+describe("pr comment delete targets the newest comment", function()
+    after_each(function()
+        if pr.current_session() then
+            pr.end_session()
+        end
+    end)
+
+    ---@param n integer  -- comments in the (capped) render list
+    ---@param newest table|nil  -- the thread's actual last comment
+    ---@return table  -- get_threads result
+    local function thread_of(n, newest)
+        local comments = {}
+        for i = 1, n do
+            comments[i] = {
+                id = 1000 + i,
+                node_id = "gid" .. i,
+                author = "reviewer",
+                body = "comment " .. i,
+                created_at = string.format("2026-01-01T00:%02d:00Z", i % 60),
+            }
+        end
+        return {
+            {
+                id = 1001,
+                thread_id = "th_1",
+                path = "a.txt",
+                side = "RIGHT",
+                line = 2,
+                resolved = false,
+                is_pending = false,
+                comments_truncated = newest ~= nil and newest.node_id ~= "gid" .. n,
+                newest_comment = newest,
+                comments = comments,
+            },
+        }
+    end
+
+    -- boot a session on a.txt with the given thread, put the cursor on its anchor row and
+    -- fire gx; returns the delete_comment params the sidecar saw, or nil
+    ---@param threads table
+    ---@return table|nil
+    local function gx_on(threads)
+        local seen = {}
+        local real = sidecar.request
+        sidecar.request = function(method, params, cb)
+            if method == "delete_comment" then
+                seen[#seen + 1] = params
+            end
+            local canned = {
+                get_pr = get_pr_result(),
+                get_file_versions = {
+                    base = { content = "a\nb\nc\n" },
+                    head = { content = "a\nB\nc\n" },
+                },
+                get_threads = threads,
+                get_timeline = { comments = {}, reviews = {} },
+                get_checks = { rollup = "SUCCESS", checks = {} },
+            }
+            vim.schedule(function()
+                cb(nil, canned[method] or {})
+            end)
+        end
+        local real_confirm = vim.fn.confirm
+        local prompts = {}
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = function(msg)
+            prompts[#prompts + 1] = msg
+            return 1 -- Yes
+        end
+
+        pr.show(PR)
+        assert.is_true(vim.wait(2000, function()
+            local s = pr.current_session()
+            return s and s.view and s.view:is_open() and s.threads ~= nil
+        end))
+        local s = pr.current_session()
+        assert.is_true(vim.wait(2000, function()
+            return #(s.thread_anchors or {}) > 0
+        end))
+        local a = s.thread_anchors[1]
+        vim.api.nvim_set_current_win(vim.fn.win_findbuf(a.bufnr)[1])
+        vim.api.nvim_win_set_cursor(0, { a.row, 0 })
+
+        _G.notifs = {}
+        assert.is_true(fire(a.bufnr, "delete comment"))
+        vim.wait(300, function()
+            return #seen > 0
+        end)
+
+        vim.fn.confirm = real_confirm
+        sidecar.request = real
+        return seen[1], prompts[1]
+    end
+
+    -- the render list stops at the cap, so its tail is whichever comment the cap reached;
+    -- deleting that destroys one the user never pointed at
+    it("deletes past the cap rather than the last comment it can see", function()
+        local sent, prompt = gx_on(thread_of(100, { node_id = "gid101", body = "the newest one" }))
+        assert.is_truthy(sent)
+        assert.are.equal("gid101", sent.comment_id)
+        assert.is_truthy(prompt:find("the newest one", 1, true))
+    end)
+
+    it("deletes the last comment of a thread that fits under the cap", function()
+        local sent = gx_on(thread_of(3, { node_id = "gid3", body = "comment 3" }))
+        assert.is_truthy(sent)
+        assert.are.equal("gid3", sent.comment_id)
+    end)
+
+    it("refuses when the thread carries no newest comment", function()
+        local sent = gx_on(thread_of(3, nil))
+        assert.is_nil(sent)
+        assert.is_truthy(_G.notifs[#_G.notifs].msg:find("can't be deleted", 1, true))
+    end)
+end)


### PR DESCRIPTION
## Summary

- fix: `gx` on a thread with more than 100 comments deleted the wrong one — the 100th oldest, which can be another author's published comment rather than your own draft. it picked its target off the capped `comments(first: 100)` list, so it now addresses the thread's newest comment by identity and pagination stays optional
- fix: `gx` and `gp` on a line carrying more than one thread silently acted on the oldest. threads stack oldest-first and render as one block with no cursor position inside it, so `gx` was the exact opposite of its own "usually a draft you just wrote". a single-thread row still acts straight away; past that they ask which
- test: a `first:`/`last:` with no `pageInfo` beside it is valid graphql, so nothing caught the four connections that already truncate silently. the test lists those as filed and the singular selections as deliberate, with a reason string each, so anything new has to argue its case
- build: `.demo` is a dot-directory and `./...` never expands into it, so nothing built, vetted or formatted the fixture sidecar even though it compiles against `internal/github`. `demo-build` covers it by explicit path, and gofmt now sees `.demo`
- build: `check` gains `fmt-check` and `demo-build`, which CI has always run and the local gate never did
- docs: drop the architecture section from the readme; it sits inside the panvimdoc-ignore block, so the vimdoc is unchanged

## Test plan

- [x] `make check` — lua unit 370/0, headless-nvim 439/0, luacheck 0, golangci-lint 0, lua_ls clean, go ok
- [x] 3 new tests for the stacked row, each proven to fail against the reinstated `threads[1]`, asserting on the node id deleted rather than on the picker
- [x] the >100-comment case driven under headless nvim with a 100-comment thread against the stub sidecar; settled offline, no github calls
- [x] `make vimdoc` regenerates doc/differ.txt unchanged
