### PR TITLE
fix: keep pull request data fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- A comment someone else posted whilst a pull request was open would never appear. The thread list was only refreshed when you commented yourself; it is now re-read as you move between files
+- The overview's `checks:` line kept reporting whatever CI was doing when you first opened the page, so it still read `pending` after a green build and disagreed with `:Differ pr checks`. It is now read fresh on every open
+- A long review kept every file version it had read for the life of the session, with `:Differ cache clear` the only way to release them. That cache is now capped at 64MB, and drops what you read longest ago
+- With GitHub unreachable, every `]f` asked for the thread list again and repeated the same error. A failed read now waits before retrying, and reports once rather than per file
+- Replying to a thread was rejected whenever anyone had pushed since you opened the pull request, discarding the reply and reloading the diff. A reply is anchored to the thread rather than to a line, so it no longer takes that check
+
+## [0.1.33] — 2026-08-22
+
+### Fixed
+
 - Closing the merge tool left its colouring, its conflict keymaps and its hooks on the worktree file you had been resolving, and opening that file again silently raised your `timeoutlen`. The file now comes back untouched
 - `:tabclose` on the merge tab, or closing its result window, left the session running against a window that no longer existed, so the next take-ours failed with `E5108`. Either now ends the session
 - Closing a diff left `g?` bound on the real file you had opened with `df`, along with autocommands that outlived the session

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -18,8 +18,7 @@ func (c *Client) TokenStatus() (status, message string) {
 	if c.tokenErr == nil {
 		return "ok", ""
 	}
-	var perr *protocol.Error
-	if errors.As(c.tokenErr, &perr) {
+	if perr, ok := errors.AsType[*protocol.Error](c.tokenErr); ok {
 		return perr.Code, perr.Message
 	}
 	return protocol.CodeInternal, c.tokenErr.Error()

--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -1,35 +1,24 @@
 package github
 
-import (
-	"strconv"
-	"sync"
-)
+import "sync"
 
-// cache is the sidecar's in-process memo. blobs are keyed by commit sha and
-// live forever (a path's bytes at a sha are immutable, and prRefs always resolves a
-// fresh sha so a moved head simply misses); threads are keyed per PR and flushed
-// wholesale by the review mutations. one mutex guards all of it, since the server
-// fans requests across goroutines.
+// cache is the sidecar's in-process memo, and it holds blobs only. a path's bytes at a
+// sha are immutable, so an entry never goes stale (prRefs always resolves a fresh sha,
+// so a moved head simply misses). threads are deliberately not cached here: the client
+// memoises them per session behind its own freshness clock, and a second copy down here
+// would only add a window where a colleague's comment is already fetched but not yet
+// visible. one mutex guards the map, since the server fans requests across goroutines.
 type cache struct {
-	mu      sync.Mutex
-	blobs   map[string]FileBlob
-	threads map[string][]Thread
-	// bumped on every thread invalidation. a paginating walk captures it up front and
-	// hands it back, so a snapshot assembled before a mutation can't re-seed the cache
-	// after it.
-	threadGen uint64
+	mu    sync.Mutex
+	blobs map[string]FileBlob
 }
 
 func newCache() *cache {
-	return &cache{blobs: map[string]FileBlob{}, threads: map[string][]Thread{}}
+	return &cache{blobs: map[string]FileBlob{}}
 }
 
 func blobKey(owner, repo, ref, path string) string {
 	return owner + "/" + repo + "/" + ref + "/" + path
-}
-
-func threadKey(owner, repo string, number int) string {
-	return owner + "/" + repo + "/" + strconv.Itoa(number)
 }
 
 func (c *cache) blob(key string) (FileBlob, bool) {
@@ -45,45 +34,8 @@ func (c *cache) putBlob(key string, b FileBlob) {
 	c.blobs[key] = b
 }
 
-func (c *cache) thread(key string) ([]Thread, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	t, ok := c.threads[key]
-	return t, ok
-}
-
-// threadGeneration is captured before a thread walk starts and passed to putThreads.
-func (c *cache) threadGeneration() uint64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.threadGen
-}
-
-// putThreads stores a walk's result unless the cache was invalidated while it ran, in
-// which case the snapshot predates the mutation and is dropped rather than cached.
-func (c *cache) putThreads(key string, t []Thread, gen uint64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if gen != c.threadGen {
-		return
-	}
-	c.threads[key] = t
-}
-
-// invalidateThreads flushes every PR's thread cache. the review mutations carry only
-// a thread or review node id, not the PR coords, so the whole map is cleared rather
-// than one key; the cache is small and these mutations are infrequent.
-func (c *cache) invalidateThreads() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	clear(c.threads)
-	c.threadGen++
-}
-
 func (c *cache) clearAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	clear(c.blobs)
-	clear(c.threads)
-	c.threadGen++
 }

--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -1,41 +1,91 @@
 package github
 
-import "sync"
+import (
+	"container/list"
+	"sync"
+)
 
-// cache is the sidecar's in-process memo, and it holds blobs only. a path's bytes at a
-// sha are immutable, so an entry never goes stale (prRefs always resolves a fresh sha,
-// so a moved head simply misses). threads are deliberately not cached here: the client
-// memoises them per session behind its own freshness clock, and a second copy down here
-// would only add a window where a colleague's comment is already fetched but not yet
-// visible. one mutex guards the map, since the server fans requests across goroutines.
+// maxBlobBytes caps the blob cache's total content. twice maxResponse, so the cap
+// always fits at least one entry however large.
+const maxBlobBytes = 64 * 1024 * 1024
+
+// cache is the sidecar's blob memo. a path's bytes at a sha are immutable, so entries
+// never go stale, only accumulate: hence the byte cap and LRU eviction. threads are not
+// cached here, the client owns their freshness. one mutex, since the server fans
+// requests across goroutines.
 type cache struct {
 	mu    sync.Mutex
-	blobs map[string]FileBlob
+	blobs map[string]*list.Element
+	lru   *list.List // *blobEntry, most-recently-used at the front; eviction pops the back
+	bytes int
+	limit int // maxBlobBytes; smaller in the eviction tests
+}
+
+// blobEntry is one cached blob and its charge against the cap; key lets eviction drop
+// the map entry from the list node alone.
+type blobEntry struct {
+	key  string
+	blob FileBlob
+	size int
+}
+
+// blobSize charges the key too, so empty blobs (a path missing at a sha) still count.
+func blobSize(key string, b FileBlob) int {
+	return len(key) + len(b.Content)
 }
 
 func newCache() *cache {
-	return &cache{blobs: map[string]FileBlob{}}
+	return &cache{blobs: map[string]*list.Element{}, lru: list.New(), limit: maxBlobBytes}
 }
 
 func blobKey(owner, repo, ref, path string) string {
 	return owner + "/" + repo + "/" + ref + "/" + path
 }
 
+// blob returns the cached bytes, marking the entry most-recently-used.
 func (c *cache) blob(key string) (FileBlob, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	b, ok := c.blobs[key]
-	return b, ok
+	el, ok := c.blobs[key]
+	if !ok {
+		return FileBlob{}, false
+	}
+	c.lru.MoveToFront(el)
+	return el.Value.(*blobEntry).blob, true
 }
 
 func (c *cache) putBlob(key string, b FileBlob) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.blobs[key] = b
+	size := blobSize(key, b)
+	if el, ok := c.blobs[key]; ok {
+		e := el.Value.(*blobEntry)
+		c.bytes += size - e.size
+		e.blob, e.size = b, size
+		c.lru.MoveToFront(el)
+	} else {
+		c.blobs[key] = c.lru.PushFront(&blobEntry{key: key, blob: b, size: size})
+		c.bytes += size
+	}
+	c.evict()
+}
+
+// evict drops the coldest entries until the cache is under the cap. the length guard
+// terminates the loop even for an entry bigger than the cap itself.
+func (c *cache) evict() {
+	for c.bytes > c.limit && c.lru.Len() > 0 {
+		el := c.lru.Back()
+		e := el.Value.(*blobEntry)
+		c.lru.Remove(el)
+		delete(c.blobs, e.key)
+		c.bytes -= e.size
+	}
 }
 
 func (c *cache) clearAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	clear(c.blobs)
+	c.lru.Init()
+	c.bytes = 0
 }

--- a/internal/github/cache_test.go
+++ b/internal/github/cache_test.go
@@ -61,8 +61,7 @@ func TestClearCacheFlushesBlobs(t *testing.T) {
 	}
 }
 
-// threads are not memoised in the sidecar: freshness is the client's clock, so every
-// get_threads reads through to GitHub rather than serving a list of unbounded age.
+// threads are the client's to keep fresh, so every walk reads through to GitHub.
 func TestThreadsAreNotCached(t *testing.T) {
 	calls := 0
 	c := newClient(func(*http.Request) (*http.Response, error) {
@@ -77,5 +76,77 @@ func TestThreadsAreNotCached(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Errorf("want both walks to reach github, got %d requests", calls)
+	}
+}
+
+// the real cache with a smaller cap, so eviction trips without allocating 64MB
+func smallCache(limit int) *cache {
+	c := newCache()
+	c.limit = limit
+	return c
+}
+
+func put(c *cache, key string, n int) {
+	c.putBlob(key, FileBlob{Content: strings.Repeat("x", n)})
+}
+
+// blobs never expire (immutable per sha), so the cap is the only thing bounding them.
+func TestBlobCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	c := smallCache(350) // three 100-byte entries fit (keys are charged too), four don't
+	put(c, "a", 100)
+	put(c, "b", 100)
+	put(c, "c", 100)
+
+	// read a, so b is now the coldest entry rather than a
+	if _, ok := c.blob("a"); !ok {
+		t.Fatal("a should still be cached")
+	}
+	put(c, "d", 100) // pushes past the cap: the coldest entry goes
+
+	if _, ok := c.blob("b"); ok {
+		t.Error("b was least-recently-used and should have been evicted")
+	}
+	for _, key := range []string{"a", "c", "d"} {
+		if _, ok := c.blob(key); !ok {
+			t.Errorf("%s should have survived eviction", key)
+		}
+	}
+	if c.bytes > c.limit {
+		t.Errorf("cache holds %d bytes, over its %d cap", c.bytes, c.limit)
+	}
+}
+
+// the charge must follow the entry, or a re-put leaks the accounting.
+func TestBlobCacheAccountsForReplacedEntries(t *testing.T) {
+	c := smallCache(1000)
+	put(c, "a", 100)
+	put(c, "a", 400)
+	if want := blobSize("a", FileBlob{Content: strings.Repeat("x", 400)}); c.bytes != want {
+		t.Errorf("want %d bytes charged after the replace, got %d", want, c.bytes)
+	}
+	if c.lru.Len() != 1 {
+		t.Errorf("a replace should reuse the entry, got %d", c.lru.Len())
+	}
+}
+
+// an entry larger than the whole cap must not wedge the eviction loop.
+func TestBlobCacheSurvivesAnOversizedEntry(t *testing.T) {
+	c := smallCache(50)
+	put(c, "big", 500)
+	if c.lru.Len() != 0 || c.bytes != 0 {
+		t.Errorf("an entry over the cap should not be retained, got %d entries / %d bytes", c.lru.Len(), c.bytes)
+	}
+	put(c, "small", 10) // the cache still works afterwards
+	if _, ok := c.blob("small"); !ok {
+		t.Error("the cache should still hold a fitting entry")
+	}
+}
+
+func TestClearCacheResetsTheCharge(t *testing.T) {
+	c := smallCache(1000)
+	put(c, "a", 100)
+	c.clearAll()
+	if c.bytes != 0 || c.lru.Len() != 0 || len(c.blobs) != 0 {
+		t.Errorf("clear should empty the cache, got %d bytes / %d entries / %d keys", c.bytes, c.lru.Len(), len(c.blobs))
 	}
 }

--- a/internal/github/cache_test.go
+++ b/internal/github/cache_test.go
@@ -26,7 +26,7 @@ func TestBlobCacheServesContents(t *testing.T) {
 		t.Fatalf("unexpected path %s", r.URL.Path)
 		return nil, nil
 	})
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if _, err := c.GetFileVersions(context.Background(), "o", "r", 3, "a.go", "", ""); err != nil {
 			t.Fatal(err)
 		}
@@ -54,7 +54,7 @@ func TestThreadCacheAndInvalidation(t *testing.T) {
 		return nil, nil
 	})
 	ctx := context.Background()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if _, err := c.GetThreads(ctx, "o", "r", 3); err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +128,7 @@ func TestThreadWalkCachesWhenNothingInvalidates(t *testing.T) {
 		return resp(200, `{"data":{"repository":{"pullRequest":{"reviewThreads":{`+
 			`"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`, nil), nil
 	})
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if _, err := c.GetThreads(context.Background(), "acme", "widget", 7); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/github/cache_test.go
+++ b/internal/github/cache_test.go
@@ -39,40 +39,6 @@ func TestBlobCacheServesContents(t *testing.T) {
 	}
 }
 
-func TestThreadCacheAndInvalidation(t *testing.T) {
-	threadCalls := 0
-	c := newClient(func(r *http.Request) (*http.Response, error) {
-		body := string(readBody(t, r))
-		switch {
-		case strings.Contains(body, "GetThreads"):
-			threadCalls++
-			return resp(200, `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`, nil), nil
-		case strings.Contains(body, "resolveReviewThread"):
-			return resp(200, `{"data":{"result":{"thread":{"isResolved":true}}}}`, nil), nil
-		}
-		t.Fatalf("unexpected op: %s", body)
-		return nil, nil
-	})
-	ctx := context.Background()
-	for range 2 {
-		if _, err := c.GetThreads(ctx, "o", "r", 3); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if threadCalls != 1 {
-		t.Fatalf("second get_threads should be cached, got %d fetches", threadCalls)
-	}
-	if _, err := c.ResolveThread(ctx, "PRT_1", true); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := c.GetThreads(ctx, "o", "r", 3); err != nil {
-		t.Fatal(err)
-	}
-	if threadCalls != 2 {
-		t.Errorf("resolve must invalidate the thread cache, got %d fetches", threadCalls)
-	}
-}
-
 func TestClearCacheFlushesBlobs(t *testing.T) {
 	var contentCalls atomic.Int64
 	c := newClient(func(r *http.Request) (*http.Response, error) {
@@ -95,33 +61,9 @@ func TestClearCacheFlushesBlobs(t *testing.T) {
 	}
 }
 
-// a mutation invalidating the thread cache mid-pagination must win: the walk in flight
-// assembled its snapshot before the change, so caching it would resurrect the pre-
-// mutation list and hide the new comment for the life of the session.
-func TestInvalidateDuringWalkDropsTheStaleSnapshot(t *testing.T) {
-	var c *Client
-	c = newClient(func(*http.Request) (*http.Response, error) {
-		// invalidate while the walk is mid-flight, as a concurrent mutation would
-		c.cache.invalidateThreads()
-		return resp(200, `{"data":{"repository":{"pullRequest":{"reviewThreads":{`+
-			`"nodes":[{"id":"th_1","path":"a.txt","comments":{"nodes":[]}}],`+
-			`"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`, nil), nil
-	})
-
-	got, err := c.GetThreads(context.Background(), "acme", "widget", 7)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("the caller still gets the walk's result, got %d", len(got))
-	}
-	if _, ok := c.cache.thread(threadKey("acme", "widget", 7)); ok {
-		t.Error("a snapshot assembled before the invalidation must not be cached")
-	}
-}
-
-// the ordinary path still caches, so the guard hasn't disabled the memo outright
-func TestThreadWalkCachesWhenNothingInvalidates(t *testing.T) {
+// threads are not memoised in the sidecar: freshness is the client's clock, so every
+// get_threads reads through to GitHub rather than serving a list of unbounded age.
+func TestThreadsAreNotCached(t *testing.T) {
 	calls := 0
 	c := newClient(func(*http.Request) (*http.Response, error) {
 		calls++
@@ -133,7 +75,7 @@ func TestThreadWalkCachesWhenNothingInvalidates(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if calls != 1 {
-		t.Errorf("want the second call served from cache, got %d requests", calls)
+	if calls != 2 {
+		t.Errorf("want both walks to reach github, got %d requests", calls)
 	}
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -47,6 +47,5 @@ func New(hc *http.Client, token string, tokenErr error, log *slog.Logger) *Clien
 	return &Client{http: hc, token: token, tokenErr: tokenErr, log: log, restURL: defaultREST, gqlURL: defaultGQL, cache: newCache()}
 }
 
-// ClearCache flushes the blob cache; the cache_clear method, surfaced as
-// :Differ cache clear, calls this.
+// ClearCache flushes the blob cache, behind :Differ cache clear.
 func (c *Client) ClearCache() { c.cache.clearAll() }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -47,6 +47,6 @@ func New(hc *http.Client, token string, tokenErr error, log *slog.Logger) *Clien
 	return &Client{http: hc, token: token, tokenErr: tokenErr, log: log, restURL: defaultREST, gqlURL: defaultGQL, cache: newCache()}
 }
 
-// ClearCache flushes the blob and thread caches; the cache_clear method, surfaced as
+// ClearCache flushes the blob cache; the cache_clear method, surfaced as
 // :Differ cache clear, calls this.
 func (c *Client) ClearCache() { c.cache.clearAll() }

--- a/internal/github/comments.go
+++ b/internal/github/comments.go
@@ -23,9 +23,6 @@ func (c *Client) PostComment(ctx context.Context, owner, repo string, number int
 	default:
 		res, err = c.postNewThread(ctx, owner, repo, number, in)
 	}
-	if err == nil {
-		c.cache.invalidateThreads()
-	}
 	return res, err
 }
 
@@ -117,12 +114,10 @@ func (c *Client) postNewThread(ctx context.Context, owner, repo string, number i
 }
 
 // DeleteComment removes a single review comment by its node id (draft or published).
-// the thread cache is invalidated so the next get_threads reflects the removal.
 func (c *Client) DeleteComment(ctx context.Context, commentID string) error {
 	if err := c.graphql(ctx, deleteCommentMutation, map[string]any{"id": commentID}, nil); err != nil {
 		return err
 	}
-	c.cache.invalidateThreads()
 	return nil
 }
 

--- a/internal/github/prs.go
+++ b/internal/github/prs.go
@@ -64,7 +64,7 @@ func (c *Client) GetPR(ctx context.Context, owner, repo string, number int) (*PR
 	viewed := map[string]string{}
 	var meta prDetailGQL
 	cursor := ""
-	for n := 0; n < gqlMaxPages; n++ {
+	for range gqlMaxPages {
 		var page prDetailGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -53,7 +53,6 @@ func (c *Client) SubmitReview(ctx context.Context, reviewID, event, body string)
 	if err := c.graphql(ctx, submitReviewMutation, vars, &out); err != nil {
 		return nil, err
 	}
-	c.cache.invalidateThreads()
 	return &SubmitReview{ID: parseID(out.SubmitPullRequestReview.PullRequestReview.FullDatabaseID)}, nil
 }
 
@@ -62,6 +61,5 @@ func (c *Client) DiscardReview(ctx context.Context, reviewID string) error {
 	if err := c.graphql(ctx, deleteReviewMutation, map[string]any{"reviewId": reviewID}, nil); err != nil {
 		return err
 	}
-	c.cache.invalidateThreads()
 	return nil
 }

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -5,13 +5,10 @@ import (
 	"strconv"
 )
 
-// GetThreads returns the PR's review threads with their comments, paginating the
-// thread list. inner comment lists are capped at threadCommentsPage and flagged when
-// they hit it. per thread, ID is the root comment's numeric id (the reply anchor),
-// ThreadID is the GraphQL node id resolve_thread targets, and IsPending marks an
-// unsubmitted draft (root comment in PENDING state). the walk reads through: the
-// client memoises the list per session behind its own freshness clock, so a memo
-// here would only delay a colleague's comment further.
+// GetThreads returns the PR's review threads, paginated; inner comment lists cap at
+// threadCommentsPage and set CommentsTruncated. per thread, ID is the root comment's
+// numeric id (the reply anchor), ThreadID the node id resolve_thread targets, IsPending
+// an unsubmitted draft. reads through, since the client owns thread freshness.
 func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int) ([]Thread, error) {
 	out := []Thread{} // non-nil so an empty PR marshals to [] (null would decode to vim.NIL)
 	cursor := ""

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -20,7 +20,7 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 	gen := c.cache.threadGeneration()
 	out := []Thread{} // non-nil so an empty PR marshals to [] (null would decode to vim.NIL)
 	cursor := ""
-	for n := 0; n < gqlMaxPages; n++ {
+	for range gqlMaxPages {
 		var page threadsGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -9,15 +9,10 @@ import (
 // thread list. inner comment lists are capped at threadCommentsPage and flagged when
 // they hit it. per thread, ID is the root comment's numeric id (the reply anchor),
 // ThreadID is the GraphQL node id resolve_thread targets, and IsPending marks an
-// unsubmitted draft (root comment in PENDING state).
+// unsubmitted draft (root comment in PENDING state). the walk reads through: the
+// client memoises the list per session behind its own freshness clock, so a memo
+// here would only delay a colleague's comment further.
 func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int) ([]Thread, error) {
-	key := threadKey(owner, repo, number)
-	if t, ok := c.cache.thread(key); ok {
-		return t, nil
-	}
-	// captured before the walk: an invalidation landing mid-pagination must win over the
-	// snapshot this walk is assembling
-	gen := c.cache.threadGeneration()
 	out := []Thread{} // non-nil so an empty PR marshals to [] (null would decode to vim.NIL)
 	cursor := ""
 	for range gqlMaxPages {
@@ -70,7 +65,6 @@ func (c *Client) GetThreads(ctx context.Context, owner, repo string, number int)
 		}
 		cursor = next
 	}
-	c.cache.putThreads(key, out, gen)
 	return out, nil
 }
 
@@ -116,7 +110,6 @@ func (c *Client) ResolveThread(ctx context.Context, threadID string, resolved bo
 	if err := c.graphql(ctx, mutation, map[string]any{"threadId": threadID}, &out); err != nil {
 		return nil, err
 	}
-	c.cache.invalidateThreads()
 	return &ResolveThread{Resolved: out.Result.Thread.IsResolved}, nil
 }
 

--- a/internal/github/timeline.go
+++ b/internal/github/timeline.go
@@ -10,7 +10,7 @@ import "context"
 func (c *Client) GetTimeline(ctx context.Context, owner, repo string, number int) (*Timeline, error) {
 	out := &Timeline{Comments: []TimelineComment{}, Reviews: []ReviewSummary{}}
 	cursor := ""
-	for n := 0; n < gqlMaxPages; n++ {
+	for range gqlMaxPages {
 		var page timelineGQL
 		vars := map[string]any{"owner": owner, "repo": repo, "number": number}
 		if cursor != "" {

--- a/internal/server/dispatch.go
+++ b/internal/server/dispatch.go
@@ -36,11 +36,9 @@ func (s *Server) dispatch(ctx context.Context, req protocol.Request, inflight *s
 		s.emit(badRequest(req.ID, "handshake required: send hello first"))
 		return
 	}
-	inflight.Add(1)
-	go func() {
-		defer inflight.Done()
+	inflight.Go(func() {
 		s.emit(s.run(ctx, req))
-	}()
+	})
 }
 
 // run invokes a handler, recovering panics into an internal error so one bad
@@ -85,8 +83,7 @@ func (s *Server) run(ctx context.Context, req protocol.Request) (resp protocol.R
 // its code; anything else is internal (and the real error is logged, never
 // surfaced, so tokens can't leak).
 func toRPCError(err error) *protocol.RPCError {
-	var perr *protocol.Error
-	if errors.As(err, &perr) {
+	if perr, ok := errors.AsType[*protocol.Error](err); ok {
 		return &protocol.RPCError{Code: perr.Code, Message: perr.Message, RetryAfter: perr.RetryAfter}
 	}
 	return &protocol.RPCError{Code: protocol.CodeInternal, Message: "internal error"}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,16 +40,14 @@ func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
 
 	// sole owner of stdout: one goroutine, so writes are serialized without a mutex.
 	var writerDone sync.WaitGroup
-	writerDone.Add(1)
-	go func() {
-		defer writerDone.Done()
+	writerDone.Go(func() {
 		enc := json.NewEncoder(out)
 		for msg := range s.outbound {
 			if err := enc.Encode(msg); err != nil {
 				s.log.Error("encode response", "err", err)
 			}
 		}
-	}()
+	})
 
 	var inflight sync.WaitGroup
 	scanner := bufio.NewScanner(in)

--- a/lua/differ/pr/comment.lua
+++ b/lua/differ/pr/comment.lua
@@ -296,14 +296,14 @@ function M.compose(session, opts)
 end
 
 -- post the composed body: assemble the post_comment args (a reply by node id, else the
--- new-thread anchor), attach review_id when drafting and the session head for the
--- guard, then re-fetch threads on success so the new comment renders authoritatively.
+-- new-thread anchor plus the session head for the guard), attach review_id when
+-- drafting, then re-fetch threads on success so the new comment renders authoritatively.
 -- a conflict means the head moved: refresh + re-anchor + re-prompt, never a silent post
 ---@param session table
 ---@param opts differ.pr.CommentOpts
 ---@param body string
 function M.post(session, opts, body)
-    local args = { body = body, expected_head = session.pr_meta.head_sha }
+    local args = { body = body }
     if opts.in_reply_to then
         args.in_reply_to = opts.in_reply_to
     else
@@ -314,6 +314,10 @@ function M.post(session, opts, body)
         args.path = opts.path
         args.side, args.line = a.side, a.line
         args.start_side, args.start_line = a.start_side, a.start_line
+        -- only the anchored path pins the head: path/side/line mean something different
+        -- at a moved head, so the guard is worth a bounced submit there. a reply targets
+        -- a thread node id, which the head can't shift under it
+        args.expected_head = session.pr_meta.head_sha
     end
     if session.review_id then
         args.review_id = session.review_id

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -687,6 +687,7 @@ local function open_session(pr, detail, opts)
         prefetching = {}, -- paths with an in-flight predictive prefetch (dedupe guard)
         threads = nil, -- PR-wide review threads, fetched by pr.threads.refresh
         threads_at = nil, -- when it was fetched; pr.threads expires it on a TTL
+        threads_fail = nil, -- consecutive get_threads failures; drives the retry backoff
         thread_collapsed = {}, -- per thread_id collapse override (gc); nil = cursor-driven
         thread_active = nil, -- the anchor key (bufnr:row) the cursor expands (peek)
         review_id = nil, -- the active pending-review node id; nil = immediate mode

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -687,7 +687,6 @@ local function open_session(pr, detail, opts)
         prefetching = {}, -- paths with an in-flight predictive prefetch (dedupe guard)
         threads = nil, -- PR-wide review threads, fetched by pr.threads.refresh
         threads_at = nil, -- when it was fetched; pr.threads expires it on a TTL
-        checks = nil, -- get_checks result, cached lazily by the overview
         thread_collapsed = {}, -- per thread_id collapse override (gc); nil = cursor-driven
         thread_active = nil, -- the anchor key (bufnr:row) the cursor expands (peek)
         review_id = nil, -- the active pending-review node id; nil = immediate mode

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -685,7 +685,8 @@ local function open_session(pr, detail, opts)
         entries = entries, -- flat FileEntry[] (single section), shared by ref with the panel
         versions = {}, -- per-path blob memo; valid for the session (shas are pinned)
         prefetching = {}, -- paths with an in-flight predictive prefetch (dedupe guard)
-        threads = nil, -- PR-wide review threads, fetched once by pr.threads.refresh
+        threads = nil, -- PR-wide review threads, fetched by pr.threads.refresh
+        threads_at = nil, -- when that list was fetched; pr.threads expires it on a TTL
         checks = nil, -- get_checks result, cached lazily by the overview
         thread_collapsed = {}, -- per thread_id collapse override (gc); nil = cursor-driven
         thread_active = nil, -- the anchor key (bufnr:row) the cursor expands (peek)

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -686,7 +686,7 @@ local function open_session(pr, detail, opts)
         versions = {}, -- per-path blob memo; valid for the session (shas are pinned)
         prefetching = {}, -- paths with an in-flight predictive prefetch (dedupe guard)
         threads = nil, -- PR-wide review threads, fetched by pr.threads.refresh
-        threads_at = nil, -- when that list was fetched; pr.threads expires it on a TTL
+        threads_at = nil, -- when it was fetched; pr.threads expires it on a TTL
         checks = nil, -- get_checks result, cached lazily by the overview
         thread_collapsed = {}, -- per thread_id collapse override (gc); nil = cursor-driven
         thread_active = nil, -- the anchor key (bufnr:row) the cursor expands (peek)

--- a/lua/differ/pr/overview.lua
+++ b/lua/differ/pr/overview.lua
@@ -365,9 +365,9 @@ local function render(session, timeline, checks)
     arm_guard(session, win)
 end
 
--- M.open(session): fetch the timeline, ensure threads (shared with the diff overlay;
--- feeds the header count + the timeline's thread sections), reuse cached checks, render
--- the page. guards the session is still live at every async hop (it can be torn down
+-- M.open(session): fetch the timeline and the checks, ensure threads (shared with the
+-- diff overlay; feeds the header count + the timeline's thread sections), render the
+-- page. guards the session is still live at every async hop (it can be torn down
 -- mid-fetch); threads and checks degrade rather than block the page
 ---@param session table|nil
 function M.open(session)
@@ -398,21 +398,18 @@ function M.open(session)
             if not ours() then
                 return
             end
-            if session.checks then
-                return render(session, timeline, session.checks)
-            end
-            -- no cached checks: fetch once, cache on the session, then render (degrade
-            -- to nil if the fetch fails — the rollup line just reads "n/a")
+            -- fetched per open, never memoised: the rollup is the most time-sensitive
+            -- thing on the page, and a kept copy would disagree with :Differ pr checks
             client.get_checks(session.pr, function(cerr, checks)
                 -- the checks fetch is the longest hop, so this is the likeliest place to
                 -- find the session already in the files
                 if not ours() then
                     return
                 end
-                if not cerr and type(checks) == "table" then
-                    session.checks = checks
+                if cerr or type(checks) ~= "table" then
+                    checks = nil -- if we couldn't fetch checks, don't block the call
                 end
-                render(session, timeline, session.checks)
+                render(session, timeline, checks)
             end)
         end)
     end)

--- a/lua/differ/pr/threads.lua
+++ b/lua/differ/pr/threads.lua
@@ -1,5 +1,5 @@
--- inline thread overlay: fetch the PR's review threads once per session, anchor
--- each to a derived buffer row through the line map, stack same-row threads oldest
+-- inline thread overlay: fetch the PR's review threads (once per TTL window, PR-wide),
+-- anchor each to a derived buffer row through the line map, stack same-row threads oldest
 -- first, and paint them as extmark `virt_lines` below the anchor (plus a range
 -- background for multi-line threads). the overlay is extmark-only: it never touches the
 -- map and never re-renders the buffer, so a refresh just re-applies marks. the pure
@@ -330,12 +330,29 @@ function M.apply_box(session, view, g, reltime)
     })
 end
 
+-- ── freshness ───────────────────────────────────────────────────────────────────
+-- the sidecar reads threads through, so this is the only clock on them: without it a
+-- list fetched on open is served for the life of the session and a colleague's comment
+-- never lands. long enough that a run of ]f never refetches mid-flow
+
+local TTL_MS = 30 * 1000
+
+-- whether the session's list is inside the freshness window. an unstamped list (a
+-- caller that seeded threads directly) counts as stale, so it revalidates once
+---@param session table
+---@return boolean
+local function fresh(session)
+    local at = session.threads_at
+    return type(at) == "number" and (vim.uv.now() - at) < TTL_MS
+end
+
 -- drop the fetched thread list so the next ensure refetches. the generation bump is
 -- what stops a fetch already in flight from being joined, or from landing its
 -- pre-mutation list on top of the change that invalidated it
 ---@param session table
 function M.invalidate(session)
     session.threads = nil
+    session.threads_at = nil
     session.threads_gen = (session.threads_gen or 0) + 1
 end
 
@@ -361,6 +378,7 @@ local function deliver(session, gen, err, list)
         -- a PR with no threads decodes to vim.NIL (userdata, truthy), so guard on
         -- type rather than `list or {}`
         session.threads = type(list) == "table" and list or {}
+        session.threads_at = vim.uv.now()
     end
     for _, fn in ipairs(waiters) do
         fn(err)
@@ -373,7 +391,7 @@ end
 ---@param session table
 ---@param cb fun(err: table|nil)
 function M.ensure(session, cb)
-    if session.threads then
+    if session.threads and fresh(session) then
         return cb(nil)
     end
     local gen = session.threads_gen or 0
@@ -393,13 +411,38 @@ function M.ensure(session, cb)
     end)
 end
 
+-- refetch under a list that stays painted. the stale list is still a good enough
+-- anchor to render from, so the fetch runs with nobody waiting on it and swaps in when
+-- it lands; a fetch already running for this generation is left to it
+---@param session table
+local function revalidate(session)
+    local gen = session.threads_gen or 0
+    if session.threads_waiters and session.threads_fetch_gen == gen then
+        return
+    end
+    session.threads_waiters = {} -- no waiters, but non-nil marks the fetch in flight
+    session.threads_fetch_gen = gen
+    client.get_threads(session.pr, function(err, list)
+        deliver(session, gen, err, list)
+        if not err then
+            M.apply(session)
+        end
+    end)
+end
+
 -- fetch (via ensure) then paint the current file. threads are additive, so a fetch
 -- error never blocks the diff (apply over nil threads just clears the overlay). called
--- on every show_file render so a file switch re-anchors from the cached list
+-- on every show_file render so a file switch re-anchors from the cached list. a list
+-- past its TTL is painted anyway and refreshed underneath: ]f is the hot path and the
+-- old anchors are near enough to be worth showing while the new ones fly
 ---@param session table
 function M.refresh(session)
     if not (session and session.view) then
         return
+    end
+    if session.threads and not fresh(session) then
+        revalidate(session)
+        return M.apply(session)
     end
     M.ensure(session, function()
         M.apply(session)

--- a/lua/differ/pr/threads.lua
+++ b/lua/differ/pr/threads.lua
@@ -336,12 +336,45 @@ end
 
 local TTL_MS = 30 * 1000
 
+-- a failing fetch doubles its wait per consecutive failure. refresh runs on every
+-- show_file, so without this a github that is down is re-asked on every ]f
+local RETRY_BASE_MS = 5 * 1000
+local RETRY_MAX_MS = 5 * 60 * 1000
+
 -- an unstamped list counts as stale, so it revalidates once
 ---@param session table
 ---@return boolean
 local function fresh(session)
     local at = session.threads_at
     return type(at) == "number" and (vim.uv.now() - at) < TTL_MS
+end
+
+-- whether a failed fetch's backoff window is still open
+---@param session table
+---@return boolean
+local function backing_off(session)
+    local at = session.threads_retry_at
+    return type(at) == "number" and vim.uv.now() < at
+end
+
+-- one notification per run of consecutive failures, not per render, and a retry window
+-- that widens with the run. the error is kept so callers during the backoff get an answer
+---@param session table
+---@param err table
+local function note_failure(session, err)
+    local n = (session.threads_fail or 0) + 1
+    local wait = math.min(RETRY_BASE_MS * 2 ^ (n - 1), RETRY_MAX_MS)
+    session.threads_fail, session.threads_err = n, err
+    session.threads_retry_at = vim.uv.now() + math.floor(wait)
+    if n == 1 then
+        require("differ.pr").notify_err(err)
+    end
+end
+
+-- end the run, so an unrelated failure later notifies again rather than staying silent
+---@param session table
+local function note_success(session)
+    session.threads_fail, session.threads_retry_at, session.threads_err = nil, nil, nil
 end
 
 -- drop the fetched thread list so the next ensure refetches. the generation bump is
@@ -352,11 +385,12 @@ function M.invalidate(session)
     session.threads = nil
     session.threads_at = nil
     session.threads_gen = (session.threads_gen or 0) + 1
+    note_success(session) -- a mutation is an explicit retry; don't sit out the backoff
 end
 
 -- settle the fetch that started at `gen`: store its list, then run everyone queued
--- behind it. an error notifies once and leaves threads nil, so the additive surfaces
--- degrade and a later ensure retries
+-- behind it. an error opens a backoff window and leaves threads nil, so the additive
+-- surfaces degrade and a later ensure retries once the window closes
 ---@param session table
 ---@param gen integer
 ---@param err table|nil
@@ -371,8 +405,9 @@ local function deliver(session, gen, err, list)
     local waiters = session.threads_waiters or {}
     session.threads_waiters = nil
     if err then
-        require("differ.pr").notify_err(err)
+        note_failure(session, err)
     else
+        note_success(session)
         -- a PR with no threads decodes to vim.NIL (userdata, truthy), so guard on
         -- type rather than `list or {}`
         session.threads = type(list) == "table" and list or {}
@@ -383,14 +418,17 @@ local function deliver(session, gen, err, list)
     end
 end
 
--- ensure the PR's threads are fetched (once, PR-wide), then run cb(err). callers while
--- a fetch is in flight queue behind it. the overview and the diff overlay share this,
--- so landing on either warms the other
+-- ensure the PR's threads are fetched (once per TTL window, PR-wide), then run cb(err).
+-- callers while a fetch is in flight queue behind it. the overview and the diff overlay
+-- share this, so landing on either warms the other
 ---@param session table
 ---@param cb fun(err: table|nil)
 function M.ensure(session, cb)
     if session.threads and fresh(session) then
         return cb(nil)
+    end
+    if backing_off(session) then
+        return cb(session.threads_err) -- answered from the last failure, no new request
     end
     local gen = session.threads_gen or 0
     -- only a fetch started under the current generation may be shared; one issued before
@@ -413,6 +451,9 @@ end
 -- a fetch already running for this generation is left to it
 ---@param session table
 local function revalidate(session)
+    if backing_off(session) then
+        return -- the painted list stays; a failing github isn't re-asked per render
+    end
     local gen = session.threads_gen or 0
     if session.threads_waiters and session.threads_fetch_gen == gen then
         return

--- a/lua/differ/pr/threads.lua
+++ b/lua/differ/pr/threads.lua
@@ -331,14 +331,12 @@ function M.apply_box(session, view, g, reltime)
 end
 
 -- ── freshness ───────────────────────────────────────────────────────────────────
--- the sidecar reads threads through, so this is the only clock on them: without it a
--- list fetched on open is served for the life of the session and a colleague's comment
--- never lands. long enough that a run of ]f never refetches mid-flow
+-- the sidecar reads threads through, so this is their only clock: without it the list
+-- fetched on open serves the whole session and a colleague's comment never lands
 
 local TTL_MS = 30 * 1000
 
--- whether the session's list is inside the freshness window. an unstamped list (a
--- caller that seeded threads directly) counts as stale, so it revalidates once
+-- an unstamped list counts as stale, so it revalidates once
 ---@param session table
 ---@return boolean
 local function fresh(session)
@@ -411,9 +409,8 @@ function M.ensure(session, cb)
     end)
 end
 
--- refetch under a list that stays painted. the stale list is still a good enough
--- anchor to render from, so the fetch runs with nobody waiting on it and swaps in when
--- it lands; a fetch already running for this generation is left to it
+-- refetch under a still-painted list: nobody waits on it, it swaps in when it lands.
+-- a fetch already running for this generation is left to it
 ---@param session table
 local function revalidate(session)
     local gen = session.threads_gen or 0
@@ -432,9 +429,8 @@ end
 
 -- fetch (via ensure) then paint the current file. threads are additive, so a fetch
 -- error never blocks the diff (apply over nil threads just clears the overlay). called
--- on every show_file render so a file switch re-anchors from the cached list. a list
--- past its TTL is painted anyway and refreshed underneath: ]f is the hot path and the
--- old anchors are near enough to be worth showing while the new ones fly
+-- on every show_file render, so a stale list is painted and refreshed underneath
+-- rather than made to wait: ]f is the hot path
 ---@param session table
 function M.refresh(session)
     if not (session and session.view) then

--- a/test/nvim/pr_threads_ensure_spec.lua
+++ b/test/nvim/pr_threads_ensure_spec.lua
@@ -120,9 +120,8 @@ describe("pr.threads.ensure (coalescing + freshness)", function()
         assert.is_nil(session.threads_waiters)
     end)
 
-    -- the freshness clock: a list inside the window is served straight back, one past it
-    -- is refetched. without this a colleague's comment posted after the session opened
-    -- never appears, since only the user's own mutations invalidate
+    -- without the clock a colleague's comment never appears: only the user's own
+    -- mutations invalidate
     it("serves a fresh list without a fetch, and refetches a stale one", function()
         local list = { { thread_id = "th_1", path = "a.txt", line = 2, comments = {} } }
         local session = { pr = PR, threads = list, threads_at = vim.uv.now() }
@@ -148,8 +147,7 @@ describe("pr.threads.ensure (coalescing + freshness)", function()
         assert.is_true(session.threads_at > vim.uv.now() - 1000) -- restamped on delivery
     end)
 
-    -- an unstamped list (seeded directly, or carried over from before the clock existed)
-    -- must not read as fresh forever
+    -- an unstamped list must not read as fresh forever
     it("treats an unstamped list as stale", function()
         local session = { pr = PR, threads = {}, threads_at = nil }
         local h = harness(session)

--- a/test/nvim/pr_threads_ensure_spec.lua
+++ b/test/nvim/pr_threads_ensure_spec.lua
@@ -1,5 +1,5 @@
--- runs under headless nvim: exercises pr.threads.ensure's in-flight coalescing in
--- isolation. ensure defers to require("differ.pr").current_session() and
+-- runs under headless nvim: exercises pr.threads.ensure's in-flight coalescing and its
+-- freshness clock in isolation. ensure defers to require("differ.pr").current_session() and
 -- client.get_threads, so both are stubbed; the get_threads cb is captured (not fired)
 -- to hold a fetch "in flight" while a second caller queues behind it
 
@@ -11,7 +11,7 @@ local pr = require("differ.pr")
 
 local PR = { owner = "acme", repo = "widget", number = 7 }
 
-describe("pr.threads.ensure (in-flight coalescing)", function()
+describe("pr.threads.ensure (coalescing + freshness)", function()
     local restore
 
     after_each(function()
@@ -118,6 +118,43 @@ describe("pr.threads.ensure (in-flight coalescing)", function()
         assert.are.equal(1, before) -- the superseded fetch's waiter is still answered
         assert.are.equal(1, after)
         assert.is_nil(session.threads_waiters)
+    end)
+
+    -- the freshness clock: a list inside the window is served straight back, one past it
+    -- is refetched. without this a colleague's comment posted after the session opened
+    -- never appears, since only the user's own mutations invalidate
+    it("serves a fresh list without a fetch, and refetches a stale one", function()
+        local list = { { thread_id = "th_1", path = "a.txt", line = 2, comments = {} } }
+        local session = { pr = PR, threads = list, threads_at = vim.uv.now() }
+        local h = harness(session)
+
+        local ran = 0
+        threads.ensure(session, function()
+            ran = ran + 1
+        end)
+        assert.are.equal(0, h.sent()) -- inside the TTL: no network
+        assert.are.equal(1, ran) -- and the cb runs straight away
+
+        session.threads_at = vim.uv.now() - (10 * 60 * 1000) -- ten minutes old
+        threads.ensure(session, function()
+            ran = ran + 1
+        end)
+        assert.are.equal(1, h.sent()) -- past the TTL: refetched
+        assert.are.equal(1, ran) -- the caller waits for the fresh list
+
+        h.fire(nil, { { thread_id = "th_2", path = "a.txt", line = 4, comments = {} } })
+        assert.are.equal(2, ran)
+        assert.are.equal("th_2", session.threads[1].thread_id)
+        assert.is_true(session.threads_at > vim.uv.now() - 1000) -- restamped on delivery
+    end)
+
+    -- an unstamped list (seeded directly, or carried over from before the clock existed)
+    -- must not read as fresh forever
+    it("treats an unstamped list as stale", function()
+        local session = { pr = PR, threads = {}, threads_at = nil }
+        local h = harness(session)
+        threads.ensure(session, function() end)
+        assert.are.equal(1, h.sent())
     end)
 
     it("on error notifies once but still runs both queued callbacks with the err", function()

--- a/test/nvim/pr_threads_ensure_spec.lua
+++ b/test/nvim/pr_threads_ensure_spec.lua
@@ -155,6 +155,61 @@ describe("pr.threads.ensure (coalescing + freshness)", function()
         assert.are.equal(1, h.sent())
     end)
 
+    -- refresh runs on every show_file, so an unbacked-off failure means a request and a
+    -- notification per ]f for as long as github is unreachable
+    it("backs off after a failure: no refetch, no second notification", function()
+        local session = { pr = PR, threads = nil }
+        local h = harness(session)
+
+        threads.ensure(session, function() end)
+        h.fire({ message = "boom" })
+        assert.are.equal(1, h.sent())
+        assert.are.equal(1, h.notified())
+
+        local seen
+        threads.ensure(session, function(e)
+            seen = e
+        end)
+        assert.are.equal(1, h.sent()) -- inside the window: no new request
+        assert.are.equal(1, h.notified()) -- and no second notification
+        assert.are.equal("boom", seen.message) -- the caller is still answered
+    end)
+
+    -- the run has to end on a success, or one failure silences every later one
+    it("retries once the window closes, and an unrelated failure notifies again", function()
+        local session = { pr = PR, threads = nil }
+        local h = harness(session)
+
+        threads.ensure(session, function() end)
+        h.fire({ message = "boom" })
+
+        session.threads_retry_at = vim.uv.now() - 1 -- the window has closed
+        threads.ensure(session, function() end)
+        assert.are.equal(2, h.sent())
+        h.fire(nil, {}, 2) -- run ends here
+        assert.is_nil(session.threads_fail)
+        assert.is_nil(session.threads_retry_at)
+
+        session.threads_at = nil -- force the next ensure to fetch
+        threads.ensure(session, function() end)
+        h.fire({ message = "later" }, nil, 3)
+        assert.are.equal(2, h.notified()) -- a new run notifies again
+    end)
+
+    -- a comment posted while backing off is an explicit "try now"
+    it("invalidate clears the backoff", function()
+        local session = { pr = PR, threads = nil }
+        local h = harness(session)
+
+        threads.ensure(session, function() end)
+        h.fire({ message = "boom" })
+
+        threads.invalidate(session)
+        assert.is_nil(session.threads_retry_at)
+        threads.ensure(session, function() end)
+        assert.are.equal(2, h.sent())
+    end)
+
     it("on error notifies once but still runs both queued callbacks with the err", function()
         local session = { pr = PR, threads = nil }
         local h = harness(session)

--- a/test/unit/pr_comment_spec.lua
+++ b/test/unit/pr_comment_spec.lua
@@ -115,6 +115,24 @@ describe("pr.comment.post anchors to the gesture's file", function()
         restore()
     end)
 
+    -- the guard is for anchored posts: path/side/line mean something else at a moved
+    -- head. a reply targets a thread node id, so pinning the head only buys it a bounced
+    -- submit and a forced diff re-source every time someone pushes
+    it("pins the head on a new thread but not on a reply", function()
+        local box, restore = capture()
+        comment.post(
+            session("a.txt"),
+            { anchor = { side = "RIGHT", line = 2 }, path = "a.txt" },
+            "new"
+        )
+        assert.are.equal("bbb2222", box.args.expected_head)
+
+        comment.post(session("a.txt"), { in_reply_to = "PRRT_1" }, "reply")
+        assert.is_nil(box.args.expected_head)
+        assert.are.equal("PRRT_1", box.args.in_reply_to)
+        restore()
+    end)
+
     it("carries the path through the conflict re-prompt's opts", function()
         local box, restore = capture()
         local opts = { anchor = { side = "RIGHT", line = 2 }, path = "a.txt" }


### PR DESCRIPTION
## Summary
- drop the sidecar's PR thread cache in favour of one on the client. it owns thread freshness on a 30s TTL, so other people's comments now show up as you move between files rather than needing the review session restarted. a stale list is painted and revalidated underneath instead of making `]f` wait on the fetch
- refetch the ci checks on every overview open instead of memoising them on the session; the overview page was de-synced from the true ci status
- bound the blob cache at 64MB with LRU eviction (`container/list`) so it stops accumulating until a call to `:Differ cache clear`
- back off after a failed thread fetch (5s, doubling to 5m) and notify once per run of failures rather than on every file
- a reply targets a thread node id that no push can shift under it, so replies were being bounced and discarded for nothing; `expected_head` is now sent only on a new anchored thread

## Test plan
- [x] lua unit 388/0, headless-nvim 493/0
- [x] `make check` clean
