### PR TITLE
fix: leave nothing behind when a merge or diff session ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Closing the merge tool left its colouring, its conflict keymaps and its hooks on the worktree file you had been resolving, and opening that file again silently raised your `timeoutlen`. The file now comes back untouched
+- `:tabclose` on the merge tab, or closing its result window, left the session running against a window that no longer existed, so the next take-ours failed with `E5108`. Either now ends the session
+- Closing a diff left `g?` bound on the real file you had opened with `df`, along with autocommands that outlived the session
+- Without a call to `setup()`, the merge tool's panes all rendered in the same colour, and the PR overview, file panel and history panel rendered uncoloured. Any surface that needs the highlight groups now registers them
+
+## [0.1.32] — 2026-08-19
+
+### Fixed
+
 - A change git lists that has no lines to show (a `chmod +x`, an empty new file, a trailing-newline-only edit, a rename, a moved submodule pointer) put a row in the panel that did nothing when you opened it, and reported "no changes" again on every try. Those rows now open a diff naming the reason
 - `s` and `u` were advertised on files that stage as a unit, then stepped to another file instead of staging it. A binary file, the zero-hunk changes above, and a new file opened from a split's left column now all stage where the keys say they will
 - A mistyped revspec reported "no changes for this source" while git actually emitted `fatal: bad revision`. `:Differ` and both `:Differ log` forms now report based on what git said
 - The panel read every untracked file from disk on every build and refresh, and one containing a carriage return also left a loose object in `.git/objects` each time. Those counts are now read once and reused until the file's timestamp or size moves
 - `:Differ pr checkout` froze nvim for as long as a slow remote took, and hung for good on a credential prompt. The fetch is now bounded and prompts are off, and git failing to start at all reports a message rather than a Lua error
-- Closing the merge tool left its colouring, its conflict keymaps and its hooks on the worktree file you had been resolving, and opening that file again silently raised your `timeoutlen`. The file now comes back untouched
-- `:tabclose` on the merge tab, or closing its result window, left the session running against a window that no longer existed, so the next take-ours failed with `E5108`. Either now ends the session
-- Closing a diff left `g?` bound on the real file you had opened with `df`, along with autocommands that outlived the session
-- Without a call to `setup()`, the merge tool's panes all rendered in the same colour, and the PR overview, file panel and history panel rendered uncoloured. Any surface that needs the highlight groups now registers them
 
 ## [0.1.31] — 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A mistyped revspec reported "no changes for this source" while git actually emitted `fatal: bad revision`. `:Differ` and both `:Differ log` forms now report based on what git said
 - The panel read every untracked file from disk on every build and refresh, and one containing a carriage return also left a loose object in `.git/objects` each time. Those counts are now read once and reused until the file's timestamp or size moves
 - `:Differ pr checkout` froze nvim for as long as a slow remote took, and hung for good on a credential prompt. The fetch is now bounded and prompts are off, and git failing to start at all reports a message rather than a Lua error
+- Closing the merge tool left its colouring, its conflict keymaps and its hooks on the worktree file you had been resolving, and opening that file again silently raised your `timeoutlen`. The file now comes back untouched
+- `:tabclose` on the merge tab, or closing its result window, left the session running against a window that no longer existed, so the next take-ours failed with `E5108`. Either now ends the session
+- Closing a diff left `g?` bound on the real file you had opened with `df`, along with autocommands that outlived the session
+- Without a call to `setup()`, the merge tool's panes all rendered in the same colour, and the PR overview, file panel and history panel rendered uncoloured. Any surface that needs the highlight groups now registers them
 
 ## [0.1.31] — 2026-08-15
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PANDOC_VERSION    := 3.10.1
 PANDOC_DIR        := .tools/pandoc-$(PANDOC_VERSION)
 PANDOC_BIN        := $(PANDOC_DIR)/bin/pandoc
 
-GOLANGCI_VERSION := 2.12.2
+GOLANGCI_VERSION := 2.13.1
 GOLANGCI_DIR     := .tools/golangci-lint-$(GOLANGCI_VERSION)
 GOLANGCI_BIN     := $(GOLANGCI_DIR)/golangci-lint
 

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -9,6 +9,8 @@ local patch = require("differ.git.patch")
 local log = require("differ.git.log")
 local watch = require("differ.git.watch")
 local text_util = require("differ.util.text")
+local tab_util = require("differ.util.tab")
+local open_session_tab, close_session_tab = tab_util.open_session, tab_util.close_session
 
 local M = {}
 
@@ -115,33 +117,6 @@ end
 -- strip trailing whitespace from a git output line (e.g. rev-parse, show, log)
 local function chomp(s)
     return (s:gsub("%s+$", ""))
-end
-
--- run a session in its own tabpage (like diffview): the tab :Differ was invoked
--- from is never touched, so ending the session drops the tab and returns there with
--- the dashboard / file / window layout intact. `tab split` carries the current buffer
--- in, so it stays displayed in the invoking tab and isn't wiped when the diff takes
--- the session window. returns the tab to return to and the new session tab
----@return integer return_tab, integer session_tab
-local function open_session_tab()
-    local return_tab = vim.api.nvim_get_current_tabpage()
-    vim.cmd("tab split")
-    return return_tab, vim.api.nvim_get_current_tabpage()
-end
-
--- close a session's tabpage, never leaving zero tabs (mirrors diffview). a no-op when
--- it's already gone: closing the last session window can collapse the tab first
----@param tab integer|nil
-local function close_session_tab(tab)
-    if not (tab and vim.api.nvim_tabpage_is_valid(tab)) then
-        return
-    end
-    if #vim.api.nvim_list_tabpages() == 1 then
-        vim.cmd("tabnew")
-    end
-    pcall(function()
-        vim.cmd("tabclose " .. vim.api.nvim_tabpage_get_number(tab))
-    end)
 end
 
 -- repo root containing `path` (a file or directory), or nil if not in a repo

--- a/lua/differ/history/init.lua
+++ b/lua/differ/history/init.lua
@@ -845,6 +845,7 @@ end
 ---@param keep_focus boolean|nil  -- leave focus in the diff window (default true)
 ---@return differ.History
 function History:open(keep_focus)
+    require("differ.ui.highlights").ensure() -- the commit rows paint before any diff opens
     self.origin_win = vim.api.nvim_get_current_win()
     self:_open_window()
     current = self

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -18,6 +18,7 @@
 
 local set_local = require("differ.util.win").set_local
 local keymap = require("differ.util.keymap")
+local tab_util = require("differ.util.tab")
 local bind, unbind = keymap.bind, keymap.unbind
 
 local M = {}
@@ -732,14 +733,7 @@ function M.close()
             pcall(vim.api.nvim_buf_delete, buf, { force = true })
         end
     end
-    if vim.api.nvim_tabpage_is_valid(s.session_tab) then
-        if #vim.api.nvim_list_tabpages() == 1 then
-            vim.cmd("tabnew")
-        end
-        pcall(function()
-            vim.cmd("tabclose " .. vim.api.nvim_tabpage_get_number(s.session_tab))
-        end)
-    end
+    tab_util.close_session(s.session_tab)
     if vim.api.nvim_tabpage_is_valid(s.return_tab) then
         vim.api.nvim_set_current_tabpage(s.return_tab)
     end
@@ -809,9 +803,7 @@ function lay_out(root, relpath, model, layout)
     require("differ.ui.highlights").ensure()
     local result = require("differ.render.merge").render(model, { layout = layout })
 
-    local return_tab = vim.api.nvim_get_current_tabpage()
-    vim.cmd("tab split")
-    local session_tab = vim.api.nvim_get_current_tabpage()
+    local return_tab, session_tab = tab_util.open_session()
     vim.cmd("silent! only")
 
     -- result spans the bottom; inputs share the top row left-to-right

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -774,6 +774,9 @@ function lay_out(root, relpath, model, layout)
     if session then -- re-open over a live session
         M.close()
     end
+    -- the four slabs are told apart by colour alone, so the groups have to exist even
+    -- when the user never called setup()
+    require("differ.ui.highlights").ensure()
     local result = require("differ.render.merge").render(model, { layout = layout })
 
     local return_tab = vim.api.nvim_get_current_tabpage()

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -17,7 +17,8 @@
 -- regions are foldable, and a take-this briefly flashes the lines it produced
 
 local set_local = require("differ.util.win").set_local
-local bind = require("differ.util.keymap").bind
+local keymap = require("differ.util.keymap")
+local bind, unbind = keymap.bind, keymap.unbind
 
 local M = {}
 
@@ -74,6 +75,8 @@ local INPUT_HL = {
 ---@field saved_markdown_render boolean|nil -- the result buffer's prior render-markdown state, restored on close
 ---@field autoformat_warned boolean|nil   -- set once a save is seen to have reformatted the markers
 ---@field diag_aug integer|nil            -- the DiagnosticChanged hook that hushes the result
+---@field aug integer|nil                 -- the session augroup on the result buffer
+---@field bound_keys (string|string[]|false)[] -- the lhs specs bound on the result buffer
 
 ---@type differ.MergeSession|nil
 local session = nil
@@ -146,6 +149,22 @@ end
 -- the active session, or nil. exposed so :Differ close can route to it
 ---@return differ.MergeSession|nil
 function M.current()
+    return session
+end
+
+-- the session to act on, or nil once its result window has gone. every verb reads the
+-- cursor from that window, so a session that outlived it can't do anything but raise
+-- E5108 from inside a keymap: tear it down instead. the WinClosed/TabClosed hooks
+-- normally get there first; this is the net for a teardown they can't see
+---@return differ.MergeSession|nil
+local function live_session()
+    if not session then
+        return nil
+    end
+    if not vim.api.nvim_win_is_valid(session.result_win) then
+        M.close()
+        return nil
+    end
     return session
 end
 
@@ -480,7 +499,7 @@ end
 -- the emphasis, and scroll the input panes to the same conflict
 ---@param dir "next"|"prev"
 local function goto_conflict(dir)
-    if not (session and vim.api.nvim_win_is_valid(session.result_win)) then
+    if not live_session() then
         return
     end
     local cur = vim.api.nvim_win_get_cursor(session.result_win)[1]
@@ -528,7 +547,7 @@ end
 -- repaint, flash the produced lines, and advance to the next remaining conflict
 ---@param choice "ours"|"theirs"|"both"|"base"|"none"
 local function resolve_choice(choice)
-    if not session then
+    if not live_session() then
         return
     end
     local regions = live_regions()
@@ -687,15 +706,26 @@ function M.close()
     local s = session
     session = nil
     restore_timeout() -- net in case the tab teardown didn't fire BufLeave on the result buf
+    -- the result buffer is the user's real file and outlives the session, so it has to be
+    -- handed back clean: no session paint, no session keymaps, no session hooks
     if vim.api.nvim_buf_is_valid(s.result_buf) then
         vim.b[s.result_buf].disable_autoformat = s.saved_autoformat -- give autoformat back
         if s.saved_markdown_render then
             set_markdown_render(s.result_buf, true) -- re-render markdown if it was on
         end
+        for _, ns in ipairs({ merge_ns, flash_ns, anchor_ns }) do
+            vim.api.nvim_buf_clear_namespace(s.result_buf, ns, 0, -1)
+        end
+        for _, spec in ipairs(s.bound_keys) do
+            unbind(s.result_buf, spec)
+        end
     end
     -- drop the diagnostics hook; the producers re-lint the now-resolved file on their own
     if s.diag_aug then
         pcall(vim.api.nvim_del_augroup_by_id, s.diag_aug)
+    end
+    if s.aug then
+        pcall(vim.api.nvim_del_augroup_by_id, s.aug)
     end
     for _, buf in ipairs(s.bufs) do
         if vim.api.nvim_buf_is_valid(buf) then
@@ -839,6 +869,7 @@ function lay_out(root, relpath, model, layout)
     local cfg = require("differ").get_config()
     local km = (cfg.keymaps.merge or require("differ.config").defaults.keymaps) --[[@as differ.KeymapSet]]
 
+    local bound = {} -- the specs actually bound below, so close drops exactly these
     local first = model.regions[1]
     session = {
         root = root,
@@ -864,6 +895,7 @@ function lay_out(root, relpath, model, layout)
         return_tab = return_tab,
         session_tab = session_tab,
         keymaps = km, -- for the g? cheatsheet
+        bound_keys = bound,
         diag_aug = suppress_diagnostics(result_buf), -- the markers aren't valid source
         saved_markdown_render = quiet_markdown_render(result_buf), -- don't conceal the markers
     }
@@ -898,6 +930,7 @@ function lay_out(root, relpath, model, layout)
     vim.b[result_buf].disable_autoformat = true
     local function rb(action, fn, desc)
         bind(result_buf, km[action], fn, desc)
+        bound[#bound + 1] = km[action]
     end
     rb("next_conflict", function()
         goto_conflict("next")
@@ -925,6 +958,7 @@ function lay_out(root, relpath, model, layout)
     -- left to native macro recording. `:Differ close` ends the session
 
     local aug = vim.api.nvim_create_augroup("differ.merge." .. result_buf, { clear = true })
+    session.aug = aug
     -- :w writes the real file; once no markers remain it auto-stages (git add = resolve),
     -- otherwise it just reports what's left. repaint so a hand-edit's regions stay current
     vim.api.nvim_create_autocmd("BufWritePost", {
@@ -978,12 +1012,46 @@ function lay_out(root, relpath, model, layout)
     vim.api.nvim_create_autocmd("BufEnter", {
         buffer = result_buf,
         group = aug,
-        callback = bump_timeout,
+        callback = function()
+            if session then -- never touch the global option outside a live session
+                bump_timeout()
+            end
+        end,
     })
     vim.api.nvim_create_autocmd("BufLeave", {
         buffer = result_buf,
         group = aug,
         callback = restore_timeout,
+    })
+    -- the session dies with its window: :tabclose on the merge tab, or a :q on the result
+    -- window, would otherwise leave a live session aimed at a dead window. deferred because
+    -- the tab is still collapsing when the event fires, and close moves tabs itself; tied to
+    -- this exact session so a close (or a new session) before the tick cancels it
+    local function teardown()
+        local this = session
+        if not this then
+            return
+        end
+        vim.schedule(function()
+            if session == this then
+                M.close()
+            end
+        end)
+    end
+    vim.api.nvim_create_autocmd("WinClosed", {
+        pattern = tostring(result_win),
+        group = aug,
+        callback = teardown,
+    })
+    -- TabClosed reports shifting tab numbers, not handles, so the callback checks the
+    -- session tab's validity rather than trying to match the one that closed
+    vim.api.nvim_create_autocmd("TabClosed", {
+        group = aug,
+        callback = function()
+            if not vim.api.nvim_tabpage_is_valid(session_tab) then
+                teardown()
+            end
+        end,
     })
     -- a hand-edit shifts the marker lines: re-parse + repaint so the regions, colour, and
     -- nav stay aligned to the live buffer (not just on splice/:w). InsertLeave covers a run

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -1412,6 +1412,7 @@ end
 -- open the panel in its position and focus it
 ---@return differ.Panel
 function Panel:open()
+    require("differ.ui.highlights").ensure()
     self.origin_win = vim.api.nvim_get_current_win()
     self:_open_window()
     self:render()

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -9,6 +9,8 @@ local repo = require("differ.pr.repo")
 local client = require("differ.pr.client")
 local guard = require("differ.pr.guard")
 local viewed = require("differ.pr.viewed")
+local tab_util = require("differ.util.tab")
+local open_session_tab, close_session_tab = tab_util.open_session, tab_util.close_session
 
 local M = {}
 
@@ -66,26 +68,6 @@ local function local_root(coords)
         return root
     end
     return nil
-end
-
--- run a session in its own tabpage (like git/init.lua): the invoking tab is never
--- touched, so ending the session drops the tab and returns there
----@return integer return_tab, integer session_tab
-local function open_session_tab()
-    local return_tab = vim.api.nvim_get_current_tabpage()
-    vim.cmd("tab split")
-    return return_tab, vim.api.nvim_get_current_tabpage()
-end
-
----@param tab integer|nil
-local function close_session_tab(tab)
-    if not (tab and vim.api.nvim_tabpage_is_valid(tab)) then
-        return
-    end
-    if #vim.api.nvim_list_tabpages() == 1 then
-        vim.cmd("tabnew")
-    end
-    pcall(vim.cmd, "tabclose " .. vim.api.nvim_tabpage_get_number(tab))
 end
 
 -- github's file-status words -> the single-letter codes the panel keys highlights on

--- a/lua/differ/pr/overview.lua
+++ b/lua/differ/pr/overview.lua
@@ -374,6 +374,7 @@ function M.open(session)
     if not session then
         return require("differ.pr").notify("open a PR first")
     end
+    require("differ.ui.highlights").ensure() -- the page is reachable without any diff view
     -- claim the page: a later open supersedes this one, and so does entering the files
     page_gen = page_gen + 1
     local gen = page_gen

--- a/lua/differ/ui/highlights.lua
+++ b/lua/differ/ui/highlights.lua
@@ -300,4 +300,13 @@ function M.setup()
     end
 end
 
+-- register the groups unless something already has. every ui surface calls this on
+-- open, so a user who never called setup() still gets the palette rather than four
+-- identically-rendered merge slabs; setup() itself stays a re-apply
+function M.ensure()
+    if not registered then
+        M.setup()
+    end
+end
+
 return M

--- a/lua/differ/util/keymap.lua
+++ b/lua/differ/util/keymap.lua
@@ -22,4 +22,20 @@ function M.bind(bufnr, spec, fn, desc, mode)
     end
 end
 
+-- drop every lhs in `spec` from `bufnr`, the inverse of bind. for the buffers we don't
+-- own (the merge result is the user's real file), where teardown can't just delete the
+-- buffer. an lhs that isn't mapped is not an error
+---@param bufnr integer
+---@param spec string|string[]|false|nil
+---@param mode? string|string[]
+function M.unbind(bufnr, spec, mode)
+    if not spec or not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+    end
+    local list = type(spec) == "table" and spec or { spec }
+    for _, lhs in ipairs(list) do
+        pcall(vim.keymap.del, mode or "n", lhs, { buffer = bufnr })
+    end
+end
+
 return M

--- a/lua/differ/util/tab.lua
+++ b/lua/differ/util/tab.lua
@@ -1,0 +1,31 @@
+-- session tabpage open/close, shared by every surface that runs in its own tab
+-- (local git, pr, merge)
+
+local M = {}
+
+-- run a session in its own tabpage (like diffview): the tab :Differ was invoked
+-- from is never touched, so ending the session drops the tab and returns there with
+-- the dashboard / file / window layout intact. `tab split` carries the current buffer
+-- in, so it stays displayed in the invoking tab and isn't wiped when the diff takes
+-- the session window. returns the tab to return to and the new session tab
+---@return integer return_tab, integer session_tab
+function M.open_session()
+    local return_tab = vim.api.nvim_get_current_tabpage()
+    vim.cmd("tab split")
+    return return_tab, vim.api.nvim_get_current_tabpage()
+end
+
+-- close a session's tabpage, never leaving zero tabs (mirrors diffview). a no-op when
+-- it's already gone: closing the last session window can collapse the tab first
+---@param tab integer|nil
+function M.close_session(tab)
+    if not (tab and vim.api.nvim_tabpage_is_valid(tab)) then
+        return
+    end
+    if #vim.api.nvim_list_tabpages() == 1 then
+        vim.cmd("tabnew")
+    end
+    pcall(vim.cmd, "tabclose " .. vim.api.nvim_tabpage_get_number(tab))
+end
+
+return M

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -9,7 +9,8 @@ local paint = require("differ.ui.paint")
 local syntax = require("differ.syntax")
 local statuscolumn = require("differ.ui.statuscolumn")
 local nav = require("differ.nav")
-local bind = require("differ.util.keymap").bind
+local keymap = require("differ.util.keymap")
+local bind, unbind = keymap.bind, keymap.unbind
 local find_buf = require("differ.util.buf").find
 
 local ns = vim.api.nvim_create_namespace("differ")
@@ -111,6 +112,9 @@ local armed_view = nil
 ---@field _suppress_close boolean  -- true while we close a diff window ourselves (relayout/teardown)
 ---@field _closing boolean  -- re-entrancy guard once a user close has begun
 ---@field _close_group integer|nil  -- augroup id for the WinClosed close guard
+---@field _zoom_group integer|nil  -- augroup id for the zoom-tab return hook
+---@field _edit_group integer|nil  -- augroup id for the edit window's WinClosed sync
+---@field _edit_map { buf: integer, spec: string|string[]|false }|nil  -- g? bound on a real file buffer
 local View = {}
 View.__index = View
 
@@ -1553,6 +1557,7 @@ end
 function View:_arm_zoom_return(zoom_tab, return_tab)
     -- key on self.id so a second view's zoom doesn't clobber this one's guard
     local group = vim.api.nvim_create_augroup("differ.view.zoom." .. self.id, { clear = true })
+    self._zoom_group = group -- a session that ends with the zoom tab still open drops it
     vim.api.nvim_create_autocmd("TabClosed", {
         group = group,
         callback = function()
@@ -1560,6 +1565,7 @@ function View:_arm_zoom_return(zoom_tab, return_tab)
                 return -- some other tab closed
             end
             pcall(vim.api.nvim_del_augroup_by_id, group)
+            self._zoom_group = nil
             vim.schedule(function()
                 if vim.api.nvim_tabpage_is_valid(return_tab) then
                     vim.api.nvim_set_current_tabpage(return_tab)
@@ -1610,8 +1616,13 @@ function View:_open_edit_window(abs, target, tcol, anchor_win)
         vim.cmd("rightbelow split")
         local win = vim.api.nvim_get_current_win()
         self.edit_win = win
+        -- grouped, not a bare `once`: a window the user never closes would otherwise
+        -- leave an autocmd nothing can reach to remove
+        self._edit_group =
+            vim.api.nvim_create_augroup("differ.view.edit." .. self.id, { clear = true })
         vim.api.nvim_create_autocmd("WinClosed", {
             pattern = tostring(win),
+            group = self._edit_group,
             once = true,
             callback = function()
                 if self.edit_win == win then
@@ -1625,16 +1636,31 @@ function View:_open_edit_window(abs, target, tcol, anchor_win)
         place_cursor(target, tcol)
     end
     -- bind g? on the real-file buffer too, so the cheatsheet is reachable from the
-    -- edit window (shadows native g?/rot13, inert in this review flow)
-    bind(vim.api.nvim_get_current_buf(), self.keymaps.help, function()
+    -- edit window (shadows native g?/rot13, inert in this review flow). recorded
+    -- because that buffer is the user's: teardown has to take the map off by hand
+    self:_drop_edit_map() -- a reused edit window may hold an earlier file's map
+    local buf = vim.api.nvim_get_current_buf()
+    bind(buf, self.keymaps.help, function()
         self:show_help()
     end, "differ: keymap help")
+    self._edit_map = { buf = buf, spec = self.keymaps.help }
+end
+
+-- take our g? back off the real file buffer. it isn't ours to delete, so nothing
+-- reclaims the mapping for us
+function View:_drop_edit_map()
+    if not self._edit_map then
+        return
+    end
+    unbind(self._edit_map.buf, self._edit_map.spec)
+    self._edit_map = nil
 end
 
 -- drop the edit window without losing work: a window holding unsaved edits is left
 -- open (it's a normal file window, harmless to keep), otherwise it's closed. either
 -- way `edit_win` is cleared. called on a file switch (stale window) and on teardown
 function View:_release_edit_window()
+    self:_drop_edit_map()
     local win = self.edit_win
     self.edit_win = nil
     if not (win and vim.api.nvim_win_is_valid(win)) then
@@ -1774,6 +1800,9 @@ function View:_discard(col, keep_win)
     end
     by_buf[col.bufnr] = nil
     statuscolumn.clear(col.bufnr)
+    -- the buffer delete below takes the cursor-line autocmds with it, but not the group
+    -- they sat in; drop that too so a long session doesn't accrue one per diff buffer
+    pcall(vim.api.nvim_del_augroup_by_name, "differ.cursorline." .. col.bufnr)
     -- only close a window we still own: if the user swapped another buffer into it
     -- (a picker / :edit), it's theirs now, so leave it (and the navigation) alone
     if
@@ -1814,9 +1843,11 @@ function View:close(keep_win)
     if armed_view == self then
         armed_view = nil
     end
-    if self._close_group then
-        pcall(vim.api.nvim_del_augroup_by_id, self._close_group)
-        self._close_group = nil
+    for _, field in ipairs({ "_close_group", "_zoom_group", "_edit_group" }) do
+        if self[field] then
+            pcall(vim.api.nvim_del_augroup_by_id, self[field])
+            self[field] = nil
+        end
     end
     self:_release_edit_window() -- drop any edit-in-review window (keeps it if unsaved)
     for _, col in ipairs(self.columns) do

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -1069,3 +1069,161 @@ describe(":Differ mergetool take-base on CRLF", function()
         end
     end)
 end)
+
+-- an open/close cycle has to leave nothing behind. the result column is the user's real
+-- worktree file, so its extmarks, keymaps and hooks are differ's to take off by hand;
+-- and the session has to end when its window does, rather than outliving it
+describe(":Differ mergetool teardown", function()
+    local NAMESPACES = { "differ.merge", "differ.merge.flash", "differ.merge.anchor" }
+    local saved_timeoutlen
+
+    -- nvim_get_autocmds errors on an unknown group and returns {} for an empty one,
+    -- so a pcall is the existence check
+    local function group_exists(name)
+        return (pcall(vim.api.nvim_get_autocmds, { group = name }))
+    end
+
+    -- the scratch buffers differ owns, by their differ:// naming
+    local function differ_bufs()
+        local out = {}
+        for _, b in ipairs(vim.api.nvim_list_bufs()) do
+            local name = vim.api.nvim_buf_get_name(b)
+            if vim.api.nvim_buf_is_valid(b) and name:find("differ://", 1, true) then
+                out[#out + 1] = name:gsub(".*differ://", "differ://")
+            end
+        end
+        table.sort(out)
+        return out
+    end
+
+    -- differ.highlights is deliberately process-lifetime (one ColorScheme hook, registered
+    -- on first use), so it isn't part of what a session has to give back
+    local function differ_autocmds()
+        local n = 0
+        for _, ac in ipairs(vim.api.nvim_get_autocmds({})) do
+            local g = ac.group_name
+            if g and g:find("^differ%.") and g ~= "differ.highlights" then
+                n = n + 1
+            end
+        end
+        return n
+    end
+
+    local function extmark_count(buf)
+        local n = 0
+        for _, name in ipairs(NAMESPACES) do
+            local ns = vim.api.nvim_create_namespace(name)
+            n = n + #vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+        end
+        return n
+    end
+
+    local function differ_maps(buf)
+        local out = {}
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+            if (m.desc or ""):find("differ", 1, true) then
+                out[#out + 1] = m.lhs
+            end
+        end
+        return out
+    end
+
+    before_each(function()
+        merge.close() -- a session an earlier case left open
+        saved_timeoutlen = vim.o.timeoutlen
+    end)
+
+    after_each(function()
+        merge.close()
+        vim.o.timeoutlen = saved_timeoutlen
+    end)
+
+    it("hands the real file back with no extmarks, keymaps or hooks", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        local bufs, autocmds = differ_bufs(), differ_autocmds()
+
+        merge.open({})
+        local s = assert(merge.current())
+        local buf = s.result_buf
+        assert.is_true(#differ_bufs() > #bufs) -- the ours/theirs scratch panes
+        assert.is_true(extmark_count(buf) > 0) -- the conflict paint
+        assert.is_true(#differ_maps(buf) > 0) -- the conflict chords
+        assert.is_true(group_exists("differ.merge." .. buf))
+
+        merge.close()
+        assert.are.same(bufs, differ_bufs())
+        assert.are.equal(autocmds, differ_autocmds())
+        assert.are.equal(0, extmark_count(buf))
+        assert.are.same({}, differ_maps(buf))
+        assert.is_false(group_exists("differ.merge." .. buf))
+        assert.is_false(group_exists("differ.merge.diag." .. buf))
+    end)
+
+    it("gives the user's timeoutlen back, and never bumps it again", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        vim.o.timeoutlen = 200 -- a which-key-style short timeout
+        merge.open({})
+        local buf = assert(merge.current()).result_buf
+        vim.api.nvim_exec_autocmds("BufEnter", { buffer = buf }) -- focus the result pane
+        assert.are.equal(1000, vim.o.timeoutlen) -- widened for the multi-key chords
+
+        merge.close()
+        assert.are.equal(200, vim.o.timeoutlen)
+        -- re-entering the file later is not a merge session
+        vim.cmd.edit(root .. "/f.txt")
+        vim.api.nvim_exec_autocmds("BufEnter", { buffer = vim.api.nvim_get_current_buf() })
+        assert.are.equal(200, vim.o.timeoutlen)
+    end)
+
+    it("ends the session when its tab closes, rather than stranding it", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        local bufs, autocmds = differ_bufs(), differ_autocmds()
+        merge.open({})
+        local buf = assert(merge.current()).result_buf
+
+        vim.cmd("tabclose")
+        vim.wait(200, function()
+            return merge.current() == nil
+        end)
+        assert.is_nil(merge.current()) -- not a live session aimed at a dead window
+        assert.are.same(bufs, differ_bufs())
+        assert.are.equal(autocmds, differ_autocmds())
+        assert.are.same({}, differ_maps(buf))
+    end)
+
+    it("ends the session when the result window closes", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local tabs = #vim.api.nvim_list_tabpages()
+        vim.api.nvim_set_current_win(assert(merge.current()).result_win)
+
+        vim.cmd("close")
+        vim.wait(200, function()
+            return merge.current() == nil
+        end)
+        assert.is_nil(merge.current())
+        assert.are.equal(tabs - 1, #vim.api.nvim_list_tabpages()) -- the session tab went too
+    end)
+
+    it("does not raise from a conflict verb once the window is gone", function()
+        local root = conflict_repo()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = assert(merge.current())
+        local take_ours
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(s.result_buf, "n")) do
+            if (m.desc or "") == "differ: take ours" then
+                take_ours = m.callback
+            end
+        end
+        assert.is_truthy(take_ours)
+        -- close the window out from under the session without letting the hooks run
+        vim.api.nvim_win_close(s.result_win, true)
+        assert.is_true(pcall(take_ours)) -- used to raise E5108 on the dead window
+        assert.is_nil(merge.current()) -- and takes the session down with it
+    end)
+end)

--- a/test/nvim/view_spec.lua
+++ b/test/nvim/view_spec.lua
@@ -26,6 +26,25 @@ local function extmarks(bufnr)
     return line_hl, word
 end
 
+local function write(dir, name, text)
+    vim.fn.mkdir(dir, "p")
+    local fd = assert(io.open(dir .. "/" .. name, "w"))
+    fd:write(text)
+    fd:close()
+end
+
+-- a file-backed model, so the edit verbs have a real file to open
+local function worktree_model(dir, path, old, new)
+    return diff.build({
+        path = path,
+        old_rev = "HEAD",
+        new_rev = "WORKTREE",
+        old_text = old,
+        new_text = new,
+        root = dir,
+    })
+end
+
 describe("view stacked", function()
     it("opens one window with rendered lines and line-level highlights", function()
         local v = View.new(model("a\nb\nc\n", "a\nB\nc\n"), {
@@ -844,24 +863,6 @@ describe("view jump-to-file", function()
 end)
 
 describe("view edit-in-review", function()
-    local function write(dir, name, text)
-        vim.fn.mkdir(dir, "p")
-        local fd = assert(io.open(dir .. "/" .. name, "w"))
-        fd:write(text)
-        fd:close()
-    end
-
-    local function worktree_model(dir, path, old, new)
-        return diff.build({
-            path = path,
-            old_rev = "HEAD",
-            new_rev = "WORKTREE",
-            old_text = old,
-            new_text = new,
-            root = dir,
-        })
-    end
-
     it("opens the real file in a kept-alive window at the mapped line", function()
         vim.cmd("silent! only")
         local dir = vim.fn.tempname()
@@ -1258,5 +1259,133 @@ describe("command router", function()
                 return v
             end)()
         )
+    end)
+end)
+
+-- a view's windows and buffers are its own, but the hooks and maps it hangs off them
+-- aren't all reclaimed by a buffer delete: the cursor-line group outlives the buffer it
+-- was keyed to, the zoom hook is global, and g? lands on the user's real file
+describe("view teardown", function()
+    -- nvim_get_autocmds errors on an unknown group and returns {} for an empty one,
+    -- so a pcall is the existence check
+    local function group_exists(name)
+        return (pcall(vim.api.nvim_get_autocmds, { group = name }))
+    end
+
+    local function differ_bufs()
+        local out = {}
+        for _, b in ipairs(vim.api.nvim_list_bufs()) do
+            local name = vim.api.nvim_buf_get_name(b)
+            if vim.api.nvim_buf_is_valid(b) and name:find("differ://", 1, true) then
+                out[#out + 1] = name:gsub(".*differ://", "differ://")
+            end
+        end
+        table.sort(out)
+        return out
+    end
+
+    -- differ.highlights is deliberately process-lifetime (one ColorScheme hook, registered
+    -- on first use), so it isn't part of what a session has to give back
+    local function differ_autocmds()
+        local n = 0
+        for _, ac in ipairs(vim.api.nvim_get_autocmds({})) do
+            local g = ac.group_name
+            if g and g:find("^differ%.") and g ~= "differ.highlights" then
+                n = n + 1
+            end
+        end
+        return n
+    end
+
+    local function differ_maps(buf)
+        local out = {}
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+            if (m.desc or ""):find("differ", 1, true) then
+                out[#out + 1] = m.lhs
+            end
+        end
+        return out
+    end
+
+    local function open_view(dir)
+        write(dir, "f.txt", "a\nB\nc\n")
+        local v = View.new(worktree_model(dir, "f.txt", "a\nb\nc\n", "a\nB\nc\n"), {
+            layout = "split",
+            context = math.huge,
+            deep_diff = { enabled = true },
+        })
+        return v:open()
+    end
+
+    it("leaves no buffers, hooks or maps behind after an open/close cycle", function()
+        vim.cmd("silent! only")
+        local bufs, autocmds = differ_bufs(), differ_autocmds()
+        local v = open_view(vim.fn.tempname())
+        local column_bufs = {}
+        for _, col in ipairs(v.columns) do
+            column_bufs[#column_bufs + 1] = col.bufnr
+        end
+        v:edit_file() -- the real file beside the diff: binds g? on a buffer we don't own
+        local real = vim.api.nvim_get_current_buf()
+
+        assert.is_true(#differ_bufs() > #bufs)
+        assert.is_true(group_exists("differ.cursorline." .. column_bufs[1]))
+        assert.are.same({ "g?" }, differ_maps(real))
+
+        v:close()
+        assert.are.same(bufs, differ_bufs())
+        assert.are.equal(autocmds, differ_autocmds())
+        assert.are.same({}, differ_maps(real)) -- the real file is the user's again
+        for _, bufnr in ipairs(column_bufs) do
+            assert.is_false(group_exists("differ.cursorline." .. bufnr))
+        end
+        assert.is_false(group_exists("differ.viewclose." .. v.id))
+        assert.is_false(group_exists("differ.view.edit." .. v.id))
+    end)
+
+    it("drops the zoom-return hook when the session ends before the zoom tab", function()
+        vim.cmd("silent! only")
+        local v = open_view(vim.fn.tempname())
+        v:edit_tab() -- the real file full-screen in its own tab, arming the return hook
+        local zoom_tab = v.zoom_tab
+        assert.is_true(group_exists("differ.view.zoom." .. v.id))
+
+        v:close() -- the session ends first; the zoom tab is the user's, so it stays
+        assert.is_false(group_exists("differ.view.zoom." .. v.id))
+        assert.is_true(vim.api.nvim_tabpage_is_valid(zoom_tab))
+        vim.api.nvim_set_current_tabpage(zoom_tab)
+        if #vim.api.nvim_list_tabpages() > 1 then
+            vim.cmd("tabclose") -- closing the view can have collapsed the invoking tab
+        end
+    end)
+
+    it("keeps one edit-window hook across repeated edit-in-review, not one per file", function()
+        vim.cmd("silent! only")
+        local dir = vim.fn.tempname()
+        local v = open_view(dir)
+        local function win_closed_hooks()
+            local grouped, ungrouped = 0, 0
+            for _, ac in ipairs(vim.api.nvim_get_autocmds({ event = "WinClosed" })) do
+                if ac.group then
+                    grouped = grouped + 1
+                else
+                    ungrouped = ungrouped + 1
+                end
+            end
+            return grouped, ungrouped
+        end
+        local before_grouped, before_ungrouped = win_closed_hooks()
+        for i = 1, 3 do
+            v:edit_file()
+            -- an unsaved edit window is kept at release, so nothing closes it for us and
+            -- its hook would sit there for the rest of the nvim session
+            vim.api.nvim_buf_set_lines(0, 0, 0, false, { "unsaved " .. i })
+            v:_release_edit_window()
+        end
+        local grouped, ungrouped = win_closed_hooks()
+        assert.are.equal(before_ungrouped, ungrouped) -- nothing ungrouped to accrue
+        assert.are.equal(before_grouped + 1, grouped) -- one hook, for the newest window
+        v:close()
+        assert.is_false(group_exists("differ.view.edit." .. v.id))
     end)
 end)


### PR DESCRIPTION
## Summary
- clear the merge session's namespaces, keymaps and augroup from the result buffer on close; it is the user's real worktree file, so nothing there is reclaimed by a buffer delete, and the unguarded `BufEnter` also raised global `timeoutlen` every time that file was opened again
- end the merge session on `TabClosed`/`WinClosed`, and guard the conflict verbs on a live result window: `:tabclose` on the merge tab used to leave the session running and the next take-ours raised `E5108`
- drop what `View:close` missed: the `differ.cursorline.<bufnr>` group, the zoom `TabClosed` hook (it only self-deleted when it fired), the edit window's ungrouped `WinClosed`, and the `g?` bound on the user's real file
- register the highlight groups from any surface that paints them, not just `setup()` and `diff_model()`: a `setup()`-less user got four identically coloured merge slabs, and an uncoloured pr overview, file panel and history panel
- share `open_session_tab`/`close_session_tab` in `util/tab.lua`; git, pr and merge each carried their own copy
- headless open/close cycle specs for both surfaces (8 cases), asserting no leaked buffers, autocmds, extmarks or keymaps
- bump golangci-lint to 2.13.1; 2.12.2 was built with go1.26 and panics against a go1.27 toolchain

## Test plan
- [x] lua unit 387/0, headless-nvim 488/0 (8 new)
- [x] every new case fails against the pre-fix tree and passes here
- [x] `make lua-typecheck`, `go vet`, `go test`, demo build, stylua, luacheck clean