### PR TITLE
fix: report a rejected comment anchor and a rate limit's actual wait time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- A comment anchored to a line outside the diff was dropped without a word when it went into a review draft, and reported as an internal error otherwise. Both now tell you the line could not be resolved
+- A GitHub rate limit always said to retry shortly. It now names the wait when GitHub gives one
+
+## [0.1.35] — 2026-08-28
+
+### Fixed
+
 - A sidecar that crashed on the way up was never retried, so pull request review stayed broken for the rest of the session. It now restarts, and `:checkhealth differ` names the crash instead of reporting a timeout
 - With your keyring locked, the sidecar sat waiting on `gh auth token` and never answered, which read as a failed build. It now gives up and tells you the keyring is the problem
 - A request over the 16MB limit killed the sidecar and took whatever was queued behind it, which then never got a reply. The oversized request is now rejected on its own

--- a/internal/github/comments.go
+++ b/internal/github/comments.go
@@ -7,9 +7,9 @@ import (
 )
 
 // PostComment creates a review comment. InReplyTo (a thread node id) replies into an
-// existing thread; with ReviewID set a new thread joins the pending draft (GraphQL);
-// otherwise the comment publishes immediately (REST). anchor shape (side, line
-// ordering) is validated by the handler before this runs.
+// existing thread; with ReviewID set a new thread joins the pending draft; otherwise
+// the comment publishes immediately. anchor shape (side, line ordering) is validated
+// by the handler before this runs.
 func (c *Client) PostComment(ctx context.Context, owner, repo string, number int, in PostCommentInput) (*PostComment, error) {
 	var (
 		res *PostComment
@@ -81,10 +81,9 @@ func (c *Client) draftThread(ctx context.Context, in PostCommentInput) (*PostCom
 
 // postNewThread opens a new top-level thread without an explicit review. GitHub allows
 // one pending review per PR, so the route depends on whether one already exists: if it
-// does, the comment must join it as a draft (and we echo the review id so the frontend
-// adopts it); if not, the comment publishes immediately as its own COMMENT review. the
-// thread shape matches the draft path, so deleted-file / cross-side anchors behave the
-// same (the REST line-based endpoint was too strict and 422'd on those anchors).
+// does, the comment must join it as a draft, otherwise the comment publishes immediately
+// as its own COMMENT review. the thread shape matches the draft path, so deleted-file /
+// cross-side anchors all behave the same.
 func (c *Client) postNewThread(ctx context.Context, owner, repo string, number int, in PostCommentInput) (*PostComment, error) {
 	prID, pendingID, err := c.prAndPendingReview(ctx, owner, repo, number)
 	if err != nil {

--- a/internal/github/comments.go
+++ b/internal/github/comments.go
@@ -64,7 +64,14 @@ func (c *Client) draftThread(ctx context.Context, in PostCommentInput) (*PostCom
 	if err := c.graphql(ctx, addThreadMutation, vars, &out); err != nil {
 		return nil, err
 	}
+	// an anchor outside the diff is not an error here: GitHub answers 200 with no
+	// errors array and a null thread, so the draft silently never exists. the publish
+	// path rejects the same anchor with UNPROCESSABLE, so report it the same way
 	thread := out.AddPullRequestReviewThread.Thread
+	if thread.ID == "" {
+		return nil, protocol.NewError(protocol.CodeBadRequest,
+			"line could not be resolved: the comment must anchor to a line in the diff")
+	}
 	pc := &PostComment{ThreadID: thread.ID}
 	if len(thread.Comments.Nodes) > 0 {
 		pc.ID = parseID(thread.Comments.Nodes[0].FullDatabaseID)

--- a/internal/github/comments_test.go
+++ b/internal/github/comments_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/undont/differ.nvim/internal/protocol"
 )
 
 // commentOp routes the post_comment graphql ops. AddThreadReply must be checked
@@ -163,5 +165,31 @@ func TestPostCommentReply(t *testing.T) {
 	}
 	if pc.ID != 9099 || pc.ThreadID != "PRT_5" {
 		t.Errorf("reply result: %+v", pc)
+	}
+}
+
+// the envelope below is what GitHub actually returned for an anchor outside the diff
+// (captured against a live PR): a 200 carrying a top-level type of UNPROCESSABLE. it is
+// the user's line to fix, so it must not read as an internal fault.
+func TestPublishCommentOutOfDiffIsBadRequest(t *testing.T) {
+	c := newClient(func(r *http.Request) (*http.Response, error) {
+		switch op := commentOp(t, readBody(t, r)); op {
+		case "StartReviewLookup":
+			return resp(200, `{"data":{"repository":{"pullRequest":{"id":"PR_NODE","reviews":{"nodes":[]}}}}}`, nil), nil
+		case "PublishComment":
+			return resp(200, `{"data":{"addPullRequestReview":null},"errors":[{"type":"UNPROCESSABLE","path":["addPullRequestReview"],"locations":[{"line":1,"column":82}],"message":"Line could not be resolved"}]}`, nil), nil
+		default:
+			t.Fatalf("unexpected op %s", op)
+			return nil, nil
+		}
+	})
+	_, err := c.PostComment(context.Background(), "o", "r", 3, PostCommentInput{
+		Path: "a.go", Side: "RIGHT", Line: 999999, Body: "nit",
+	})
+	if got := codeOf(t, err); got != protocol.CodeBadRequest {
+		t.Fatalf("out-of-diff anchor → %q, want %q", got, protocol.CodeBadRequest)
+	}
+	if perrOf(t, err).Message != "Line could not be resolved" {
+		t.Errorf("github's own message must survive: %v", err)
 	}
 }

--- a/internal/github/comments_test.go
+++ b/internal/github/comments_test.go
@@ -193,3 +193,24 @@ func TestPublishCommentOutOfDiffIsBadRequest(t *testing.T) {
 		t.Errorf("github's own message must survive: %v", err)
 	}
 }
+
+// the draft path fails differently: GitHub answers 200 with no errors array at all and
+// a null thread (captured live), so nothing maps it. left unchecked the caller is told
+// a comment landed that GitHub never stored.
+func TestDraftThreadNullThreadIsBadRequest(t *testing.T) {
+	c := newClient(func(r *http.Request) (*http.Response, error) {
+		if op := commentOp(t, readBody(t, r)); op != "AddThread" {
+			t.Fatalf("a draft post must use AddThread, got op %s", op)
+		}
+		return resp(200, `{"data":{"addPullRequestReviewThread":{"thread":null}}}`, nil), nil
+	})
+	pc, err := c.PostComment(context.Background(), "o", "r", 3, PostCommentInput{
+		Path: "a.go", Side: "RIGHT", Line: 999999, Body: "nit", ReviewID: "PRR_1",
+	})
+	if pc != nil {
+		t.Errorf("a dropped draft must not return a comment: %+v", pc)
+	}
+	if got := codeOf(t, err); got != protocol.CodeBadRequest {
+		t.Fatalf("null thread → %q, want %q", got, protocol.CodeBadRequest)
+	}
+}

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -20,12 +20,9 @@ type restErrorBody struct {
 	Message string `json:"message"`
 }
 
-// mapHTTP turns a REST response (or a transport error) into a protocol.Error, or
-// nil when the status is 2xx. body is the already-read response body for messages.
-func mapHTTP(resp *http.Response, body []byte, transportErr error) *protocol.Error {
-	if transportErr != nil {
-		return protocol.NewError(protocol.CodeNetwork, "network error: "+transportErr.Error())
-	}
+// mapHTTP turns a REST response into a protocol.Error, or nil when the status is 2xx.
+// a transport error never reaches here, it's handled by the caller
+func mapHTTP(resp *http.Response, body []byte) *protocol.Error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
@@ -43,6 +40,7 @@ func mapHTTP(resp *http.Response, body []byte, transportErr error) *protocol.Err
 		}
 		return protocol.NewError(protocol.CodeAuth, msg)
 	case http.StatusTooManyRequests:
+		// a 429 is a rate limit by definition, so only the hint is of interest
 		ra, _ := rateLimited(resp)
 		return protocol.RateLimited(msg, ra)
 	case http.StatusNotFound:
@@ -57,8 +55,8 @@ func mapHTTP(resp *http.Response, body []byte, transportErr error) *protocol.Err
 	}
 }
 
-// rateLimited reports whether a 403/429 is a rate-limit (not a permissions denial)
-// and the retry-after hint in seconds.
+// rateLimited returns the retry-after hint in seconds (0 when there is none) and
+// whether the response is a rate limit or permissions denial.
 func rateLimited(resp *http.Response) (int, bool) {
 	if v := resp.Header.Get("Retry-After"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -45,6 +45,8 @@ func mapHTTP(resp *http.Response, body []byte) *protocol.Error {
 		return protocol.RateLimited(msg, ra)
 	case http.StatusNotFound:
 		return protocol.NewError(protocol.CodeNotFound, msg)
+	// every write goes through graphql, so REST is GETs only
+	// kept here defensively in case any writes via REST get added in the future
 	case http.StatusConflict:
 		return protocol.NewError(protocol.CodeConflict, msg)
 	case http.StatusUnprocessableEntity:

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -118,6 +118,8 @@ func mapGraphQL(errs []gqlError) *protocol.Error {
 		return protocol.NewError(protocol.CodeAuth, msg)
 	case "RATE_LIMITED":
 		return protocol.RateLimited(msg, 0)
+	case "UNPROCESSABLE": // rejected input == BadRequest
+		return protocol.NewError(protocol.CodeBadRequest, msg)
 	default:
 		return protocol.NewError(protocol.CodeInternal, msg)
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -422,6 +422,7 @@ func TestGraphQLErrorMapping(t *testing.T) {
 		{"FORBIDDEN", protocol.CodeAuth},
 		{"INSUFFICIENT_SCOPES", protocol.CodeAuth},
 		{"RATE_LIMITED", protocol.CodeRateLimited},
+		{"UNPROCESSABLE", protocol.CodeBadRequest},
 		{"SOMETHING_ELSE", protocol.CodeInternal},
 	}
 	for _, tc := range cases {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -279,9 +279,8 @@ func TestGetPRGraphQLFilesPagination(t *testing.T) {
 
 // ── error mapping ───────────────────────────────────────────────────────────
 
-// the message half matters as much as the code: "403 Forbidden" sends the user
-// looking for a missing scope, where GitHub's own body says which secondary limit
-// they hit or which line of the diff a 422 rejected
+// the message half matters as much as the code: "403 Forbidden" sends the user looking
+// for a missing scope, where GitHub's own body says which secondary limit they hit.
 func TestErrorMappingTable(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/github/mutations.go
+++ b/internal/github/mutations.go
@@ -65,7 +65,7 @@ query PRNodeID($owner: String!, $repo: String!, $number: Int!) {
 }`
 
 // addThreadMutation opens a new thread inside a pending review ($reviewId, a draft).
-// immediate (published) comments take the REST path instead, so this only drafts.
+// immediate (published) comments go through publishCommentMutation directly.
 // line/side anchor the end of the range, startLine/startSide the start of a multi-line
 // range (null for single-line; cross-side ranges are valid).
 const addThreadMutation = `

--- a/internal/github/rest.go
+++ b/internal/github/rest.go
@@ -42,7 +42,7 @@ func (c *Client) send(req *http.Request) (*http.Response, []byte, error) {
 	body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxResponse))
 	// the status outranks a truncated read: a 403 that also failed to read is still a
 	// 403, and its message is the useful half
-	if perr := mapHTTP(resp, body, nil); perr != nil {
+	if perr := mapHTTP(resp, body); perr != nil {
 		return resp, body, perr
 	}
 	if rerr != nil {

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -41,7 +41,12 @@ func (c *Client) StartReview(ctx context.Context, owner, repo string, number int
 	if err := c.graphql(ctx, addReviewMutation, map[string]any{"prId": prID}, &created); err != nil {
 		return nil, err
 	}
-	return &StartReview{ReviewID: created.AddPullRequestReview.PullRequestReview.ID}, nil
+	// an empty id would read as a started review otherwise, check it here before continuing
+	id := created.AddPullRequestReview.PullRequestReview.ID
+	if id == "" {
+		return nil, protocol.NewError(protocol.CodeInternal, "github returned no review id")
+	}
+	return &StartReview{ReviewID: id}, nil
 }
 
 // SubmitReview finalizes a pending review with the given event, returning the

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -128,3 +128,21 @@ func TestDiscardReviewMapsGraphQLError(t *testing.T) {
 		t.Fatalf("want not_found, got %v", err)
 	}
 }
+
+// a null review payload must not read as a started review: lua would store the empty id,
+// promise the user drafts, and publish every later comment straight to the PR.
+func TestStartReviewRejectsEmptyID(t *testing.T) {
+	c := newClient(func(r *http.Request) (*http.Response, error) {
+		if strings.Contains(string(readBody(t, r)), "StartReviewLookup") {
+			return resp(200, `{"data":{"repository":{"pullRequest":{"id":"PR_NODE","reviews":{"nodes":[]}}}}}`, nil), nil
+		}
+		return resp(200, `{"data":{"addPullRequestReview":{"pullRequestReview":null}}}`, nil), nil
+	})
+	sr, err := c.StartReview(context.Background(), "o", "r", 3)
+	if sr != nil {
+		t.Errorf("no review id must not yield a review: %+v", sr)
+	}
+	if got := codeOf(t, err); got != protocol.CodeInternal {
+		t.Fatalf("empty review id → %q, want %q", got, protocol.CodeInternal)
+	}
+}

--- a/internal/handlers/mutate_comments.go
+++ b/internal/handlers/mutate_comments.go
@@ -24,7 +24,7 @@ type postCommentParams struct {
 
 // postComment creates a review comment: a reply when in_reply_to is set, else a new
 // thread (a draft with review_id, immediate without). anchor validation runs here so
-// GitHub's opaque 422s never reach the user.
+// GitHub's opaque rejections never reach the user.
 func (d Deps) postComment(ctx context.Context, params json.RawMessage) (any, error) {
 	var p postCommentParams
 	if err := decode(params, &p); err != nil {
@@ -82,7 +82,8 @@ func (d Deps) deleteComment(ctx context.Context, params json.RawMessage) (any, e
 // validateAnchor checks a new thread's diff anchor before any API call. only what
 // GitHub guarantees is enforced: a known side, a positive end line, and a range that
 // starts strictly before it ends. cross-side ranges (start LEFT → end RIGHT) are
-// valid and not rejected; diff-membership is left to GitHub (its 422 → bad_request).
+// valid and not rejected; diff-membership is left to GitHub (its UNPROCESSABLE, and the
+// null thread it returns on the draft path, both map to bad_request).
 func validateAnchor(p postCommentParams) error {
 	if p.Path == "" {
 		return protocol.NewError(protocol.CodeBadRequest, "path is required")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -277,3 +277,17 @@ func TestDefaultLevelTracesNothing(t *testing.T) {
 		t.Errorf("info level should not trace requests:\n%s", buf.String())
 	}
 }
+
+func TestRateLimitCarriesRetryAfter(t *testing.T) {
+	reg := handlers.NewRegistry(handlers.Deps{Log: discardLog()})
+	reg["limited"] = func(context.Context, json.RawMessage) (any, error) {
+		return nil, protocol.RateLimited("API rate limit exceeded", 45)
+	}
+	last := drive(t, reg, helloLine, `{"id":4,"method":"limited","params":{}}`)[1]
+	if last.Error == nil || last.Error.Code != protocol.CodeRateLimited {
+		t.Fatalf("want rate_limited, got %+v", last)
+	}
+	if last.Error.RetryAfter != 45 {
+		t.Errorf("retry_after lost on the wire: %+v", last.Error)
+	}
+}

--- a/lua/differ/pr/init.lua
+++ b/lua/differ/pr/init.lua
@@ -39,11 +39,33 @@ local CODE_HINT = {
     gh_missing = "install gh or set GH_TOKEN",
     rate_limited = "github rate limit hit, retry shortly",
 }
+
+---@param secs integer
+---@return string
+local function wait_for(secs)
+    if secs < 60 then
+        return secs .. "s"
+    end
+    return math.ceil(secs / 60) .. "m"
+end
+
+-- github only sends a retry-after on a primary rate limit
+---@param err table|nil
+---@return string|nil
+function M.error_hint(err)
+    local code = err and err.code
+    local secs = err and err.retry_after
+    if code == "rate_limited" and type(secs) == "number" and secs > 0 then
+        return "github rate limit hit, retry in " .. wait_for(secs)
+    end
+    return CODE_HINT[code]
+end
+
 ---@param err table|nil
 local function notify_err(err)
     local code = (err and err.code) or "internal"
     local msg = (err and err.message) or code
-    local hint = CODE_HINT[code]
+    local hint = M.error_hint(err)
     notify(hint and (msg .. " (" .. hint .. ")") or msg, vim.log.levels.ERROR)
 end
 

--- a/test/unit/pr_error_hint_spec.lua
+++ b/test/unit/pr_error_hint_spec.lua
@@ -1,0 +1,36 @@
+local pr = require("differ.pr")
+
+describe("pr.error_hint", function()
+    it("gives a fixable code its static hint", function()
+        assert.are.equal("run gh auth login", pr.error_hint({ code = "auth" }))
+        assert.are.equal("install gh or set GH_TOKEN", pr.error_hint({ code = "gh_missing" }))
+    end)
+
+    it("has no hint for a code the user cannot act on", function()
+        assert.is_nil(pr.error_hint({ code = "internal" }))
+        assert.is_nil(pr.error_hint({ code = "not_found" }))
+        assert.is_nil(pr.error_hint(nil))
+    end)
+
+    it("spends github's retry_after when it sent one", function()
+        assert.are.equal(
+            "github rate limit hit, retry in 30s",
+            pr.error_hint({ code = "rate_limited", retry_after = 30 })
+        )
+        assert.are.equal(
+            "github rate limit hit, retry in 2m",
+            pr.error_hint({ code = "rate_limited", retry_after = 90 })
+        )
+    end)
+
+    -- a secondary limit and a graphql RATE_LIMITED both arrive without one
+    it("falls back to the static wording with no usable retry_after", function()
+        local static = "github rate limit hit, retry shortly"
+        assert.are.equal(static, pr.error_hint({ code = "rate_limited" }))
+        assert.are.equal(static, pr.error_hint({ code = "rate_limited", retry_after = 0 }))
+    end)
+
+    it("ignores retry_after on any other code", function()
+        assert.is_nil(pr.error_hint({ code = "internal", retry_after = 30 }))
+    end)
+end)


### PR DESCRIPTION
## Summary
- a graphql `UNPROCESSABLE` (an anchor outside the diff) mapped to `internal`, so a
  failure the user could fix was owned as differ's bug and surfaced with no hint. it now
  maps to `bad_request` carrying github's own message
- `addPullRequestReviewThread` answers 200 with no errors array and a null thread, so an
  out-of-diff draft comment was reported as posted and silently never existed. null
  threads are now rejected the same way
- `StartReview` returned an empty review id unguarded. `pullRequestReview` is nullable in
  the schema, exactly like the `thread` field above, and an empty id can only come from a
  null payload since `id` itself is non-null. left through, lua promises the user drafts
  while every later comment publishes
- `retry_after` was computed, serialised and unpacked but read by nothing; the
  `rate_limited` hint was a static "retry shortly". it now names the wait when github
  sends one, and keeps the static wording when it doesn't (a secondary limit and a
  graphql `RATE_LIMITED` both carry none)
- `mapHTTP`'s `transportErr` parameter was unused, `send` already handles the transport
  error before there is a response to map
- comments describing a rest comment-post path that no longer exists, in five places.
  one of them claimed a 422 already mapped to `bad_request`, which was false until this
  branch
