### PR TITLE
fix: relax the go toolchain pin, and warn when termguicolors is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- differ warns once when `termguicolors` is off, which is what leaves the diff rendering uncoloured
+- The README documents `:Differ sidecar`, `:Differ cache clear`, `:Differ mergetool`, `:Differ gofile` and `:Differ edit`, including how to open the merge tool, and the `details` keymap default
+
 ### Fixed
+
+- Installing asked for an exact Go patch release, so the build hook pulled down a second toolchain on machines that already had Go 1.26, and failed outright under a distro-packaged Go or `GOTOOLCHAIN=local`
+- A sidecar protocol mismatch told you to run `:Differ build`, which is not a command. It now names `make go-build`
+
+## [0.1.29] — 2026-08-11
 
 - `gx` on a thread with more than 100 comments deleted the wrong one, which could be another author's published comment rather than your own draft. It now asks GitHub for the thread's newest comment instead of taking the last one it had read
 - `gx` and `gp` on a line carrying more than one thread silently acted on the oldest, so you could delete from or reply to a thread you weren't reading. They now ask which one

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The GitHub side runs in a separate process rather than the editor, so opening a 
 ## Requirements
 
 - Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
+- `termguicolors` on - nvim enables it itself on any terminal it detects as 24-bit capable, so this is usually already true; without it the diff, merge and thread highlights render uncoloured
 - git on `PATH`
 - A Treesitter parser for the languages you diff (optional)
 - For PR review: Go + make on `PATH`, and `gh` authenticated
@@ -157,6 +158,7 @@ require("differ").setup({
     scroll_down = "f",           -- shadows native f/b; set false to restore
     scroll_up = "b",
     select = { "<CR>", "o" },    -- diff, pr overview, panel, history
+    details = "K",               -- history: float the full commit message
     help = "g?",                 -- diff, pr overview, panel, history
     toggle_listing = "i",        -- panel: toggle tree / name
     close_node = "c",            -- panel: collapse the dir under the cursor; history: the commit
@@ -230,6 +232,21 @@ These re-render the active view only. No refetch, no re-diff, and the state is l
 `context` defaults to the whole file, so no folds are created at all and a diff reads as the file it came from. Set it to a number to fold the long unchanged runs away instead: every line is in the buffer either way (search, yank, and motions all work), and `context` only decides where a native fold forms once an unchanged run exceeds it either side of a hunk. Folds are created open, not closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`). `d-` narrows out of whole-file the same way, landing on a threshold of 10 and stepping down a line at a time from there; `d=` has nothing wider to reach, so it does nothing.
 
 Set `command_alias` in `setup()` to register a shorter name for the same command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must start with an uppercase letter (enforced by vim, not by me). If you lazy-load on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see [troubleshooting](TROUBLESHOOTING.md#command_alias-and-lazy-loading) for why.
+
+### Session and sidecar commands
+
+| Command | Effect |
+|---|---|
+| `:Differ mergetool [path]` | Open the [merge tool](#merge-tool) on a conflicted file; no argument takes the current file, else the only conflicted one, else a picker |
+| `:Differ edit` | Edit the real file in a transient split at the cursor's mapped line, keeping the session; `:w` re-sources the diff. The `df` key |
+| `:Differ gofile` | Open the real file at the cursor's mapped line and end the session. The `de` key |
+| `:Differ sidecar` | Smoke-check the Go sidecar: start it, round-trip a handshake, and report the binary and protocol version |
+| `:Differ sidecar stop` | Stop the supervised sidecar; the next PR command starts a fresh one |
+| `:Differ cache clear` | Flush the sidecar's in-process caches (file blobs and PR review threads) |
+
+`:Differ sidecar` is the diagnostic to reach for when PR review doesn't work. It tells a sidecar that was never built (`make go-build`) apart from a protocol mismatch or a `gh` auth failure, and it's the only thing that reports which binary is actually running.
+
+`:Differ cache clear` is worth knowing about because the sidecar memoises review threads for the life of the process and flushes them only on your own mutations, so a colleague's comment posted while you have the PR open won't show up until you clear it. File blobs are keyed by commit sha and can't go stale, so clearing those only costs a refetch.
 
 ### Keymaps
 
@@ -338,7 +355,7 @@ Code-comment threads render as a contained box (GitHub's outline, differ's left-
 
 #### Merge tool
 
-Bound on the result buffer.
+`:Differ mergetool [path]` opens it: with no argument it takes the current file when that's one of the conflicted ones, else the only conflicted file in the tree, else it offers a picker over them. Keys are bound on the result buffer.
 
 | Key | Action |
 |---|---|

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -8,6 +8,7 @@ Table of Contents                                   *differ-table-of-contents*
 3. Configuration                                        |differ-configuration|
 4. Usage                                                        |differ-usage|
   - Runtime controls                           |differ-usage-runtime-controls|
+  - Session and sidecar commands   |differ-usage-session-and-sidecar-commands|
   - Keymaps                                             |differ-usage-keymaps|
   - Launchers                                         |differ-usage-launchers|
   - Statusline                                       |differ-usage-statusline|
@@ -34,6 +35,7 @@ Table of Contents                                   *differ-table-of-contents*
 2. Requirements                                          *differ-requirements*
 
 - Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
+- `termguicolors` on - nvim enables it itself on any terminal it detects as 24-bit capable, so this is usually already true; without it the diff, merge and thread highlights render uncoloured
 - git on `PATH`
 - A Treesitter parser for the languages you diff (optional)
 - For PR review: Go + make on `PATH`, and `gh` authenticated
@@ -93,6 +95,7 @@ Table of Contents                                   *differ-table-of-contents*
         scroll_down = "f",           -- shadows native f/b; set false to restore
         scroll_up = "b",
         select = { "<CR>", "o" },    -- diff, pr overview, panel, history
+        details = "K",               -- history: float the full commit message
         help = "g?",                 -- diff, pr overview, panel, history
         toggle_listing = "i",        -- panel: toggle tree / name
         close_node = "c",            -- panel: collapse the dir under the cursor; history: the commit
@@ -192,6 +195,49 @@ command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must
 start with an uppercase letter (enforced by vim, not by me). If you lazy-load
 on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see
 troubleshooting <TROUBLESHOOTING.md#command_alias-and-lazy-loading> for why.
+
+
+SESSION AND SIDECAR COMMANDS       *differ-usage-session-and-sidecar-commands*
+
+  -----------------------------------------------------------------------
+  Command                             Effect
+  ----------------------------------- -----------------------------------
+  :Differ mergetool [path]            Open the merge tool on a conflicted
+                                      file; no argument takes the current
+                                      file, else the only conflicted one,
+                                      else a picker
+
+  :Differ edit                        Edit the real file in a transient
+                                      split at the cursor’s mapped line,
+                                      keeping the session; :w re-sources
+                                      the diff. The df key
+
+  :Differ gofile                      Open the real file at the cursor’s
+                                      mapped line and end the session.
+                                      The de key
+
+  :Differ sidecar                     Smoke-check the Go sidecar: start
+                                      it, round-trip a handshake, and
+                                      report the binary and protocol
+                                      version
+
+  :Differ sidecar stop                Stop the supervised sidecar; the
+                                      next PR command starts a fresh one
+
+  :Differ cache clear                 Flush the sidecar’s in-process
+                                      caches (file blobs and PR review
+                                      threads)
+  -----------------------------------------------------------------------
+`:Differ sidecar` is the diagnostic to reach for when PR review doesn’t work.
+It tells a sidecar that was never built (`make go-build`) apart from a protocol
+mismatch or a `gh` auth failure, and it’s the only thing that reports which
+binary is actually running.
+
+`:Differ cache clear` is worth knowing about because the sidecar memoises
+review threads for the life of the process and flushes them only on your own
+mutations, so a colleague’s comment posted while you have the PR open won’t
+show up until you clear it. File blobs are keyed by commit sha and can’t go
+stale, so clearing those only costs a refetch.
 
 
 KEYMAPS                                                 *differ-usage-keymaps*
@@ -358,7 +404,9 @@ apart at a glance.
 
 MERGE TOOL ~
 
-Bound on the result buffer.
+`:Differ mergetool [path]` opens it: with no argument it takes the current file
+when that’s one of the conflicted ones, else the only conflicted file in the
+tree, else it offers a picker over them. Keys are bound on the result buffer.
 
   Key                    Action
   ---------------------- ------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/undont/differ.nvim
 
-go 1.26.4
+go 1.26

--- a/internal/handlers/hello.go
+++ b/internal/handlers/hello.go
@@ -29,7 +29,7 @@ func (d Deps) hello(_ context.Context, params json.RawMessage) (any, error) {
 	if p.Protocol > protocol.Version {
 		return nil, protocol.NewError(protocol.CodeBadRequest,
 			"protocol mismatch: client speaks "+strconv.Itoa(p.Protocol)+
-				", sidecar speaks "+strconv.Itoa(protocol.Version)+", rebuild your sidecar (:Differ build)")
+				", sidecar speaks "+strconv.Itoa(protocol.Version)+", rebuild your sidecar; run `make go-build`")
 	}
 	return helloResult{Protocol: protocol.Version, Binary: protocol.Binary}, nil
 }

--- a/lua/differ/ui/highlights.lua
+++ b/lua/differ/ui/highlights.lua
@@ -262,6 +262,24 @@ local function apply()
     end
 end
 
+-- the palette groups carry gui fg/bg and no cterm pair, so without termguicolors
+-- every blended tint is dropped and the diff renders uncoloured (the plain links
+-- above still ride the theme's cterm attributes). warn once rather than refusing:
+-- nvim enables the option itself on any terminal it detects as 24-bit capable, and
+-- one that genuinely isn't should still get a usable session
+local warned = false
+
+local function check_termguicolors()
+    if warned or vim.o.termguicolors then
+        return
+    end
+    warned = true
+    vim.notify(
+        "differ.nvim needs 'termguicolors' for its diff colours; without it the diff renders uncoloured",
+        vim.log.levels.WARN
+    )
+end
+
 local registered = false
 
 function M.setup()
@@ -272,6 +290,13 @@ function M.setup()
             group = vim.api.nvim_create_augroup("differ.highlights", { clear = true }),
             callback = apply,
         })
+        -- a colorscheme or a late option file can still turn it on, so a setup() during
+        -- startup asks after startup rather than now
+        if vim.v.vim_did_enter == 1 then
+            check_termguicolors()
+        else
+            vim.api.nvim_create_autocmd("VimEnter", { once = true, callback = check_termguicolors })
+        end
     end
 end
 

--- a/test/nvim/highlights_spec.lua
+++ b/test/nvim/highlights_spec.lua
@@ -1,0 +1,72 @@
+-- runs under headless nvim: the groups are set through nvim_set_hl, and the
+-- termguicolors warning reads a real option. the module's warn-once state is
+-- file-local, so each case reloads it
+
+local function reload()
+    package.loaded["differ.ui.highlights"] = nil
+    return require("differ.ui.highlights")
+end
+
+-- run `fn` with vim.notify captured, returning the WARN messages it emitted
+---@param fn fun(hl: table)
+---@return string[]
+local function warnings_from(fn)
+    local real, seen = vim.notify, {}
+    vim.notify = function(msg, level)
+        if level == vim.log.levels.WARN then
+            seen[#seen + 1] = msg
+        end
+    end
+    local ok, err = pcall(fn, reload())
+    vim.notify = real
+    assert(ok, err)
+    return seen
+end
+
+describe("highlights termguicolors guard", function()
+    local saved
+
+    before_each(function()
+        saved = vim.o.termguicolors
+    end)
+
+    after_each(function()
+        vim.o.termguicolors = saved
+    end)
+
+    it("warns when termguicolors is off, since the palette groups are gui-only", function()
+        local seen = warnings_from(function(hl)
+            vim.o.termguicolors = false
+            hl.setup()
+        end)
+        assert.are.equal(1, #seen)
+        assert.is_truthy(seen[1]:find("termguicolors", 1, true))
+    end)
+
+    it("stays quiet when termguicolors is on", function()
+        local seen = warnings_from(function(hl)
+            vim.o.termguicolors = true
+            hl.setup()
+        end)
+        assert.are.equal(0, #seen)
+    end)
+
+    it("warns once, not on every session", function()
+        local seen = warnings_from(function(hl)
+            vim.o.termguicolors = false
+            hl.setup()
+            hl.setup()
+            hl.setup()
+        end)
+        assert.are.equal(1, #seen)
+    end)
+
+    it("still defines the groups rather than bailing", function()
+        warnings_from(function(hl)
+            vim.o.termguicolors = false
+            hl.setup()
+        end)
+        assert.is_truthy(vim.api.nvim_get_hl(0, { name = "differLineAdd" }).bg)
+        assert.is_truthy(vim.api.nvim_get_hl(0, { name = "differMergeOurs" }).bg)
+    end)
+end)


### PR DESCRIPTION
## Summary

- build: `go.mod` asked for an exact patch release, on a plugin whose only install step compiles Go and which ships no prebuilt binaries. under the default `GOTOOLCHAIN=auto` that downloads a whole toolchain inside the `build =` hook; under a distro-packaged Go or `GOTOOLCHAIN=local` it fails outright with `go.mod requires go >= 1.26.9 (running go 1.26.5; GOTOOLCHAIN=local)`. relaxed to `go 1.26`; CI reads `go-version-file: go.mod` and still resolves the latest 1.26.x
- fix: a sidecar protocol mismatch told the user to run `:Differ build`, which is not a command. it now names `make go-build`, matching its lua twin at `sidecar/init.lua:190` and the `run \`cmd\`` shape in `auth.go:30`. reachable after a plugin update without a rebuild, which is when the two protocol versions diverge
- fix: every palette group carries gui `fg`/`bg` and no cterm pair, so with `termguicolors` off the diff, merge and thread palette is dropped and nothing said why. the linked groups survive, so the panel keeps its chrome and loses its colour coding, while the diff body loses add-vs-delete entirely. warns once rather than refusing: nvim enables the option itself on any terminal it detects as 24-bit capable, and one that genuinely isn't should still get a usable session. a `setup()` during startup holds the check until `VimEnter`, so a colorscheme or a late option file can still turn it on first
- docs: `:Differ sidecar [stop]`, `cache clear`, `mergetool [path]`, `gofile` and `edit` were undocumented. `sidecar` is the only built-in diagnostic and the answer to "why won't PR review work"; `cache clear` is the only escape hatch for the thread cache, which flushes on your own mutations alone. the merge tool documented ~20 lines of keymaps while never saying how to open it, so its section now opens with `:Differ mergetool`
- docs: `details = "K"` was the one default missing from the readme `setup()` block, and `termguicolors` joins requirements

## Test plan

- [x] `make check`: lua unit 370/0, headless-nvim 443/0, luacheck 0, golangci-lint 0, lua_ls clean, demo-build ok, go ok
- [x] 4 new tests in `test/nvim/highlights_spec.lua`; the two warning assertions fail against the guard commented out, the other two pin that it stays quiet when the option is on and defines the groups rather than bailing
- [x] both warning paths driven under headless nvim: immediate when `v:vim_did_enter` is 1, deferred to `VimEnter` when `setup()` runs during startup
- [x] with `notermguicolors` nvim emits `ESC[m` for a `guibg`-only group; with it on, `ESC[48;2;43;59;43m`
- [x] the patch pin fails against a scratch module under `GOTOOLCHAIN=local`, and `go 1.26` builds on the same machine
- [x] `make vimdoc` regenerated and `doc/differ.txt` committed
