### PR TITLE
feat: add :checkhealth differ and retain sidecar logs

### DIFF
--- a/.demo/fake-sidecar/fixtures.go
+++ b/.demo/fake-sidecar/fixtures.go
@@ -309,3 +309,6 @@ func (f *fixture) MergePR(_ context.Context, _, _ string, _ int, _ string, _ boo
 func (f *fixture) SetPRState(_ context.Context, _, _ string, _ int, state string) (*github.SetPRState, error) {
 	return &github.SetPRState{State: state}, nil
 }
+
+// the demo never touches github, so auth is always ready as far as it is concerned
+func (f *fixture) TokenStatus() (string, string) { return "ok", "" }

--- a/.github/workflows/vimdoc.yml
+++ b/.github/workflows/vimdoc.yml
@@ -5,10 +5,10 @@ name: Vimdoc
 # pushed here with GITHUB_TOKEN triggers no workflows, which leaves every required
 # check parked at action_required on the new head and the pr unmergeable.
 #
-# `make vimdoc` pins panvimdoc, pandoc and the locale, and the header carries no
-# datestamp, so the output is reproducible and a plain diff is a fair check. the
-# pandoc version below is duplicated from the Makefile on purpose; `make vimdoc`
-# fails loudly when the two disagree.
+# `make vimdoc` fetches its own pinned panvimdoc and pandoc into .tools and pins the
+# locale, and the header carries no datestamp, so the output is reproducible and a
+# plain diff is a fair check. nothing here installs pandoc: the version lives in the
+# Makefile alone, and this runs the same binary a contributor does.
 
 on:
   pull_request:
@@ -27,9 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Cache pinned tools
+        uses: actions/cache@v4
         with:
-          pandoc-version: "3.10.1"
+          path: .tools
+          key: vimdoc-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Regenerate doc/differ.txt
         run: make vimdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `:checkhealth differ` reports the Neovim floor, git, the options you passed to `setup()`, the sidecar binary and its handshake, and whether a GitHub token is available
-- `DIFFER_LOG_LEVEL=debug` traces the sidecar: a line per request, and a line per GitHub call carrying its status and the rate limit you have left
+- `:checkhealth differ` reports the Neovim floor, git, the options you passed to `setup()`, the sidecar binary and its handshake, whether a GitHub token is available, and anything the sidecar has logged
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `:checkhealth differ` reports the Neovim floor, git, the options you passed to `setup()`, the sidecar binary and its handshake, and whether a GitHub token is available
+- `DIFFER_LOG_LEVEL=debug` traces the sidecar: a line per request, and a line per GitHub call carrying its status and the rate limit you have left
+
+### Fixed
+
+- A sidecar that crashed reported only an exit code, discarding the Go logs and panic stack. Its last output now comes with the error, and `:checkhealth differ` keeps it
+- An option that didn't name a real key, or carried a value outside a closed set like `panel.position = "middle"`, was accepted in silence. Those are now reported, and the value falls back to its default correctly
+
 ## [0.1.30] — 2026-08-12
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ The Lua type-check runs a version-pinned lua-language-server, downloaded into gi
 
 Modules under `test/unit` must not touch any Neovim or `vim` API, at load or in the functions they test — that's what keeps them fast and dependency-free. Neovim-only behaviour (windows, extmarks, treesitter) belongs in `test/nvim` instead.
 
+## Debugging the sidecar
+
+`DIFFER_LOG_LEVEL` sets the sidecar's log level: `debug`, `info` (the default), `warn` or `error`. At `debug` it writes a line per request (method, duration, outcome) and a line per GitHub call (status, duration, remaining rate limit). The level is read when the process starts and the sidecar inherits Neovim's environment, so `DIFFER_LOG_LEVEL=debug nvim` covers a session; to turn it on without restarting, set `vim.env.DIFFER_LOG_LEVEL` then `:Differ sidecar stop`.
+
+Its stderr is piped to the client, never to your terminal. `:checkhealth differ` shows the tail — of a process that died, and of one still running — and the tail also comes with the error when a request fails on a sidecar that has just died. The client keeps the last 200 lines per process, so a long `debug` trace loses its beginning; nothing writes it to disk. Tokens are never logged, by contract in `logx`'s package doc and asserted in the `github` tests.
+
 ## Docs
 
 `doc/differ.txt` is generated from `README.md`, so a change to the readme has to carry the regenerated vimdoc with it:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ PANVIMDOC_VERSION := v4.0.1
 PANVIMDOC_DIR     := .tools/panvimdoc-$(PANVIMDOC_VERSION:v%=%)
 PANVIMDOC_BIN     := $(PANVIMDOC_DIR)/panvimdoc.sh
 PANDOC_VERSION    := 3.10.1
+PANDOC_DIR        := .tools/pandoc-$(PANDOC_VERSION)
+PANDOC_BIN        := $(PANDOC_DIR)/bin/pandoc
 
 GOLANGCI_VERSION := 2.12.2
 GOLANGCI_DIR     := .tools/golangci-lint-$(GOLANGCI_VERSION)
@@ -183,22 +185,16 @@ go-fmt-check: ## Verify Go formatting without writing
 ##@ Docs
 # ──────────────────────────────────────────────────────────────────────────────
 
-vimdoc: $(PANVIMDOC_BIN) ## Regenerate doc/differ.txt from README.md (needs pandoc)
-	@have=$$(pandoc --version 2>/dev/null | head -1 | awk '{print $$2}'); \
-	if [ -z "$$have" ]; then \
-		printf "$(RED)pandoc not found on PATH$(NC) (brew install pandoc)\n"; \
-		exit 1; \
-	elif [ "$$have" != "$(PANDOC_VERSION)" ]; then \
-		printf "$(RED)pandoc $$have, need $(PANDOC_VERSION)$(NC) (output differs between versions)\n"; \
-		exit 1; \
-	fi
+vimdoc: $(PANVIMDOC_BIN) $(PANDOC_BIN) ## Regenerate doc/differ.txt from README.md
 	@$(INFO) "Generating doc/differ.txt (panvimdoc $(PANVIMDOC_VERSION), pandoc $(PANDOC_VERSION))"
 	@# LC_ALL=C keeps the nbsp pandoc puts after "e.g." intact: the writer wraps with
 	@# lua patterns, and %s is locale-dependent, so bsd libc in a utf-8 locale counts
 	@# 0xa0 as space and splits it into u+fffd. --description replaces the header's
 	@# daily "Last change" stamp, and GITHUB_ACTIONS is cleared because panvimdoc.sh
-	@# hardcodes /scripts when it's set, over --scripts-dir. output prints on failure
-	@out=$$(LC_ALL=C GITHUB_ACTIONS=false bash $(PANVIMDOC_BIN) \
+	@# hardcodes /scripts when it's set, over --scripts-dir. output prints on failure.
+	@# panvimdoc.sh calls `pandoc` by name, so the pinned one leads on PATH: pandoc's
+	@# output differs between releases, and a brew upgrade would otherwise decide it
+	@out=$$(PATH="$(CURDIR)/$(PANDOC_DIR)/bin:$$PATH" LC_ALL=C GITHUB_ACTIONS=false bash $(PANVIMDOC_BIN) \
 		--scripts-dir "$(PANVIMDOC_DIR)/scripts" \
 		--project-name differ \
 		--input-file README.md \
@@ -222,6 +218,32 @@ $(PANVIMDOC_BIN):
 	@mkdir -p .tools
 	@curl -fsSL "https://github.com/kdheepak/panvimdoc/archive/refs/tags/$(PANVIMDOC_VERSION).tar.gz" \
 		| tar -xz -C .tools && $(OK) "Installed panvimdoc $(PANVIMDOC_VERSION)"
+
+# pandoc ships a zip on macos and a tarball on linux, and spells the architecture
+# differently in each, so this can't follow stylua's one-liner shape
+$(PANDOC_BIN):
+	@$(INFO) "Fetching pandoc $(PANDOC_VERSION)"
+	@mkdir -p .tools
+	@os=$$(uname -s | tr 'A-Z' 'a-z'); \
+	arch=$$(uname -m); \
+	tmp=$$(mktemp -d); \
+	base="https://github.com/jgm/pandoc/releases/download/$(PANDOC_VERSION)"; \
+	case "$$os" in \
+		darwin) \
+			case "$$arch" in aarch64|arm64) arch=arm64;; *) arch=x86_64;; esac; \
+			curl -fsSL -o "$$tmp/p.zip" "$$base/pandoc-$(PANDOC_VERSION)-$$arch-macOS.zip" \
+				&& unzip -q -d "$$tmp" "$$tmp/p.zip";; \
+		linux) \
+			case "$$arch" in aarch64|arm64) arch=arm64;; *) arch=amd64;; esac; \
+			curl -fsSL "$$base/pandoc-$(PANDOC_VERSION)-linux-$$arch.tar.gz" \
+				| tar -xz -C "$$tmp";; \
+		*) printf "$(RED)unsupported OS: $$os$(NC)\n"; exit 1;; \
+	esac; \
+	src=$$(find "$$tmp" -type f -name pandoc -perm -u+x | head -1); \
+	test -n "$$src" || { printf "$(RED)pandoc missing from the archive$(NC)\n"; rm -rf "$$tmp"; exit 1; }; \
+	mkdir -p $(PANDOC_DIR)/bin && cp "$$src" $(PANDOC_BIN); \
+	rm -rf "$$tmp"
+	@$(OK) "Installed pandoc $(PANDOC_VERSION)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 ##@ Aggregate

--- a/README.md
+++ b/README.md
@@ -256,14 +256,7 @@ Set `command_alias` in `setup()` to register a shorter name for the same command
 
 An option that doesn't name a real key, or that carries a value outside a closed set (`panel.position = "middle"`), is reported once at startup and again by `:checkhealth`. differ still starts, and the value it can't honour falls back to its default.
 
-`DIFFER_LOG_LEVEL` sets how much the sidecar logs: `debug`, `info` (the default), `warn` or `error`. At `debug` it writes one line per request (method, duration, outcome) and one per GitHub call (status, duration, and the rate limit you have left), which is what to reach for when PR review is slow or returns less than you expect. The sidecar inherits the environment Neovim was started in, so `DIFFER_LOG_LEVEL=debug nvim` covers a session.
-
-```
-level=DEBUG msg=request method=get_pr id=4 ms=812 code=ok
-level=DEBUG msg="github call" verb=POST url=https://api.github.com/graphql status=200 ms=790 ratelimit_remaining=4832
-```
-
-The sidecar logs to its stderr, which differ keeps rather than discards: the tail of it rides along with the error if the process dies, and `:checkhealth differ` shows it. Nothing there carries your token.
+The sidecar logs to its stderr, which differ keeps rather than lets through to your terminal, so `:checkhealth differ` is where it surfaces: what a process said before it died, and what a running one has said since. The tail also comes with the error when a request fails on a sidecar that has just died. Nothing there carries your token.
 
 ### Keymaps
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The GitHub side runs in a separate process rather than the editor, so opening a 
 - For PR review: Go + make on `PATH`, and `gh` authenticated
 - Local diffs need none of the above beyond git
 
+`:checkhealth differ` reports which of these are satisfied.
+
 ---
 
 <!-- panvimdoc-ignore-start -->
@@ -247,6 +249,21 @@ Set `command_alias` in `setup()` to register a shorter name for the same command
 `:Differ sidecar` is the diagnostic to reach for when PR review doesn't work. It tells a sidecar that was never built (`make go-build`) apart from a protocol mismatch or a `gh` auth failure, and it's the only thing that reports which binary is actually running.
 
 `:Differ cache clear` is worth knowing about because the sidecar memoises review threads for the life of the process and flushes them only on your own mutations, so a colleague's comment posted while you have the PR open won't show up until you clear it. File blobs are keyed by commit sha and can't go stale, so clearing those only costs a refetch.
+
+### Diagnostics
+
+`:checkhealth differ` is the first thing to run when something doesn't work. It reports the Neovim floor and `termguicolors`, git, the options you passed to `setup()`, the resolved sidecar binary and whether it completes a handshake, and whether a GitHub token is available. A sidecar that died during the session is reported there too, with the last thing it wrote.
+
+An option that doesn't name a real key, or that carries a value outside a closed set (`panel.position = "middle"`), is reported once at startup and again by `:checkhealth`. differ still starts, and the value it can't honour falls back to its default.
+
+`DIFFER_LOG_LEVEL` sets how much the sidecar logs: `debug`, `info` (the default), `warn` or `error`. At `debug` it writes one line per request (method, duration, outcome) and one per GitHub call (status, duration, and the rate limit you have left), which is what to reach for when PR review is slow or returns less than you expect. The sidecar inherits the environment Neovim was started in, so `DIFFER_LOG_LEVEL=debug nvim` covers a session.
+
+```
+level=DEBUG msg=request method=get_pr id=4 ms=812 code=ok
+level=DEBUG msg="github call" verb=POST url=https://api.github.com/graphql status=200 ms=790 ratelimit_remaining=4832
+```
+
+The sidecar logs to its stderr, which differ keeps rather than discards: the tail of it rides along with the error if the process dies, and `:checkhealth differ` shows it. Nothing there carries your token.
 
 ### Keymaps
 

--- a/cmd/differ-sidecar/main.go
+++ b/cmd/differ-sidecar/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -20,7 +19,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	log := logx.New(slog.LevelInfo)
+	raw := os.Getenv(logx.LevelEnv)
+	level, known := logx.ParseLevel(raw)
+	log := logx.New(level)
+	if !known {
+		log.Warn("unrecognised log level, using info", "var", logx.LevelEnv, "value", raw)
+	}
 
 	// token resolution failure is non-fatal: the handshake still works and the
 	// error is handed to the client so only PR methods surface gh_missing/auth.
@@ -28,7 +32,7 @@ func main() {
 	if tokenErr != nil {
 		log.Warn("github auth not ready", "err", tokenErr)
 	}
-	gh := github.New(nil, token, tokenErr)
+	gh := github.New(nil, token, tokenErr, log)
 
 	reg := handlers.NewRegistry(handlers.Deps{GH: gh, Log: log})
 	srv := server.New(reg, log)

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -257,21 +257,11 @@ closed set (`panel.position = "middle"`), is reported once at startup and again
 by `:checkhealth`. differ still starts, and the value it can’t honour falls
 back to its default.
 
-`DIFFER_LOG_LEVEL` sets how much the sidecar logs: `debug`, `info` (the
-default), `warn` or `error`. At `debug` it writes one line per request (method,
-duration, outcome) and one per GitHub call (status, duration, and the rate
-limit you have left), which is what to reach for when PR review is slow or
-returns less than you expect. The sidecar inherits the environment Neovim was
-started in, so `DIFFER_LOG_LEVEL=debug nvim` covers a session.
-
->
-    level=DEBUG msg=request method=get_pr id=4 ms=812 code=ok
-    level=DEBUG msg="github call" verb=POST url=https://api.github.com/graphql status=200 ms=790 ratelimit_remaining=4832
-<
-
-The sidecar logs to its stderr, which differ keeps rather than discards: the
-tail of it rides along with the error if the process dies, and `:checkhealth
-differ` shows it. Nothing there carries your token.
+The sidecar logs to its stderr, which differ keeps rather than lets through to
+your terminal, so `:checkhealth differ` is where it surfaces: what a process
+said before it died, and what a running one has said since. The tail also comes
+with the error when a request fails on a sidecar that has just died. Nothing
+there carries your token.
 
 
 KEYMAPS                                                 *differ-usage-keymaps*

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -9,6 +9,7 @@ Table of Contents                                   *differ-table-of-contents*
 4. Usage                                                        |differ-usage|
   - Runtime controls                           |differ-usage-runtime-controls|
   - Session and sidecar commands   |differ-usage-session-and-sidecar-commands|
+  - Diagnostics                                     |differ-usage-diagnostics|
   - Keymaps                                             |differ-usage-keymaps|
   - Launchers                                         |differ-usage-launchers|
   - Statusline                                       |differ-usage-statusline|
@@ -40,6 +41,8 @@ Table of Contents                                   *differ-table-of-contents*
 - A Treesitter parser for the languages you diff (optional)
 - For PR review: Go + make on `PATH`, and `gh` authenticated
 - Local diffs need none of the above beyond git
+
+`:checkhealth differ` reports which of these are satisfied.
 
 ------------------------------------------------------------------------------
 
@@ -239,6 +242,36 @@ review threads for the life of the process and flushes them only on your own
 mutations, so a colleague’s comment posted while you have the PR open won’t
 show up until you clear it. File blobs are keyed by commit sha and can’t go
 stale, so clearing those only costs a refetch.
+
+
+DIAGNOSTICS                                         *differ-usage-diagnostics*
+
+`:checkhealth differ` is the first thing to run when something doesn’t work.
+It reports the Neovim floor and `termguicolors`, git, the options you passed to
+`setup()`, the resolved sidecar binary and whether it completes a handshake,
+and whether a GitHub token is available. A sidecar that died during the session
+is reported there too, with the last thing it wrote.
+
+An option that doesn’t name a real key, or that carries a value outside a
+closed set (`panel.position = "middle"`), is reported once at startup and again
+by `:checkhealth`. differ still starts, and the value it can’t honour falls
+back to its default.
+
+`DIFFER_LOG_LEVEL` sets how much the sidecar logs: `debug`, `info` (the
+default), `warn` or `error`. At `debug` it writes one line per request (method,
+duration, outcome) and one per GitHub call (status, duration, and the rate
+limit you have left), which is what to reach for when PR review is slow or
+returns less than you expect. The sidecar inherits the environment Neovim was
+started in, so `DIFFER_LOG_LEVEL=debug nvim` covers a session.
+
+>
+    level=DEBUG msg=request method=get_pr id=4 ms=812 code=ok
+    level=DEBUG msg="github call" verb=POST url=https://api.github.com/graphql status=200 ms=790 ratelimit_remaining=4832
+<
+
+The sidecar logs to its stderr, which differ keeps rather than discards: the
+tail of it rides along with the error if the process dies, and `:checkhealth
+differ` shows it. Nothing there carries your token.
 
 
 KEYMAPS                                                 *differ-usage-keymaps*

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -1,12 +1,29 @@
 package github
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/undont/differ.nvim/internal/protocol"
 )
+
+// TokenStatus reports whether this client has a usable token: "ok", or the closed-set
+// code the resolution failed with ("gh_missing"/"auth") and the message explaining what
+// to do about it. resolution happens once at startup and its failure is otherwise only
+// visible when a PR method is called, which is far too late to be a diagnostic. the
+// token itself is never returned, only whether there is one.
+func (c *Client) TokenStatus() (status, message string) {
+	if c.tokenErr == nil {
+		return "ok", ""
+	}
+	var perr *protocol.Error
+	if errors.As(c.tokenErr, &perr) {
+		return perr.Code, perr.Message
+	}
+	return protocol.CodeInternal, c.tokenErr.Error()
+}
 
 // ResolveToken finds a GitHub token without go-gh: GH_TOKEN, then
 // GITHUB_TOKEN, then `gh auth token`. a missing gh binary with no env token is

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ type Client struct {
 	http     *http.Client
 	token    string
 	tokenErr error // resolution failure (gh_missing/auth), surfaced on authed calls
+	log      *slog.Logger
 	restURL  string
 	gqlURL   string
 
@@ -34,11 +36,15 @@ type Client struct {
 // timeout. token is the resolved GitHub token (see ResolveToken); tokenErr is the
 // resolution failure, if any, returned to the caller on the first authed request
 // so the precise gh_missing/auth code reaches the client instead of a bare 401.
-func New(hc *http.Client, token string, tokenErr error) *Client {
+// log receives one debug line per GitHub call; nil discards them.
+func New(hc *http.Client, token string, tokenErr error, log *slog.Logger) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: 30 * time.Second}
 	}
-	return &Client{http: hc, token: token, tokenErr: tokenErr, restURL: defaultREST, gqlURL: defaultGQL, cache: newCache()}
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Client{http: hc, token: token, tokenErr: tokenErr, log: log, restURL: defaultREST, gqlURL: defaultGQL, cache: newCache()}
 }
 
 // ClearCache flushes the blob and thread caches; the cache_clear method, surfaced as

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,10 +1,12 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +25,7 @@ type rtFunc func(*http.Request) (*http.Response, error)
 func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func newClient(f rtFunc) *Client {
-	return New(&http.Client{Transport: f}, "test-token", nil)
+	return New(&http.Client{Transport: f}, "test-token", nil, nil)
 }
 
 // bodies tallies every response body resp() hands out against every Close() on one.
@@ -382,7 +384,7 @@ func TestRepeatedFailuresReuseTheConnection(t *testing.T) {
 	srv.Start()
 	defer srv.Close()
 
-	c := New(srv.Client(), "test-token", nil)
+	c := New(srv.Client(), "test-token", nil, nil)
 	c.restURL = srv.URL
 	for range 10 {
 		if err := c.getJSON(context.Background(), c.restURL+"/x", nil); err == nil {
@@ -441,11 +443,48 @@ func TestTokenErrShortCircuits(t *testing.T) {
 	c := New(&http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
 		t.Fatal("must not hit the network when token resolution failed")
 		return nil, nil
-	})}, "", want)
+	})}, "", want, nil)
 	if _, err := c.ListPRs(context.Background(), "o", "r", "open"); codeOf(t, err) != protocol.CodeGHMissing {
 		t.Fatalf("want gh_missing, got %v", err)
 	}
 	if _, err := c.GetPR(context.Background(), "o", "r", 1); codeOf(t, err) != protocol.CodeGHMissing {
 		t.Fatalf("get_pr want gh_missing, got %v", err)
+	}
+}
+
+func TestDebugTracesEveryCallWithoutLeakingTheToken(t *testing.T) {
+	trackBodies(t)
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	c := New(&http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		return resp(200, `[]`, map[string]string{"X-RateLimit-Remaining": "4832"}), nil
+	})}, "super-secret-token", nil, log)
+
+	if _, err := c.ListPRs(context.Background(), "o", "r", "open"); err != nil {
+		t.Fatalf("ListPRs: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, `msg="github call"`) || !strings.Contains(got, "status=200") {
+		t.Errorf("the call was not traced:\n%s", got)
+	}
+	// the budget is half the reason for the line: a run of 403s is only legible
+	// alongside what was left
+	if !strings.Contains(got, "ratelimit_remaining=4832") {
+		t.Errorf("rate limit was not traced:\n%s", got)
+	}
+	// logx's contract, and the whole reason send logs URL.Redacted rather than headers
+	if strings.Contains(got, "super-secret-token") {
+		t.Errorf("the token reached the log:\n%s", got)
+	}
+}
+
+func TestNilLoggerDiscards(t *testing.T) {
+	trackBodies(t)
+	c := newClient(func(*http.Request) (*http.Response, error) {
+		return resp(200, `[]`, nil), nil
+	})
+	if _, err := c.ListPRs(context.Background(), "o", "r", "open"); err != nil {
+		t.Fatalf("a nil logger must not panic: %v", err)
 	}
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -77,11 +77,11 @@ func resp(status int, body string, headers map[string]string) *http.Response {
 
 func perrOf(t *testing.T, err error) *protocol.Error {
 	t.Helper()
-	var pe *protocol.Error
-	if !errors.As(err, &pe) {
+	var perr *protocol.Error
+	if !errors.As(err, &perr) {
 		t.Fatalf("want *protocol.Error, got %T: %v", err, err)
 	}
-	return pe
+	return perr
 }
 
 func codeOf(t *testing.T, err error) string {
@@ -311,12 +311,12 @@ func TestErrorMappingTable(t *testing.T) {
 			c := newClient(func(*http.Request) (*http.Response, error) {
 				return resp(tc.status, tc.body, tc.headers), nil
 			})
-			pe := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
-			if pe.Code != tc.want {
-				t.Fatalf("status %d → %q, want %q", tc.status, pe.Code, tc.want)
+			perr := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
+			if perr.Code != tc.want {
+				t.Fatalf("status %d → %q, want %q", tc.status, perr.Code, tc.want)
 			}
-			if pe.Message != tc.wantMsg {
-				t.Fatalf("status %d message = %q, want %q", tc.status, pe.Message, tc.wantMsg)
+			if perr.Message != tc.wantMsg {
+				t.Fatalf("status %d message = %q, want %q", tc.status, perr.Message, tc.wantMsg)
 			}
 		})
 	}
@@ -400,9 +400,9 @@ func TestRetryAfterPropagates(t *testing.T) {
 	c := newClient(func(*http.Request) (*http.Response, error) {
 		return resp(429, `{"message":"slow"}`, map[string]string{"Retry-After": "30"}), nil
 	})
-	pe := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
-	if pe.RetryAfter != 30 {
-		t.Fatalf("want retry_after=30, got %+v", pe)
+	perr := perrOf(t, c.getJSON(context.Background(), c.restURL+"/x", nil))
+	if perr.RetryAfter != 30 {
+		t.Fatalf("want retry_after=30, got %+v", perr)
 	}
 }
 
@@ -486,5 +486,40 @@ func TestNilLoggerDiscards(t *testing.T) {
 	})
 	if _, err := c.ListPRs(context.Background(), "o", "r", "open"); err != nil {
 		t.Fatalf("a nil logger must not panic: %v", err)
+	}
+}
+
+func TestTokenStatus(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		status  string
+		message string
+	}{
+		{"resolved", nil, "ok", ""},
+		{
+			"no gh binary",
+			protocol.NewError(protocol.CodeGHMissing, "the gh CLI is not installed"),
+			"gh_missing", "the gh CLI is not installed",
+		},
+		{
+			"gh present but not logged in",
+			protocol.NewError(protocol.CodeAuth, "run `gh auth login`"),
+			"auth", "run `gh auth login`",
+		},
+		// anything not already carrying a code must still land inside the closed set
+		{"unmapped", errors.New("something else"), "internal", "something else"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(nil, "super-secret-token", tc.err, nil)
+			status, message := c.TokenStatus()
+			if status != tc.status || message != tc.message {
+				t.Errorf("got %q/%q, want %q/%q", status, message, tc.status, tc.message)
+			}
+			if strings.Contains(status+message, "super-secret-token") {
+				t.Error("the token must never appear in the status")
+			}
+		})
 	}
 }

--- a/internal/github/rest.go
+++ b/internal/github/rest.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"time"
 
 	"github.com/undont/differ.nvim/internal/protocol"
 )
@@ -22,11 +23,21 @@ const maxResponse = 32 * 1024 * 1024 // bound a single response body
 // returned even on a mapped error, for callers that special-case a status; its body
 // is spent, so only headers and the status line are readable from it
 func (c *Client) send(req *http.Request) (*http.Response, []byte, error) {
+	start := time.Now()
 	resp, err := c.http.Do(req)
 	if err != nil {
+		// URL.Redacted, not URL.String: the only secret a URL can carry is userinfo,
+		// and the token itself rides in a header that is never logged
+		c.log.Debug("github call failed", "verb", req.Method, "url", req.URL.Redacted(),
+			"ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, nil, protocol.NewError(protocol.CodeNetwork, "network error: "+err.Error())
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// the single choke point for REST and GraphQL alike, so this one line accounts
+	// for every call the sidecar makes, and for the budget it spends doing it
+	c.log.Debug("github call", "verb", req.Method, "url", req.URL.Redacted(),
+		"status", resp.StatusCode, "ms", time.Since(start).Milliseconds(),
+		"ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"))
 
 	body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
 	// the status outranks a truncated read: a 403 that also failed to read is still a

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -40,6 +40,7 @@ type API interface {
 	SetFileViewed(ctx context.Context, owner, repo string, number int, path string, viewed bool) (*github.SetFileViewed, error)
 	MergePR(ctx context.Context, owner, repo string, number int, method string, deleteBranch bool, subject, body string) (*github.Merge, error)
 	SetPRState(ctx context.Context, owner, repo string, number int, state string) (*github.SetPRState, error)
+	TokenStatus() (status, message string)
 }
 
 // Deps are the handler dependencies, injected once at construction (no globals).

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/undont/differ.nvim/internal/github"
@@ -37,6 +38,8 @@ type mockAPI struct {
 	headSHA      string // the head HeadSHA returns (for the TOCTOU guard)
 	headErr      error
 	headCalled   bool
+	tokenStatus  string // what hello reports about auth
+	tokenMessage string
 }
 
 func (m *mockAPI) ListPRs(_ context.Context, _, _, filter string) ([]github.PR, error) {
@@ -157,22 +160,24 @@ func (m *mockAPI) SetPRState(_ context.Context, _, _ string, number int, state s
 
 func (m *mockAPI) ClearCache() { m.cleared = true }
 
+func (m *mockAPI) TokenStatus() (string, string) { return m.tokenStatus, m.tokenMessage }
+
 func deps(m *mockAPI) Deps {
 	return Deps{GH: m, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 }
 
 func wantBadRequest(t *testing.T, err error) {
 	t.Helper()
-	var pe *protocol.Error
-	if !errors.As(err, &pe) || pe.Code != protocol.CodeBadRequest {
+	var perr *protocol.Error
+	if !errors.As(err, &perr) || perr.Code != protocol.CodeBadRequest {
 		t.Fatalf("want bad_request, got %v", err)
 	}
 }
 
 func wantConflict(t *testing.T, err error) {
 	t.Helper()
-	var pe *protocol.Error
-	if !errors.As(err, &pe) || pe.Code != protocol.CodeConflict {
+	var perr *protocol.Error
+	if !errors.As(err, &perr) || perr.Code != protocol.CodeConflict {
 		t.Fatalf("want conflict, got %v", err)
 	}
 }
@@ -430,8 +435,8 @@ func TestPostCommentPropagatesHeadError(t *testing.T) {
 	_, err := deps(m).postComment(context.Background(), json.RawMessage(
 		fmt.Sprintf(postCommentBody, `,"expected_head":"abc123"`),
 	))
-	var pe *protocol.Error
-	if !errors.As(err, &pe) || pe.Code != protocol.CodeNetwork {
+	var perr *protocol.Error
+	if !errors.As(err, &perr) || perr.Code != protocol.CodeNetwork {
 		t.Fatalf("want network error, got %v", err)
 	}
 	if m.gotComment.Body != "" {
@@ -618,5 +623,40 @@ func TestPostCommentValidation(t *testing.T) {
 				t.Error("GH must not be called on invalid input")
 			}
 		})
+	}
+}
+
+func TestHelloReportsAuthStatus(t *testing.T) {
+	m := &mockAPI{tokenStatus: "gh_missing", tokenMessage: "the gh CLI is not installed"}
+	res, err := deps(m).hello(context.Background(), json.RawMessage(`{"protocol":1}`))
+	if err != nil {
+		t.Fatalf("hello: %v", err)
+	}
+	got, ok := res.(helloResult)
+	if !ok {
+		t.Fatalf("want helloResult, got %T", res)
+	}
+	if got.Auth != "gh_missing" || got.AuthMessage != "the gh CLI is not installed" {
+		t.Errorf("auth not reported: %+v", got)
+	}
+	if got.Protocol != protocol.Version {
+		t.Errorf("want protocol %d, got %d", protocol.Version, got.Protocol)
+	}
+}
+
+func TestHelloWithoutGitHubOmitsAuth(t *testing.T) {
+	// the handshake must survive a registry built without a github surface, and say
+	// nothing about auth rather than guessing at it
+	d := Deps{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	res, err := d.hello(context.Background(), json.RawMessage(`{"protocol":1}`))
+	if err != nil {
+		t.Fatalf("hello: %v", err)
+	}
+	line, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(line), "auth") {
+		t.Errorf("auth should be omitted entirely, got %s", line)
 	}
 }

--- a/internal/handlers/hello.go
+++ b/internal/handlers/hello.go
@@ -13,9 +13,16 @@ type helloParams struct {
 	Protocol int    `json:"protocol"`
 }
 
+// Auth is "ok" or the closed-set code token resolution failed with; AuthMessage
+// carries what to do about it. both are absent when there is no github surface to
+// ask (and from a sidecar predating them), which the client reads as unknown rather
+// than as trouble. added after protocol 1 froze, so it needs no version bump: an
+// older client decodes the frame and ignores the fields.
 type helloResult struct {
-	Protocol int    `json:"protocol"`
-	Binary   string `json:"binary"`
+	Protocol    int    `json:"protocol"`
+	Binary      string `json:"binary"`
+	Auth        string `json:"auth,omitempty"`
+	AuthMessage string `json:"auth_message,omitempty"`
 }
 
 // hello is the handshake. a client protocol newer than ours is a hard
@@ -31,5 +38,9 @@ func (d Deps) hello(_ context.Context, params json.RawMessage) (any, error) {
 			"protocol mismatch: client speaks "+strconv.Itoa(p.Protocol)+
 				", sidecar speaks "+strconv.Itoa(protocol.Version)+", rebuild your sidecar; run `make go-build`")
 	}
-	return helloResult{Protocol: protocol.Version, Binary: protocol.Binary}, nil
+	res := helloResult{Protocol: protocol.Version, Binary: protocol.Binary}
+	if d.GH != nil {
+		res.Auth, res.AuthMessage = d.GH.TokenStatus()
+	}
+	return res, nil
 }

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -6,7 +6,32 @@ package logx
 import (
 	"log/slog"
 	"os"
+	"strings"
 )
+
+// LevelEnv names the environment variable that sets the log level. the client
+// spawns the sidecar with its own environment, so `DIFFER_LOG_LEVEL=debug nvim`
+// reaches it, as does setting vim.env before the first request starts a process.
+const LevelEnv = "DIFFER_LOG_LEVEL"
+
+// ParseLevel maps a LevelEnv value to a slog level, case-insensitively. an empty
+// value is the default rather than an error; ok is false only for a value that was
+// set to something unrecognised, so the caller can say so instead of going quiet.
+func ParseLevel(s string) (level slog.Level, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return slog.LevelInfo, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	}
+	return slog.LevelInfo, false
+}
 
 // New returns a slog logger writing text to stderr at the given level.
 func New(level slog.Level) *slog.Logger {

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -1,0 +1,30 @@
+package logx
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  slog.Level
+		known bool
+	}{
+		{"", slog.LevelInfo, true}, // unset is the default, not a mistake
+		{"debug", slog.LevelDebug, true},
+		{"DEBUG", slog.LevelDebug, true},
+		{"  Info  ", slog.LevelInfo, true},
+		{"warn", slog.LevelWarn, true},
+		{"warning", slog.LevelWarn, true},
+		{"error", slog.LevelError, true},
+		{"verbose", slog.LevelInfo, false}, // unrecognised: default, but say so
+		{"3", slog.LevelInfo, false},
+	}
+	for _, tc := range cases {
+		got, known := ParseLevel(tc.in)
+		if got != tc.want || known != tc.known {
+			t.Errorf("ParseLevel(%q) = %v, %v; want %v, %v", tc.in, got, known, tc.want, tc.known)
+		}
+	}
+}

--- a/internal/server/dispatch.go
+++ b/internal/server/dispatch.go
@@ -5,9 +5,19 @@ import (
 	"errors"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/undont/differ.nvim/internal/protocol"
 )
+
+// outcome names how a request ended, for the debug trace: the error's closed-set
+// code, or "ok".
+func outcome(resp protocol.Response) string {
+	if resp.Error != nil {
+		return resp.Error.Code
+	}
+	return "ok"
+}
 
 // dispatch routes one request. hello is handled inline (no goroutine) so the
 // hello-first gate has no race; every other method runs in its own goroutine and
@@ -37,6 +47,14 @@ func (s *Server) dispatch(ctx context.Context, req protocol.Request, inflight *s
 // handler can never crash the process or corrupt the stream.
 func (s *Server) run(ctx context.Context, req protocol.Request) (resp protocol.Response) {
 	resp.ID = req.ID
+	// registered first, so it runs last and sees whatever the recover below settled
+	// on. one line per request is the spine of a debug trace: what was asked, how
+	// long it took, and what came back
+	start := time.Now()
+	defer func() {
+		s.log.Debug("request", "method", req.Method, "id", req.ID,
+			"ms", time.Since(start).Milliseconds(), "code", outcome(resp))
+	}()
 	defer func() {
 		if r := recover(); r != nil {
 			s.log.Error("handler panic", "method", req.Method, "panic", r, "stack", string(debug.Stack()))

--- a/internal/server/dispatch.go
+++ b/internal/server/dispatch.go
@@ -85,9 +85,9 @@ func (s *Server) run(ctx context.Context, req protocol.Request) (resp protocol.R
 // its code; anything else is internal (and the real error is logged, never
 // surfaced, so tokens can't leak).
 func toRPCError(err error) *protocol.RPCError {
-	var pe *protocol.Error
-	if errors.As(err, &pe) {
-		return &protocol.RPCError{Code: pe.Code, Message: pe.Message, RetryAfter: pe.RetryAfter}
+	var perr *protocol.Error
+	if errors.As(err, &perr) {
+		return &protocol.RPCError{Code: perr.Code, Message: perr.Message, RetryAfter: perr.RetryAfter}
 	}
 	return &protocol.RPCError{Code: protocol.CodeInternal, Message: "internal error"}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -209,4 +210,46 @@ func (b *lockedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// captureLog returns a debug-level logger writing into buf.
+func captureLog(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func runWith(t *testing.T, log *slog.Logger, reg handlers.Registry, lines ...string) {
+	t.Helper()
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out strings.Builder
+	if err := New(reg, log).Run(context.Background(), in, &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestDebugTracesEveryRequest(t *testing.T) {
+	var buf bytes.Buffer
+	reg := handlers.NewRegistry(handlers.Deps{Log: captureLog(&buf)})
+	reg["boom"] = func(context.Context, json.RawMessage) (any, error) { panic("kaboom") }
+	runWith(t, captureLog(&buf), reg, helloLine, `{"id":3,"method":"boom","params":{}}`)
+
+	got := buf.String()
+	if !strings.Contains(got, "msg=request method=hello id=1") {
+		t.Errorf("hello was not traced:\n%s", got)
+	}
+	// the trace line is registered before the recover, so it runs after it and
+	// reports the code the caller actually received rather than "ok"
+	if !strings.Contains(got, "msg=request method=boom id=3") || !strings.Contains(got, "code=internal") {
+		t.Errorf("the panicking request was not traced with its outcome:\n%s", got)
+	}
+}
+
+func TestDefaultLevelTracesNothing(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil)) // no level set: info
+	reg := handlers.NewRegistry(handlers.Deps{Log: log})
+	runWith(t, log, reg, helloLine)
+
+	if strings.Contains(buf.String(), "msg=request") {
+		t.Errorf("info level should not trace requests:\n%s", buf.String())
+	}
 }

--- a/lua/differ/command.lua
+++ b/lua/differ/command.lua
@@ -270,7 +270,14 @@ function M.sidecar(arg)
     end
     sidecar.ping(function(err, info)
         if err then
-            return notify("sidecar: " .. (err.message or err.code), vim.log.levels.ERROR)
+            -- a spawn/handshake failure already carries the binary's own stderr; a
+            -- protocol-level one doesn't, so fall back to whatever it last said
+            local msg = "sidecar: " .. (err.message or err.code)
+            local exit = sidecar.last_exit()
+            if not msg:find("\n", 1, true) and exit then
+                msg = sidecar.with_tail(msg, exit.stderr)
+            end
+            return notify(msg, vim.log.levels.ERROR)
         end
         notify(
             ("sidecar ok — binary %s, protocol %d"):format(info.binary or "?", info.protocol or 0)

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -340,6 +340,32 @@ function M.resolve_keymaps(user_km)
     return out
 end
 
+-- resolve a dotted `M.closed` path against `t`: the table holding the final key, and
+-- that key. a path with no dot is top level, so `t` holds it directly
+---@param t table
+---@param path string
+---@return table|nil holder, string key
+function M.locate(t, path)
+    local section, key = path:match("^(.-)%.(.+)$")
+    if not section then
+        return t, path
+    end
+    return type(t[section]) == "table" and t[section] or nil, key
+end
+
+-- put any out-of-set value back to its default. a value no branch matches is worse
+-- than the default: `panel.position = "middle"` opened the bottom split (the else
+-- arm) while rendering as a sidebar (the top/bottom test), so nothing downstream
+-- agreed on what it meant
+local function clamp_closed(cfg)
+    for path, allowed in pairs(M.closed) do
+        local holder, key = M.locate(cfg, path)
+        if holder and not vim.tbl_contains(allowed, holder[key]) then
+            holder[key] = (M.locate(M.defaults, path))[key]
+        end
+    end
+end
+
 -- merge user opts over defaults and return the resolved config. keymaps are resolved
 -- into per-surface tables separately (a plain deep-extend would index-merge the
 -- multi-lhs lists)
@@ -349,6 +375,7 @@ function M.resolve(user)
     user = user or {}
     local cfg = vim.tbl_deep_extend("force", M.defaults, user)
     cfg.keymaps = M.resolve_keymaps(user.keymaps)
+    clamp_closed(cfg)
     return cfg
 end
 

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -1,4 +1,4 @@
--- plugin options: defaults, user merge, and shallow validation
+-- plugin options: defaults, user merge, and validation
 
 ---@class differ.Config.Panel
 ---@field position "bottom"|"top"|"left"|"right"
@@ -42,6 +42,15 @@ local M = {}
 -- own `keymaps.<surface>` override subtable
 local SURFACES = { "diff", "panel", "history", "merge" }
 local SURFACE_SET = { diff = true, panel = true, history = true, merge = true }
+
+-- the closed value sets the options below draw from. named once and shared, so a
+-- set used by two options (position) has one definition; `M.closed` maps each
+-- option to its set
+local POSITION = { "bottom", "top", "left", "right" }
+local LISTING = { "tree", "name" }
+local LAYOUT = { "stacked", "split" }
+local PANES = { "default", "diff4" }
+local GRAIN = { "word", "char" }
 
 ---@type differ.Config
 M.defaults = {
@@ -172,6 +181,129 @@ M.defaults = {
     -- uppercase letter (a vim user-command rule); registered by setup()
     command_alias = nil,
 }
+
+-- option path -> the set it must fall in. a value outside its set merges cleanly
+-- and then silently does nothing, which is what makes these worth checking by name
+---@type table<string, string[]>
+M.closed = {
+    ["layout"] = LAYOUT,
+    ["panel.position"] = POSITION,
+    ["panel.listing"] = LISTING,
+    ["history.position"] = POSITION,
+    ["merge.layout"] = PANES,
+    ["deep_diff.granularity"] = GRAIN,
+}
+
+-- options that default to nil, so the defaults table carries no key for them and
+-- the unknown-key walk can't see them. keep in step with the nil entries above
+local NILABLE = { base = true, sidecar_bin = true, command_alias = true }
+
+local function show(value)
+    if type(value) == "string" then
+        return '"' .. value .. '"'
+    end
+    return tostring(value)
+end
+
+local function check_enum(path, value, diags)
+    local allowed = M.closed[path]
+    if not allowed or value == nil then
+        return
+    end
+    for _, ok in ipairs(allowed) do
+        if value == ok then
+            return
+        end
+    end
+    local quoted = {}
+    for i, ok in ipairs(allowed) do
+        quoted[i] = '"' .. ok .. '"'
+    end
+    diags[#diags + 1] = ("%s must be one of %s (got %s)"):format(
+        path,
+        table.concat(quoted, ", "),
+        show(value)
+    )
+end
+
+-- one level down into a known table option: unknown sub-keys and their enums.
+-- every nested default is non-nil, so absence from the default is a real typo
+local function check_section(key, value, diags)
+    local default = M.defaults[key]
+    if type(default) ~= "table" then
+        return
+    end
+    if type(value) ~= "table" then
+        diags[#diags + 1] = ("%s must be a table (got %s)"):format(key, type(value))
+        return
+    end
+    for sub, sub_value in pairs(value) do
+        local path = key .. "." .. sub
+        if default[sub] == nil then
+            diags[#diags + 1] = ('unknown option "%s"'):format(path)
+        else
+            check_enum(path, sub_value, diags)
+        end
+    end
+end
+
+-- keymaps is flat action -> lhs plus the per-surface subtables, so it doesn't
+-- follow the nested-table shape the other sections do
+local function check_keymaps(value, diags)
+    if type(value) ~= "table" then
+        diags[#diags + 1] = ("keymaps must be a table (got %s)"):format(type(value))
+        return
+    end
+    for action, lhs in pairs(value) do
+        if SURFACE_SET[action] then
+            if type(lhs) ~= "table" then
+                diags[#diags + 1] = ("keymaps.%s must be a table of actions (got %s)"):format(
+                    action,
+                    type(lhs)
+                )
+            else
+                for sub in pairs(lhs) do
+                    if M.defaults.keymaps[sub] == nil then
+                        diags[#diags + 1] = ('unknown keymap action "keymaps.%s.%s"'):format(
+                            action,
+                            sub
+                        )
+                    end
+                end
+            end
+        elseif M.defaults.keymaps[action] == nil then
+            diags[#diags + 1] = ('unknown keymap action "keymaps.%s"'):format(action)
+        end
+    end
+end
+
+-- check user opts against the defaults: unknown keys at the top level and one level
+-- into each known table, plus the closed value sets. warnings only, and side-effect
+-- free so setup() and :checkhealth can both render the same list. pure (no vim), like
+-- resolve_keymaps, so it stays in the busted suite
+---@param user table|nil
+---@return string[]
+function M.validate(user)
+    if user == nil then
+        return {}
+    end
+    if type(user) ~= "table" then
+        return { ("setup() expects a table of options (got %s)"):format(type(user)) }
+    end
+    local diags = {}
+    for key, value in pairs(user) do
+        if key == "keymaps" then
+            check_keymaps(value, diags)
+        elseif M.defaults[key] == nil and not NILABLE[key] then
+            diags[#diags + 1] = ('unknown option "%s"'):format(key)
+        else
+            check_enum(key, value, diags)
+            check_section(key, value, diags)
+        end
+    end
+    table.sort(diags) -- pairs order is arbitrary; a stable list keeps the notice readable
+    return diags
+end
 
 -- resolve the keymaps config into per-surface action tables. the shared (top-level)
 -- defaults take any top-level user override, then each surface layers its own

--- a/lua/differ/health.lua
+++ b/lua/differ/health.lua
@@ -59,20 +59,25 @@ local function check_config()
     end
 end
 
--- reported even when the sidecar is healthy now; a crash-restart leaves no other trace
-local function check_last_exit(sidecar)
+-- whatever the sidecar has said, dead or alive. a crash-restart leaves no other trace,
+-- and neither does a recovered panic: dispatch logs the stack and keeps the process up,
+-- so the caller gets a bare "internal error" and this is where the stack surfaces
+local function check_sidecar_output(sidecar)
     local exit = sidecar.last_exit()
-    if not exit then
-        return
-    end
-    health.warn(
-        sidecar.with_tail(
-            ("the sidecar exited unexpectedly this session (code %d), last words:"):format(
-                exit.code
-            ),
-            exit.stderr
+    if exit then
+        health.warn(
+            sidecar.with_tail(
+                ("the sidecar exited unexpectedly this session (code %d), last words:"):format(
+                    exit.code
+                ),
+                exit.stderr
+            )
         )
-    )
+    end
+    local lines = sidecar.stderr_lines()
+    if #lines > 0 then
+        health.info(sidecar.with_tail("the running sidecar has logged:", lines))
+    end
 end
 
 -- returns the hello result so the auth section needs no second ping
@@ -113,12 +118,12 @@ local function check_sidecar(sidecar)
 
     if not pinged or not done then
         health.error(("no answer to a hello within %dms"):format(PING_TIMEOUT_MS))
-        check_last_exit(sidecar)
+        check_sidecar_output(sidecar)
         return nil
     end
     if gerr then
-        -- no check_last_exit: a death on the way up already folded its stderr in here,
-        -- and a handshake that failed any other way left no exit to report
+        -- no check_sidecar_output: a death on the way up already folded its stderr in
+        -- here, and a handshake that failed any other way left no exit to report
         health.error(gerr.message or gerr.code)
         return nil
     end
@@ -126,7 +131,7 @@ local function check_sidecar(sidecar)
     health.ok(
         ("handshake ok: protocol %d, binary %s"):format(ginfo.protocol or 0, ginfo.binary or "?")
     )
-    check_last_exit(sidecar)
+    check_sidecar_output(sidecar)
     return ginfo
 end
 

--- a/lua/differ/health.lua
+++ b/lua/differ/health.lua
@@ -1,0 +1,165 @@
+-- :checkhealth differ. one section per requirement that can fail at runtime
+
+local health = vim.health
+
+local M = {}
+
+-- a cold check pays a process start before the handshake answers
+local PING_TIMEOUT_MS = 5000
+
+local function check_nvim()
+    health.start("neovim")
+    if vim.fn.has("nvim-0.12") == 1 then
+        health.ok("nvim " .. tostring(vim.version()))
+    else
+        health.error(
+            ("nvim %s is below the 0.12 floor"):format(vim.version()),
+            { "differ needs vim.text.diff, which 0.12 introduced" }
+        )
+    end
+    if vim.o.termguicolors then
+        health.ok("'termguicolors' is on")
+    else
+        health.warn(
+            "'termguicolors' is off; the diff, merge and thread highlights render uncoloured",
+            {
+                "add `vim.o.termguicolors = true` to your config",
+            }
+        )
+    end
+end
+
+local function check_git()
+    health.start("git")
+    if vim.fn.executable("git") ~= 1 then
+        return health.error("git is not on PATH", {
+            "every local diff, log and merge surface shells out to git",
+        })
+    end
+    local res = vim.system({ "git", "--version" }, { text = true }):wait()
+    if res.code ~= 0 then
+        return health.error("git is on PATH but `git --version` failed: " .. (res.stderr or ""))
+    end
+    health.ok(vim.trim(res.stdout or "git found"))
+end
+
+local function check_config()
+    health.start("configuration")
+    local differ = require("differ")
+    if differ.config == nil then
+        health.info("setup() has not been called; the built-in defaults are in use")
+    end
+    -- the raw opts: after the merge an unknown key looks like a deliberate one
+    local diags = require("differ.config").validate(differ.user_opts)
+    if #diags == 0 then
+        return health.ok("no problems found in the options passed to setup()")
+    end
+    for _, diag in ipairs(diags) do
+        health.error(diag)
+    end
+end
+
+-- reported even when the sidecar is healthy now; a crash-restart leaves no other trace
+local function check_last_exit(sidecar)
+    local exit = sidecar.last_exit()
+    if not exit then
+        return
+    end
+    health.warn(
+        sidecar.with_tail(
+            ("the sidecar exited unexpectedly this session (code %d), last words:"):format(
+                exit.code
+            ),
+            exit.stderr
+        )
+    )
+end
+
+-- returns the hello result so the auth section needs no second ping
+---@return differ.sidecar.Hello|nil
+local function check_sidecar(sidecar)
+    health.start("sidecar")
+    local level = vim.env.DIFFER_LOG_LEVEL
+    if level and level ~= "" then
+        health.info("DIFFER_LOG_LEVEL=" .. level)
+    end
+
+    local bin = sidecar.binary_path()
+    if not bin then
+        health.warn("no differ-sidecar binary found; PR review is unavailable", {
+            "run `make go-build` in the plugin directory",
+            "or point `sidecar_bin` at an existing one",
+        })
+        return nil
+    end
+    health.info("binary: " .. bin)
+
+    local done, gerr = false, nil
+    ---@type differ.sidecar.Hello|nil
+    local ginfo
+    -- vim.wait delivers the client's own failure notification inside this call, and an
+    -- error-level notify aborts :checkhealth
+    local notify = vim.notify
+    vim.notify = function() end
+    local pinged = pcall(function()
+        sidecar.ping(function(err, info)
+            gerr, ginfo, done = err, info, true
+        end)
+        return vim.wait(PING_TIMEOUT_MS, function()
+            return done
+        end)
+    end)
+    vim.notify = notify
+
+    if not pinged or not done then
+        health.error(("no answer to a hello within %dms"):format(PING_TIMEOUT_MS))
+        check_last_exit(sidecar)
+        return nil
+    end
+    if gerr then
+        -- no check_last_exit: a death on the way up already folded its stderr in here,
+        -- and a handshake that failed any other way left no exit to report
+        health.error(gerr.message or gerr.code)
+        return nil
+    end
+
+    health.ok(
+        ("handshake ok: protocol %d, binary %s"):format(ginfo.protocol or 0, ginfo.binary or "?")
+    )
+    check_last_exit(sidecar)
+    return ginfo
+end
+
+---@param hello differ.sidecar.Hello|nil
+local function check_auth(hello)
+    health.start("github auth")
+    if not hello then
+        return health.info("not checked: the sidecar did not answer")
+    end
+    -- absent is not "ok": a sidecar predating the field simply says nothing
+    if not hello.auth or hello.auth == "" then
+        return health.warn("this sidecar does not report auth state", {
+            "rebuild it with `make go-build` to see it here",
+        })
+    end
+    if hello.auth == "ok" then
+        return health.ok("a github token is available")
+    end
+    local advice = { "PR review is unavailable until this is resolved" }
+    if hello.auth == "gh_missing" then
+        advice = { "install the gh CLI, or set GH_TOKEN / GITHUB_TOKEN" }
+    elseif hello.auth == "auth" then
+        advice = { "run `gh auth login`" }
+    end
+    health.warn(hello.auth_message or ("github auth: " .. hello.auth), advice)
+end
+
+function M.check()
+    local sidecar = require("differ.sidecar")
+    check_nvim()
+    check_git()
+    check_config()
+    check_auth(check_sidecar(sidecar))
+end
+
+return M

--- a/lua/differ/health.lua
+++ b/lua/differ/health.lua
@@ -55,7 +55,7 @@ local function check_config()
         return health.ok("no problems found in the options passed to setup()")
     end
     for _, diag in ipairs(diags) do
-        health.error(diag)
+        health.warn(diag)
     end
 end
 

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -31,9 +31,20 @@ local function register_aliases(alias)
     end
 end
 
+-- warn on anything config.validate flagged. one notification for the lot: a typo'd
+-- table tends to produce several, and one line each buries the rest of the notify log
+---@param diags string[]
+local function warn_config(diags)
+    if #diags == 0 then
+        return
+    end
+    vim.notify("differ: config warnings:\n  " .. table.concat(diags, "\n  "), vim.log.levels.WARN)
+end
+
 -- resolve options and register highlight groups; call once from user config
 ---@param opts table|nil
 function M.setup(opts)
+    warn_config(config.validate(opts))
     M.config = config.resolve(opts)
     require("differ.ui.highlights").setup()
     register_aliases(M.config.command_alias)

--- a/lua/differ/init.lua
+++ b/lua/differ/init.lua
@@ -7,6 +7,12 @@ local M = {}
 ---@type differ.Config|nil
 M.config = nil
 
+-- the options setup() was handed, kept unresolved so :checkhealth can re-run
+-- validation against what was actually written rather than the merged result, where
+-- an unknown key is indistinguishable from a deliberate one
+---@type table|nil
+M.user_opts = nil
+
 -- register each `command_alias` as an ex-command routing to the `:Differ` dispatcher.
 -- a bad name (e.g. not starting uppercase) warns rather than aborting setup()
 ---@param alias string|string[]|nil
@@ -45,6 +51,7 @@ end
 ---@param opts table|nil
 function M.setup(opts)
     warn_config(config.validate(opts))
+    M.user_opts = opts
     M.config = config.resolve(opts)
     require("differ.ui.highlights").setup()
     register_aliases(M.config.command_alias)

--- a/lua/differ/sidecar/init.lua
+++ b/lua/differ/sidecar/init.lua
@@ -14,6 +14,15 @@ local MAX_ATTEMPTS = 5
 -- that paginates (or never returns) outlives it; generous enough for a large PR's file
 -- walk, since firing early would fail a request that was going to succeed
 local REQUEST_TIMEOUT_MS = 60000
+-- the binary's structured logs land on stderr, kept in a bounded ring per process so a
+-- chatty log level can't grow without limit. without them the only account of a crash
+-- is an exit code
+local STDERR_RING = 200
+-- how much of that ring gets folded onto an error, in bytes rather than lines: slog
+-- renders a multi-line value (the panic stack dispatch logs) as one long quoted line,
+-- which costs the same screen height once wrapped as the same bytes spread over many
+-- lines, so counting lines would bound the wrong thing
+local STDERR_BYTES = 2000
 
 local M = {}
 
@@ -27,14 +36,22 @@ local M = {}
 ---@field pending table<integer, { cb: fun(err: table|nil, result: any), timer: any }>
 ---@field queue { method: string, params: any, cb: fun(err: table|nil, result: any) }[]
 ---@field stdout_buf string
+---@field stderr_buf string    -- unterminated tail of the stderr stream
+---@field stderr_ring table    -- bounded line ring, { n = <total pushed>, [1..STDERR_RING] }
 ---@field attempts integer     -- consecutive restart attempts (backoff)
 ---@field binary string|nil    -- version reported by hello
 
 ---@type differ.sidecar.Client|nil
 local client = nil
 
+-- the last unintentional death, kept at module scope so it outlives the client the
+-- crash took with it: after the restart budget runs out there is no client left to
+-- ask, and that is exactly when someone goes looking
+---@type { code: integer, stderr: string[] }|nil
+local last_exit = nil
+
 -- forward declarations (mutual recursion across start/exit/restart)
-local start, on_stdout, on_exit, handshake, schedule_restart, flush_queue, do_request
+local start, on_stdout, on_stderr, on_exit, handshake, schedule_restart, flush_queue, do_request
 
 local function mkerr(code, message)
     return { code = code, message = message }
@@ -50,9 +67,66 @@ local function new_client()
         pending = {},
         queue = {},
         stdout_buf = "",
+        stderr_buf = "",
+        stderr_ring = { n = 0 },
         attempts = 0,
         binary = nil,
     }
+end
+
+local function ring_push(ring, line)
+    ring.n = ring.n + 1
+    ring[(ring.n - 1) % STDERR_RING + 1] = line
+end
+
+-- the ring's contents in write order, oldest first
+local function ring_lines(ring)
+    local out = {}
+    local total = math.min(ring.n, STDERR_RING)
+    for k = ring.n - total + 1, ring.n do
+        out[#out + 1] = ring[(k - 1) % STDERR_RING + 1]
+    end
+    return out
+end
+
+-- fold the sidecar's own last words onto an error. the Go logs are the only account of
+-- why it died, so an error that omits them leaves an exit code and nothing else.
+local function with_tail(msg, lines)
+    if not lines or #lines == 0 then
+        return msg
+    end
+    local out, size = {}, 0
+    for i = #lines, 1, -1 do
+        local line = lines[i]
+        if size + #line > STDERR_BYTES then
+            if #out == 0 then
+                -- one line can outrun the whole budget on its own (a stack is one
+                -- line); keep its head, where go puts the innermost frames
+                out[1] = line:sub(1, STDERR_BYTES) .. " …"
+            end
+            break
+        end
+        size = size + #line + 1
+        table.insert(out, 1, line)
+    end
+    return msg .. "\n" .. table.concat(out, "\n")
+end
+
+-- split `buf` on newlines, handing each complete line to `fn`; returns the
+-- unterminated remainder for the next chunk. both streams arrive in arbitrary
+-- chunks, so neither can assume a chunk boundary is a line boundary
+local function consume_lines(buf, fn)
+    while true do
+        local nl = buf:find("\n", 1, true)
+        if not nl then
+            return buf
+        end
+        local line = buf:sub(1, nl - 1)
+        buf = buf:sub(nl + 1)
+        if line ~= "" then
+            fn(line)
+        end
+    end
 end
 
 -- this file is lua/differ/sidecar/init.lua, so the plugin root is three dirs up.
@@ -174,14 +248,16 @@ function handshake()
             return -- this client was stopped/replaced; its handshake result is moot
         end
         if err then
+            -- a binary that dies before answering hello lands here, not in the restart
+            -- path, so this is the only error its callers ever see. `err` is the exit
+            -- error and carries the process's stderr; passing it on is what makes the
+            -- difference between "handshake failed" and the reason it failed
+            local why = "handshake failed: " .. (err.message or err.code)
             vim.schedule(function()
-                vim.notify(
-                    "differ: sidecar handshake failed: " .. (err.message or err.code),
-                    vim.log.levels.ERROR
-                )
+                vim.notify("differ: sidecar " .. why, vim.log.levels.ERROR)
             end)
             client.stopping = true
-            fail_all(mkerr("internal", "handshake failed"))
+            fail_all(mkerr("internal", why))
             return
         end
         if type(result) ~= "table" or result.protocol ~= PROTOCOL then
@@ -192,7 +268,13 @@ function handshake()
                 )
             end)
             client.stopping = true
-            fail_all(mkerr("internal", "protocol mismatch"))
+            -- the caller gets the same instruction the notification carries
+            fail_all(
+                mkerr(
+                    "internal",
+                    "protocol mismatch — rebuild your sidecar (run `make go-build` or `go install`)"
+                )
+            )
             return
         end
         client.ready = true
@@ -203,42 +285,48 @@ function handshake()
     send({ id = id, method = "hello", params = { client = "differ.nvim", protocol = PROTOCOL } })
 end
 
+-- an id-less frame is a v1 no-op (the seam for phase-6 server→client
+-- notifications); only a response matching a pending id is dispatched.
+local function dispatch_line(line)
+    local ok, msg = pcall(vim.json.decode, line)
+    if not (ok and type(msg) == "table" and msg.id ~= nil and client.pending[msg.id]) then
+        return
+    end
+    local cb = take(msg.id)
+    local e, result
+    if msg.error then
+        e = {
+            code = msg.error.code or "internal",
+            message = msg.error.message,
+            retry_after = msg.error.retry_after,
+        }
+    else
+        result = msg.result
+    end
+    vim.schedule(function()
+        cb(e, result)
+    end)
+end
+
 -- libuv fast context: accumulate stdout and dispatch each complete line. only
 -- vim.json.decode / vim.schedule are touched here (both fast-context safe).
 function on_stdout(err, data)
     if err or not data or not client then
         return
     end
-    client.stdout_buf = client.stdout_buf .. data
-    while true do
-        local nl = client.stdout_buf:find("\n", 1, true)
-        if not nl then
-            break
-        end
-        local line = client.stdout_buf:sub(1, nl - 1)
-        client.stdout_buf = client.stdout_buf:sub(nl + 1)
-        -- an id-less frame is a v1 no-op (the seam for phase-6 server→client
-        -- notifications); only a response matching a pending id is dispatched.
-        if line ~= "" then
-            local ok, msg = pcall(vim.json.decode, line)
-            if ok and type(msg) == "table" and msg.id ~= nil and client.pending[msg.id] then
-                local cb = take(msg.id)
-                local e, result
-                if msg.error then
-                    e = {
-                        code = msg.error.code or "internal",
-                        message = msg.error.message,
-                        retry_after = msg.error.retry_after,
-                    }
-                else
-                    result = msg.result
-                end
-                vim.schedule(function()
-                    cb(e, result)
-                end)
-            end
-        end
+    client.stdout_buf = consume_lines(client.stdout_buf .. data, dispatch_line)
+end
+
+-- libuv fast context, as on_stdout: string and table work only. a nil `data` is
+-- EOF, which leaves any unterminated tail for on_exit to flush
+function on_stderr(err, data)
+    if err or not data or not client then
+        return
     end
+    local ring = client.stderr_ring
+    client.stderr_buf = consume_lines(client.stderr_buf .. data, function(line)
+        ring_push(ring, line)
+    end)
 end
 
 function on_exit(obj)
@@ -248,7 +336,15 @@ function on_exit(obj)
     client.running = false
     client.ready = false
     client.proc = nil
-    fail_pending(mkerr("internal", "sidecar exited (code " .. tostring(obj.code) .. ")"))
+    if client.stderr_buf ~= "" then
+        ring_push(client.stderr_ring, client.stderr_buf) -- a last line with no newline
+        client.stderr_buf = ""
+    end
+    local lines = ring_lines(client.stderr_ring)
+    last_exit = { code = obj.code, stderr = lines }
+    fail_pending(
+        mkerr("internal", with_tail("sidecar exited (code " .. tostring(obj.code) .. ")", lines))
+    )
     if client.stopping then
         client.stopping = false
         return
@@ -263,7 +359,12 @@ function schedule_restart()
         vim.schedule(function()
             vim.notify("differ: sidecar keeps crashing; giving up", vim.log.levels.ERROR)
         end)
-        fail_all(mkerr("internal", "sidecar unavailable"))
+        -- the tail matters most here: a request made before the handshake sits in the
+        -- queue, so the per-exit failure above never reaches it and this is the only
+        -- error a caller sees on a binary that never comes up
+        fail_all(
+            mkerr("internal", with_tail("sidecar unavailable", last_exit and last_exit.stderr))
+        )
         return
     end
     local delay = math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ^ (client.attempts - 1))
@@ -289,6 +390,8 @@ function start()
         return false, "sidecar binary not found (run `make go-build`, or set sidecar_bin)"
     end
     client.stdout_buf = ""
+    client.stderr_buf = ""
+    client.stderr_ring = { n = 0 } -- per process: the previous one's logs live on in last_exit
     client.ready = false
     -- every callback below belongs to the client that spawned this process. a stop (or
     -- a crash-restart) can leave an older process still dying while a newer one runs, and
@@ -305,7 +408,7 @@ function start()
     local ok, proc = pcall(vim.system, { bin }, {
         stdin = true,
         stdout = owned(on_stdout),
-        stderr = function() end, -- structured logs on the binary's stderr; the client ignores them
+        stderr = owned(on_stderr),
     }, owned(on_exit))
     if not ok then
         return false, tostring(proc)
@@ -384,6 +487,33 @@ end
 -- whether the handshake has completed and requests flow without queueing.
 function M.is_ready()
     return client ~= nil and client.ready
+end
+
+-- what the running sidecar has said, oldest first, back to the ring's limit. empty
+-- when nothing is running or the binary has been quiet, which at the default log
+-- level it is. callers cut it to their own length with `with_tail`
+---@return string[]
+function M.stderr_lines()
+    if not client then
+        return {}
+    end
+    return ring_lines(client.stderr_ring)
+end
+
+-- the last crash: its exit code and the stderr it left behind. nil when nothing has
+-- died unexpectedly this session (an intentional stop is not recorded)
+---@return { code: integer, stderr: string[] }|nil
+function M.last_exit()
+    return last_exit
+end
+
+-- append a capped tail of `lines` to `msg`, as the client's own errors do. exported so
+-- callers surfacing a stored crash cut it to the same length rather than their own
+---@param msg string
+---@param lines string[]|nil
+---@return string
+function M.with_tail(msg, lines)
+    return with_tail(msg, lines)
 end
 
 return M

--- a/lua/differ/sidecar/init.lua
+++ b/lua/differ/sidecar/init.lua
@@ -14,11 +14,11 @@ local MAX_ATTEMPTS = 5
 -- that paginates (or never returns) outlives it; generous enough for a large PR's file
 -- walk, since firing early would fail a request that was going to succeed
 local REQUEST_TIMEOUT_MS = 60000
--- the binary's structured logs land on stderr, kept in a bounded ring per process so a
--- chatty log level can't grow without limit. without them the only account of a crash
--- is an exit code
-local STDERR_RING = 200
--- how much of that ring gets folded onto an error, in bytes rather than lines: slog
+-- the binary's structured logs land on stderr, kept per process and capped so a chatty
+-- log level can't grow without limit across a session measured in days. without them
+-- the only account of a crash is an exit code
+local STDERR_MAX = 200
+-- how much of that log gets folded onto an error, in bytes rather than lines: slog
 -- renders a multi-line value (the panic stack dispatch logs) as one long quoted line,
 -- which costs the same screen height once wrapped as the same bytes spread over many
 -- lines, so counting lines would bound the wrong thing
@@ -37,7 +37,7 @@ local M = {}
 ---@field queue { method: string, params: any, cb: fun(err: table|nil, result: any) }[]
 ---@field stdout_buf string
 ---@field stderr_buf string    -- unterminated tail of the stderr stream
----@field stderr_ring table    -- bounded line ring, { n = <total pushed>, [1..STDERR_RING] }
+---@field stderr_log string[]  -- the last STDERR_MAX lines this process wrote
 ---@field attempts integer     -- consecutive restart attempts (backoff)
 ---@field binary string|nil    -- version reported by hello
 
@@ -68,25 +68,19 @@ local function new_client()
         queue = {},
         stdout_buf = "",
         stderr_buf = "",
-        stderr_ring = { n = 0 },
+        stderr_log = {},
         attempts = 0,
         binary = nil,
     }
 end
 
-local function ring_push(ring, line)
-    ring.n = ring.n + 1
-    ring[(ring.n - 1) % STDERR_RING + 1] = line
-end
-
--- the ring's contents in write order, oldest first
-local function ring_lines(ring)
-    local out = {}
-    local total = math.min(ring.n, STDERR_RING)
-    for k = ring.n - total + 1, ring.n do
-        out[#out + 1] = ring[(k - 1) % STDERR_RING + 1]
+-- append, dropping the oldest once at the cap. a shift per line past the cap, which at
+-- a couple of lines per user action does not earn a cleverer structure
+local function push_line(lines, line)
+    lines[#lines + 1] = line
+    if #lines > STDERR_MAX then
+        table.remove(lines, 1)
     end
-    return out
 end
 
 -- fold the sidecar's own last words onto an error. the Go logs are the only account of
@@ -323,9 +317,9 @@ function on_stderr(err, data)
     if err or not data or not client then
         return
     end
-    local ring = client.stderr_ring
+    local log = client.stderr_log
     client.stderr_buf = consume_lines(client.stderr_buf .. data, function(line)
-        ring_push(ring, line)
+        push_line(log, line)
     end)
 end
 
@@ -337,10 +331,10 @@ function on_exit(obj)
     client.ready = false
     client.proc = nil
     if client.stderr_buf ~= "" then
-        ring_push(client.stderr_ring, client.stderr_buf) -- a last line with no newline
+        push_line(client.stderr_log, client.stderr_buf) -- a last line with no newline
         client.stderr_buf = ""
     end
-    local lines = ring_lines(client.stderr_ring)
+    local lines = client.stderr_log
     last_exit = { code = obj.code, stderr = lines }
     fail_pending(
         mkerr("internal", with_tail("sidecar exited (code " .. tostring(obj.code) .. ")", lines))
@@ -391,7 +385,7 @@ function start()
     end
     client.stdout_buf = ""
     client.stderr_buf = ""
-    client.stderr_ring = { n = 0 } -- per process: the previous one's logs live on in last_exit
+    client.stderr_log = {} -- per process: the previous one's lines live on in last_exit
     client.ready = false
     -- every callback below belongs to the client that spawned this process. a stop (or
     -- a crash-restart) can leave an older process still dying while a newer one runs, and
@@ -489,7 +483,7 @@ function M.is_ready()
     return client ~= nil and client.ready
 end
 
--- what the running sidecar has said, oldest first, back to the ring's limit. empty
+-- what the running sidecar has said, oldest first, back to the cap. empty
 -- when nothing is running or the binary has been quiet, which at the default log
 -- level it is. callers cut it to their own length with `with_tail`
 ---@return string[]
@@ -497,7 +491,7 @@ function M.stderr_lines()
     if not client then
         return {}
     end
-    return ring_lines(client.stderr_ring)
+    return vim.list_slice(client.stderr_log, 1)
 end
 
 -- the last crash: its exit code and the stderr it left behind. nil when nothing has

--- a/lua/differ/sidecar/init.lua
+++ b/lua/differ/sidecar/init.lua
@@ -439,9 +439,17 @@ function M.request(method, params, cb)
     end
 end
 
--- prove the round trip without touching GitHub: an explicit hello, returning
--- { protocol, binary }. drives the :Differ sidecar smoke check.
----@param cb fun(err: table|nil, info: table|nil)
+-- the handshake result. auth and auth_message are absent from a sidecar built before
+-- they were added, which reads as unknown rather than as "no token"
+---@class differ.sidecar.Hello
+---@field protocol integer
+---@field binary string
+---@field auth string|nil          -- "ok" | "gh_missing" | "auth"
+---@field auth_message string|nil  -- what to do about a non-ok auth
+
+-- prove the round trip without touching GitHub: an explicit hello. drives the
+-- :Differ sidecar smoke check and the :checkhealth sidecar section.
+---@param cb fun(err: table|nil, info: differ.sidecar.Hello|nil)
 function M.ping(cb)
     M.request("hello", { client = "differ.nvim", protocol = PROTOCOL }, cb)
 end
@@ -481,6 +489,13 @@ end
 -- whether the handshake has completed and requests flow without queueing.
 function M.is_ready()
     return client ~= nil and client.ready
+end
+
+-- the binary a request would spawn, by the same resolution order, or nil when not
+-- reachable. used by :checkhealth, to report the path
+---@return string|nil
+function M.binary_path()
+    return resolve_bin()
 end
 
 -- what the running sidecar has said, oldest first, back to the cap. empty

--- a/test/nvim/config_spec.lua
+++ b/test/nvim/config_spec.lua
@@ -31,3 +31,44 @@ describe("config.resolve merge", function()
         assert.are.equal("right", cfg.panel.position)
     end)
 end)
+
+describe("setup config warnings", function()
+    local saved
+
+    -- setup() also runs the highlight registration, which warns about
+    -- termguicolors under headless nvim; only the config notice is ours
+    local function config_notifs()
+        local out = {}
+        for _, n in ipairs(_G.notifs) do
+            if (n.msg or ""):find("config warnings", 1, true) then
+                out[#out + 1] = n
+            end
+        end
+        return out
+    end
+
+    before_each(function()
+        saved = require("differ").config
+        _G.notifs = {}
+    end)
+
+    after_each(function()
+        require("differ").config = saved
+    end)
+
+    it("warns once, listing every diagnostic, and still applies the valid keys", function()
+        require("differ").setup({ pannel = {}, panel = { position = "middle" } })
+        local warnings = config_notifs()
+        assert.are.equal(1, #warnings)
+        assert.are.equal(vim.log.levels.WARN, warnings[1].level)
+        assert.is_truthy(warnings[1].msg:find('unknown option "pannel"', 1, true))
+        assert.is_truthy(warnings[1].msg:find("panel.position must be one of", 1, true))
+        -- warn-only: the bad value still merges, exactly as it did before
+        assert.are.equal("middle", require("differ").get_config().panel.position)
+    end)
+
+    it("stays quiet on a valid config", function()
+        require("differ").setup({ panel = { position = "left" } })
+        assert.are.equal(0, #config_notifs())
+    end)
+end)

--- a/test/nvim/config_spec.lua
+++ b/test/nvim/config_spec.lua
@@ -63,12 +63,48 @@ describe("setup config warnings", function()
         assert.are.equal(vim.log.levels.WARN, warnings[1].level)
         assert.is_truthy(warnings[1].msg:find('unknown option "pannel"', 1, true))
         assert.is_truthy(warnings[1].msg:find("panel.position must be one of", 1, true))
-        -- warn-only: the bad value still merges, exactly as it did before
-        assert.are.equal("middle", require("differ").get_config().panel.position)
+        -- warn, don't refuse: differ still starts on the default for the value it
+        -- could not honour
+        assert.are.equal("right", require("differ").get_config().panel.position)
     end)
 
     it("stays quiet on a valid config", function()
         require("differ").setup({ panel = { position = "left" } })
         assert.are.equal(0, #config_notifs())
+    end)
+end)
+
+describe("config.resolve clamping", function()
+    -- an out-of-set value used to merge verbatim, leaving no branch matching it:
+    -- panel.position = "middle" opened the bottom split while rendering as a sidebar
+    it("puts an out-of-set value back to its default", function()
+        local cfg = config.resolve({ panel = { position = "middle" } })
+        assert.are.equal("right", cfg.panel.position)
+    end)
+
+    it("clamps every closed set, at both levels", function()
+        local cfg = config.resolve({
+            layout = "sideways",
+            panel = { position = "middle", listing = "grid" },
+            history = { position = "middle" },
+            merge = { layout = "diff9" },
+            deep_diff = { granularity = "sentence" },
+        })
+        assert.are.equal("stacked", cfg.layout)
+        assert.are.equal("right", cfg.panel.position)
+        assert.are.equal("tree", cfg.panel.listing)
+        assert.are.equal("bottom", cfg.history.position)
+        assert.are.equal("default", cfg.merge.layout)
+        assert.are.equal("word", cfg.deep_diff.granularity)
+    end)
+
+    it("leaves valid values and unrelated keys alone", function()
+        local cfg = config.resolve({
+            panel = { position = "left", width = 80 },
+            deep_diff = { granularity = "char" },
+        })
+        assert.are.equal("left", cfg.panel.position)
+        assert.are.equal(80, cfg.panel.width) -- not a closed set, untouched
+        assert.are.equal("char", cfg.deep_diff.granularity)
     end)
 end)

--- a/test/nvim/health_spec.lua
+++ b/test/nvim/health_spec.lua
@@ -124,6 +124,26 @@ describe("differ.health", function()
         assert.are.equal(0, notified, "check() let a notification escape")
     end)
 
+    it("reports what a healthy, still-running sidecar has logged", function()
+        -- a recovered panic leaves the process up, so there is no exit to report and
+        -- the stack would otherwise be readable nowhere
+        require("differ").setup({
+            sidecar_bin = fake_sidecar({
+                'echo \'level=ERROR msg="handler panic" stack="goroutine 1"\' >&2',
+                "while IFS= read -r line; do",
+                '  id=$(printf %s "$line" | sed \'s/.*"id":\\([0-9]*\\).*/\\1/\')',
+                '  printf \'{"id":%s,"result":{"protocol":1,"binary":"fake"}}\\n\' "$id"',
+                "done",
+            }),
+        })
+        local calls = capture()
+
+        assert.is_truthy(find(calls, "sidecar", "handshake ok"))
+        local logged = find(calls, "sidecar", "handler panic")
+        assert.is_truthy(logged, "the running sidecar's output was not reported")
+        assert.are.equal("info", logged.kind)
+    end)
+
     it("warns rather than failing when no binary is resolvable", function()
         require("differ").setup({ sidecar_bin = "/nonexistent/differ-sidecar-xyz" })
         local calls = capture()

--- a/test/nvim/health_spec.lua
+++ b/test/nvim/health_spec.lua
@@ -101,13 +101,10 @@ describe("differ.health", function()
         require("differ").setup({ pannel = {}, panel = { position = "middle" } })
         local calls = capture()
 
-        -- error, not warn: a key that can never do what it says is wrong for everyone,
-        -- unlike a missing gh CLI, which is only wrong if you review PRs
-        assert.are.equal("error", find(calls, "configuration", 'unknown option "pannel"').kind)
-        assert.are.equal(
-            "error",
-            find(calls, "configuration", "panel.position must be one of").kind
-        )
+        -- warn, matching the notification setup() already fires: differ still runs, it
+        -- just runs on defaults where the config could not be honoured
+        assert.are.equal("warn", find(calls, "configuration", 'unknown option "pannel"').kind)
+        assert.are.equal("warn", find(calls, "configuration", "panel.position must be one of").kind)
     end)
 
     it("reports a sidecar that dies without abandoning the report", function()

--- a/test/nvim/health_spec.lua
+++ b/test/nvim/health_spec.lua
@@ -1,0 +1,138 @@
+-- runs under headless nvim: drives the real check() with vim.health stubbed, so the
+-- assertions are on what each section reports rather than on rendered buffer text
+local health = require("differ.health")
+
+-- capture: { { kind = "ok"|"warn"|..., section = "sidecar", msg = "..." } }, plus a
+-- count of any vim.notify that escaped check(). the suite's own notify stub means an
+-- error-level one can't raise here the way it does inside a real :checkhealth, so the
+-- assertion has to be that none is emitted at all
+local notified = 0
+
+local function capture()
+    local real_health, real_notify = vim.health, vim.notify
+    local calls, section = {}, nil
+    local function record(kind)
+        return function(msg)
+            calls[#calls + 1] = { kind = kind, section = section, msg = msg }
+        end
+    end
+    vim.health = {
+        start = function(name)
+            section = name
+        end,
+        ok = record("ok"),
+        info = record("info"),
+        warn = record("warn"),
+        error = record("error"),
+    }
+    notified = 0
+    vim.notify = function()
+        notified = notified + 1
+    end
+    -- health.lua caches vim.health at require time, so reload it against the stub
+    package.loaded["differ.health"] = nil
+    local ok, err = pcall(function()
+        require("differ.health").check()
+    end)
+    vim.health, vim.notify = real_health, real_notify
+    package.loaded["differ.health"] = health
+    assert.is_true(ok, "check() raised: " .. tostring(err))
+    return calls
+end
+
+local function find(calls, section, pattern)
+    for _, c in ipairs(calls) do
+        if c.section == section and tostring(c.msg):find(pattern, 1, true) then
+            return c
+        end
+    end
+    return nil
+end
+
+local function section_kinds(calls, section)
+    local kinds = {}
+    for _, c in ipairs(calls) do
+        if c.section == section then
+            kinds[c.kind] = true
+        end
+    end
+    return kinds
+end
+
+describe("differ.health", function()
+    local saved_config, saved_opts
+
+    local function fake_sidecar(lines)
+        local path = vim.fn.tempname()
+        vim.fn.writefile(vim.list_extend({ "#!/bin/sh" }, lines), path)
+        vim.fn.setfperm(path, "rwxr-xr-x")
+        return path
+    end
+
+    before_each(function()
+        local differ = require("differ")
+        saved_config, saved_opts = differ.config, differ.user_opts
+    end)
+
+    after_each(function()
+        require("differ.sidecar").stop()
+        local differ = require("differ")
+        differ.config, differ.user_opts = saved_config, saved_opts
+        vim.wait(100)
+    end)
+
+    it("reports every section against the real binary", function()
+        require("differ").setup({})
+        local calls = capture()
+
+        for _, section in ipairs({ "neovim", "git", "configuration", "sidecar", "github auth" }) do
+            assert.is_true(#vim.tbl_filter(function(c)
+                return c.section == section
+            end, calls) > 0, "no output for section: " .. section)
+        end
+        assert.is_truthy(find(calls, "neovim", "nvim "))
+        assert.is_truthy(find(calls, "git", "git version"))
+        assert.is_truthy(find(calls, "sidecar", "handshake ok: protocol 1"))
+        -- the real binary reports its auth state, whatever this machine's state is
+        assert.is_nil(find(calls, "github auth", "does not report auth state"))
+    end)
+
+    it("surfaces config warnings in the configuration section", function()
+        require("differ").setup({ pannel = {}, panel = { position = "middle" } })
+        local calls = capture()
+
+        -- error, not warn: a key that can never do what it says is wrong for everyone,
+        -- unlike a missing gh CLI, which is only wrong if you review PRs
+        assert.are.equal("error", find(calls, "configuration", 'unknown option "pannel"').kind)
+        assert.are.equal(
+            "error",
+            find(calls, "configuration", "panel.position must be one of").kind
+        )
+    end)
+
+    it("reports a sidecar that dies without abandoning the report", function()
+        require("differ").setup({
+            sidecar_bin = fake_sidecar({ "echo 'boom: cannot start' >&2", "exit 3" }),
+        })
+        local calls = capture()
+
+        local err = find(calls, "sidecar", "sidecar exited (code 3)")
+        assert.is_truthy(err)
+        assert.are.equal("error", err.kind)
+        assert.is_truthy(err.msg:find("boom: cannot start", 1, true)) -- its own last words
+        -- the sections after the failure still ran
+        assert.is_truthy(find(calls, "github auth", "the sidecar did not answer"))
+        -- the client notifies at error level on a failed handshake, which inside a real
+        -- :checkhealth raises out of the command and abandons everything after it
+        assert.are.equal(0, notified, "check() let a notification escape")
+    end)
+
+    it("warns rather than failing when no binary is resolvable", function()
+        require("differ").setup({ sidecar_bin = "/nonexistent/differ-sidecar-xyz" })
+        local calls = capture()
+
+        -- an unresolvable path still resolves to itself; the spawn is what fails
+        assert.is_true(section_kinds(calls, "sidecar").error)
+        assert.is_truthy(find(calls, "github auth", "the sidecar did not answer"))
+    end)
+end)

--- a/test/nvim/sidecar_spec.lua
+++ b/test/nvim/sidecar_spec.lua
@@ -283,14 +283,14 @@ describe("sidecar stderr", function()
             return done
         end))
 
-        -- 400 filler lines against a 200-line ring, then ~2000 bytes of that against
+        -- 400 filler lines against the 200-line cap, then ~2000 bytes of that against
         -- the byte cap: the newest survive both, the oldest survive neither
         assert.is_truthy(gerr.message:find("the last thing it said", 1, true))
         assert.is_truthy(gerr.message:find("filler line 399", 1, true))
         assert.is_nil(gerr.message:find("filler line 100", 1, true))
         assert.is_true(#gerr.message < 2500, "tail was not capped: " .. #gerr.message)
 
-        -- the ring itself keeps more than any one message shows, for :checkhealth
+        -- the stored log keeps more than any one message shows, for :checkhealth
         assert.are.equal(200, #sidecar.last_exit().stderr)
     end)
 
@@ -305,7 +305,7 @@ describe("sidecar stderr", function()
             return done
         end))
 
-        sidecar.stop() -- the client and its ring are gone; the crash record is not
+        sidecar.stop() -- the client and its log are gone; the crash record is not
         local exit = sidecar.last_exit()
         assert.are.equal(1, exit.code)
         assert.are.same({ "fatal: cannot start" }, exit.stderr)

--- a/test/nvim/sidecar_spec.lua
+++ b/test/nvim/sidecar_spec.lua
@@ -194,3 +194,121 @@ describe("sidecar client", function()
         assert.are.equal("the sidecar did not answer in time", gerr.message)
     end)
 end)
+
+describe("sidecar stderr", function()
+    local saved_config
+
+    -- a stand-in binary: the real one is quiet at the default log level, so the only
+    -- way to assert on stderr deterministically is to control what gets written
+    local function fake_sidecar(lines)
+        local path = vim.fn.tempname()
+        vim.fn.writefile(vim.list_extend({ "#!/bin/sh" }, lines), path)
+        vim.fn.setfperm(path, "rwxr-xr-x")
+        require("differ").setup({ sidecar_bin = path })
+        return path
+    end
+
+    before_each(function()
+        saved_config = require("differ").config
+    end)
+
+    after_each(function()
+        sidecar.stop()
+        require("differ").config = saved_config
+        vim.wait(100)
+    end)
+
+    it("carries the dying process's stderr into the exit error", function()
+        -- answers the handshake, then dies on the next request with an in-flight
+        -- caller waiting: the fail_pending path
+        fake_sidecar({
+            "while IFS= read -r line; do",
+            '  case "$line" in',
+            '    *hello*) printf \'{"id":1,"result":{"protocol":1,"binary":"fake"}}\\n\' ;;',
+            '    *) echo \'level=ERROR msg="handler panic" stack="goroutine 1"\' >&2; exit 3 ;;',
+            "  esac",
+            "done",
+        })
+
+        local done, gerr = false, nil
+        sidecar.request("cache_clear", nil, function(err)
+            gerr, done = err, true
+        end)
+        assert.is_true(
+            vim.wait(5000, function()
+                return done
+            end),
+            "the in-flight request was never failed"
+        )
+        assert.are.equal("internal", gerr.code)
+        assert.is_truthy(gerr.message:find("sidecar exited (code 3)", 1, true))
+        assert.is_truthy(gerr.message:find("handler panic", 1, true))
+        assert.is_truthy(gerr.message:find("goroutine 1", 1, true))
+    end)
+
+    it("explains why a binary that never comes up failed", function()
+        fake_sidecar({ "echo 'fatal: cannot start' >&2", "exit 1" })
+
+        local done, gerr = false, nil
+        sidecar.request("cache_clear", nil, function(err)
+            gerr, done = err, true
+        end)
+        assert.is_true(
+            vim.wait(5000, function()
+                return done
+            end),
+            "the queued request was never failed"
+        )
+        -- dying before hello fails the handshake, which stops the client outright:
+        -- the restart/give-up path is never reached, so this is the caller's only error
+        assert.are.equal("internal", gerr.code)
+        assert.is_truthy(gerr.message:find("handshake failed", 1, true))
+        assert.is_truthy(gerr.message:find("sidecar exited (code 1)", 1, true))
+        assert.is_truthy(gerr.message:find("fatal: cannot start", 1, true))
+    end)
+
+    it("cuts an oversized tail from the far end, keeping what was said last", function()
+        -- slog puts a whole panic stack on one line, so one line can outrun the cap
+        fake_sidecar({
+            'i=0; while [ $i -lt 400 ]; do echo "filler line $i" >&2; i=$((i+1)); done',
+            "echo 'level=ERROR msg=\"the last thing it said\"' >&2",
+            "exit 2",
+        })
+
+        local done, gerr = false, nil
+        sidecar.request("cache_clear", nil, function(err)
+            gerr, done = err, true
+        end)
+        assert.is_true(vim.wait(5000, function()
+            return done
+        end))
+
+        -- 400 filler lines against a 200-line ring, then ~2000 bytes of that against
+        -- the byte cap: the newest survive both, the oldest survive neither
+        assert.is_truthy(gerr.message:find("the last thing it said", 1, true))
+        assert.is_truthy(gerr.message:find("filler line 399", 1, true))
+        assert.is_nil(gerr.message:find("filler line 100", 1, true))
+        assert.is_true(#gerr.message < 2500, "tail was not capped: " .. #gerr.message)
+
+        -- the ring itself keeps more than any one message shows, for :checkhealth
+        assert.are.equal(200, #sidecar.last_exit().stderr)
+    end)
+
+    it("keeps the last crash reachable after the client is gone", function()
+        fake_sidecar({ "echo 'fatal: cannot start' >&2", "exit 1" })
+
+        local done = false
+        sidecar.request("cache_clear", nil, function()
+            done = true
+        end)
+        assert.is_true(vim.wait(5000, function()
+            return done
+        end))
+
+        sidecar.stop() -- the client and its ring are gone; the crash record is not
+        local exit = sidecar.last_exit()
+        assert.are.equal(1, exit.code)
+        assert.are.same({ "fatal: cannot start" }, exit.stderr)
+        assert.are.same({}, sidecar.stderr_lines())
+    end)
+end)

--- a/test/unit/config_spec.lua
+++ b/test/unit/config_spec.lua
@@ -154,8 +154,8 @@ describe("config.closed", function()
     -- the defaults can't see one, since it only walks keys that are actually set
     it("names a real default for every closed set", function()
         for path, allowed in pairs(config.closed) do
-            local section, key = path:match("^(.-)%.(.+)$")
-            local default = section and config.defaults[section][key] or config.defaults[path]
+            local holder, key = config.locate(config.defaults, path)
+            local default = holder and holder[key]
             assert.is_not_nil(default, path .. " has no default")
             local found = false
             for _, ok in ipairs(allowed) do

--- a/test/unit/config_spec.lua
+++ b/test/unit/config_spec.lua
@@ -43,3 +43,125 @@ describe("config.resolve_keymaps", function()
         assert.are.equal("gh", km.panel.next_hunk)
     end)
 end)
+
+describe("config.validate", function()
+    it("passes a valid config, and the defaults themselves", function()
+        assert.are.same({}, config.validate(nil))
+        assert.are.same({}, config.validate({}))
+        assert.are.same({}, config.validate(config.defaults))
+        assert.are.same(
+            {},
+            config.validate({
+                layout = "split",
+                panel = { position = "left", width = 40 },
+                history = { position = "top" },
+                merge = { layout = "diff4" },
+                deep_diff = { granularity = "char" },
+                comments = { inline = false },
+                keymaps = { next_hunk = "gh", panel = { stage = "ga" } },
+            })
+        )
+    end)
+
+    it("accepts the options that default to nil", function()
+        assert.are.same(
+            {},
+            config.validate({ base = "main", sidecar_bin = "/tmp/x", command_alias = "D" })
+        )
+    end)
+
+    it("flags an unknown top-level key", function()
+        assert.are.same({ 'unknown option "pannel"' }, config.validate({ pannel = {} }))
+    end)
+
+    it("flags an unknown key one level down", function()
+        assert.are.same(
+            { 'unknown option "panel.positon"' },
+            config.validate({ panel = { positon = "left" } })
+        )
+    end)
+
+    it("flags a value outside a closed set", function()
+        assert.are.same(
+            { 'panel.position must be one of "bottom", "top", "left", "right" (got "middle")' },
+            config.validate({ panel = { position = "middle" } })
+        )
+        assert.are.same(
+            { 'layout must be one of "stacked", "split" (got "sideways")' },
+            config.validate({ layout = "sideways" })
+        )
+        assert.are.same(
+            { 'deep_diff.granularity must be one of "word", "char" (got true)' },
+            config.validate({ deep_diff = { granularity = true } })
+        )
+    end)
+
+    it("flags a misspelled keymap action, top-level and per-surface", function()
+        assert.are.same(
+            { 'unknown keymap action "keymaps.next_hunkk"' },
+            config.validate({ keymaps = { next_hunkk = "gh" } })
+        )
+        assert.are.same(
+            { 'unknown keymap action "keymaps.panel.stag"' },
+            config.validate({ keymaps = { panel = { stag = "s" } } })
+        )
+    end)
+
+    it("does not mistake a surface subtable for an action", function()
+        assert.are.same({}, config.validate({ keymaps = { merge = { choose_ours = "x" } } }))
+    end)
+
+    it("flags a section given a non-table", function()
+        assert.are.same(
+            { "panel must be a table (got string)" },
+            config.validate({ panel = "left" })
+        )
+        assert.are.same(
+            { "keymaps must be a table (got string)" },
+            config.validate({ keymaps = "none" })
+        )
+        assert.are.same(
+            { "keymaps.panel must be a table of actions (got string)" },
+            config.validate({ keymaps = { panel = "s" } })
+        )
+    end)
+
+    it("returns every diagnostic, sorted", function()
+        assert.are.same(
+            {
+                'layout must be one of "stacked", "split" (got "sideways")',
+                'unknown keymap action "keymaps.next_hunkk"',
+                'unknown option "pannel"',
+            },
+            config.validate({
+                layout = "sideways",
+                pannel = {},
+                keymaps = { next_hunkk = "g" },
+            })
+        )
+    end)
+
+    it("rejects a non-table opts outright", function()
+        assert.are.same(
+            { "setup() expects a table of options (got string)" },
+            config.validate("stacked")
+        )
+    end)
+end)
+
+describe("config.closed", function()
+    -- a renamed or dropped option would leave a dangling path here; validate() on
+    -- the defaults can't see one, since it only walks keys that are actually set
+    it("names a real default for every closed set", function()
+        for path, allowed in pairs(config.closed) do
+            local section, key = path:match("^(.-)%.(.+)$")
+            local default = section and config.defaults[section][key] or config.defaults[path]
+            assert.is_not_nil(default, path .. " has no default")
+            local found = false
+            for _, ok in ipairs(allowed) do
+                found = found or default == ok
+            end
+            assert.is_true(found, path .. " default " .. tostring(default) .. " is outside its set")
+        end
+    end)
+end)


### PR DESCRIPTION
## Summary

- feat: `:checkhealth differ` reports the nvim floor and `termguicolors`, git, the options passed to `setup()`, the resolved sidecar binary and whether it handshakes, whether a github token is available, and anything the sidecar has logged — dead or alive
- feat: the client kept `stderr = function() end`, so everything the binary logged went nowhere, including the panic stack `dispatch.go:42` deliberately writes. it now keeps the last 200 lines per process and folds a byte-capped tail onto the errors a death produces. capped by bytes rather than lines because slog renders a multi-line value as one long quoted line, so a line count bounds the wrong thing
- feat: `hello` reports the auth tri-state (`ok`/`gh_missing`/`auth`) with the message telling you what to do. it was resolved at startup and only surfaced when a PR method was called, which is far too late to be a diagnostic. additive and `omitempty`, so no protocol bump: an older client ignores the fields, and a sidecar predating them reads as unknown rather than as "no token"
- feat: `DIFFER_LOG_LEVEL` sets the sidecar's log level, which was pinned at info with no `Debug` call anywhere. at `debug` it traces one line per request in `server.run` and one per github call in `github.send`, which is the single choke point for REST and graphql alike, so it carries every call's status, duration and remaining rate limit. documented in CONTRIBUTING as a debugging aid, not in the readme: it needs a rebuild-and-restart to change and has no reader beyond the health report
- fix: an option that did not name a real key, or carried a value outside a closed set, was accepted in silence across a ~70-key surface. `config.validate` walks the user's opts against the defaults at both levels plus the six closed sets and the keymap actions, and `setup()` reports the lot in one notification
- fix: an out-of-set value then merged verbatim, so nothing downstream agreed on it: `panel.position = "middle"` fell into `_open_window`'s `else` arm and opened the bottom split, while `panel/init.lua:318` read it as not-horizontal and rendered with the sidebar width logic. `resolve` now clamps a value outside its set back to its default, so warn-and-continue is honest. warn rather than refuse: differ's whole config surface is placement and keymaps, so proceeding is never dangerous, and a future key rename would otherwise brick every existing config on next launch
- fix: a sidecar dying before it answered `hello` never reached the restart path — the handshake callback fired first and replaced the exit error with the bare string `handshake failed`, discarding the stderr just attached to it. it now passes the reason through, as does the adjacent protocol-mismatch branch, which was dropping its own "rebuild your sidecar" instruction
- fix: `:checkhealth differ` aborted outright when the sidecar was broken. the client's error-level notification is delivered inside `vim.wait`, and an error notify raised inside `:checkhealth` takes the whole command down, so the one failure most worth reporting was the one that destroyed the report
- build: pandoc came from `PATH` with a version check while every other pinned tool is fetched into `.tools`, so a routine `brew upgrade` blocked `make vimdoc` until noticed. it is now fetched like the rest, and ci drops `setup-pandoc` and the pin duplicated into the workflow
- docs: a diagnostics section covering `:checkhealth differ` and what a config warning means; the sidecar's log level and its 200-line cap go to CONTRIBUTING

## Test plan

- [x] `make check`: unit 381/0, headless-nvim 458/0, luacheck 0, golangci-lint 0, lua_ls clean, demo-build ok, go ok under `-race`
- [x] the notify-escape guard and the closed-set drift guard each fail with their fix removed
- [x] `:checkhealth differ` in four states: healthy, bad config, a sidecar dying on startup, one logging a recovered panic and staying up
- [x] stderr tail against fake sidecars: panicking after `hello`, dying immediately, and 400 lines past both caps
- [x] the built binary under `DIFFER_LOG_LEVEL=debug`, unset, and `=loud`
- [x] `hello` with real `gh` auth and with `PATH=/nonexistent`: `auth: ok` and `gh_missing`
- [x] a planted token reaches neither the `send` log line nor `TokenStatus`
- [x] cold `.tools` pandoc fetch byte-identical; a broken `pandoc 99.99.99` on `PATH` ignored; linux tarball layout simulated
- [x] `make vimdoc` idempotent, no dangling helptag refs
