### PR TITLE
fix: various ux tweaks and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `]n` and `[n` step from one conflict marker to the next in the merge tool. `]x` and `[x` still step conflict to conflict
+- `:Differ pr list` completes the filters it has always accepted: `open`, `mine`, `review_requested`
+
+### Changed
+
+- With conflicts in the tree, `:Differ` and `:Differ HEAD` open the merge tool instead of a diff of files with conflict markers in them. Every other source still opens its diff, and says once that there is a merge waiting
+
+### Fixed
+
+- `<Esc>` no longer cancels the compose window, where double-tapping out of insert mode discarded a half-written comment or review summary. `q` and `:q` still cancel
+- Opening the merge tool over a live diff session took `g?` off the file you had open with `df`, leaving that window without its cheatsheet. It comes back when you return to the window
+
+## [0.1.36] — 2026-08-29
+
 ### Fixed
 
 - A comment anchored to a line outside the diff was dropped without a word when it went into a review draft, and reported as an internal error otherwise. Both now tell you the line could not be resolved

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ require("differ").setup({
     review_discard = "gD",       -- pr: discard the pending review and its drafts
     -- merge tool, bound on the result buffer
     next_conflict = "]x", prev_conflict = "[x",
+    next_marker = "]n", prev_marker = "[n",  -- step marker line to marker line
     choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
     choose_all = "<leader>ca",   -- take both (ours then theirs)
     choose_none = "<leader>cx",  -- drop the conflict region

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Set `command_alias` in `setup()` to register a shorter name for the same command
 
 | Command | Effect |
 |---|---|
+| `:Differ pr list [filter]` | List the repo's open pull requests. The filter is `open` (the default), `mine` for the ones you opened, or `review_requested` for the ones waiting on your review |
 | `:Differ mergetool [path]` | Open the merge tool on a conflicted file; no argument takes the current file, else the only conflicted one, else a picker |
 | `:Differ edit` | Edit the real file in a transient split at the cursor's mapped line, keeping the session; `:w` re-sources the diff. The `df` key |
 | `:Differ gofile` | Open the real file at the cursor's mapped line and end the session. The `de` key |

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -202,6 +202,12 @@ SESSION AND SIDECAR COMMANDS       *differ-usage-session-and-sidecar-commands*
   -----------------------------------------------------------------------
   Command                             Effect
   ----------------------------------- -----------------------------------
+  :Differ pr list [filter]            List the repo’s open pull requests.
+                                      The filter is open (the default),
+                                      mine for the ones you opened, or
+                                      review_requested for the ones
+                                      waiting on your review
+
   :Differ mergetool [path]            Open the merge tool on a conflicted
                                       file; no argument takes the current
                                       file, else the only conflicted one,

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -126,6 +126,7 @@ Table of Contents                                   *differ-table-of-contents*
         review_discard = "gD",       -- pr: discard the pending review and its drafts
         -- merge tool, bound on the result buffer
         next_conflict = "]x", prev_conflict = "[x",
+        next_marker = "]n", prev_marker = "[n",  -- step marker line to marker line
         choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
         choose_all = "<leader>ca",   -- take both (ours then theirs)
         choose_none = "<leader>cx",  -- drop the conflict region

--- a/lua/differ/command.lua
+++ b/lua/differ/command.lua
@@ -314,27 +314,50 @@ local SUB = {
     cache = M.cache,
 }
 
--- whether the working tree the current buffer (or cwd) sits in has conflicted files
----@return boolean
-local function has_conflicts()
+-- the conflicted files in the tree the current buffer (or cwd) sits in, with its root
+---@return string|nil root, string[] paths
+local function conflicts()
     local git = require("differ.git")
     local file = vim.api.nvim_buf_get_name(0)
     local anchor = (file ~= "" and vim.fn.filereadable(file) == 1) and file or vim.fn.getcwd()
     local root = git.root(anchor)
-    return root ~= nil and #git.conflicted(root) > 0
+    if not root then
+        return nil, {}
+    end
+    return root, git.conflicted(root)
+end
+
+-- whether `:Differ <fargs>` resolves to an uncommitted pairing (HEAD/index vs worktree)
+---@param fargs string[]
+---@return boolean
+local function current_state(fargs)
+    local rev = require("differ.git.rev")
+    local source = rev.source(fargs)
+    return rev.editable(source.old.label, source.new.label)
 end
 
 -- route `:Differ ...`. a recognised subcommand (layout/context/panel) takes its
 -- arg; `base` is the trunk shortcut → the whole branch vs base (`<base>...`, incl.
 -- uncommitted); anything else, including no args, is a local-diff rev spec,
 -- so `:Differ`, `:Differ main...`, `:Differ a..b` open the file panel over that
--- change set and show the first file's diff (DiffviewOpen-style). the exception: bare
--- `:Differ` mid-conflict opens the merge tool instead
+-- change set and show the first file's diff (DiffviewOpen-style). the exception: a
+-- worktree-backed source mid-conflict opens the merge tool instead
 ---@param fargs string[]
 function M.dispatch(fargs)
     local handler = fargs[1] and SUB[fargs[1]]
     if handler then
         return handler(fargs[2], fargs[3])
+    end
+    -- mid-conflict the uncommitted sources go to the merge tool, which picks its own
+    -- target (current/sole/picker); everything else opens with a hint. above the `base`
+    -- branch so `base` is hinted too, matching the `<base>...` it expands to
+    local root, conflicted = conflicts()
+    local reroute = root ~= nil and #conflicted > 0 and current_state(fargs)
+    if root then
+        require("differ.git").notify_conflicts(root, conflicted, reroute)
+    end
+    if reroute then
+        return require("differ.merge").open({})
     end
     if fargs[1] == "base" then
         local base = require("differ.git").resolve_base()
@@ -346,12 +369,6 @@ function M.dispatch(fargs)
             open_first = true,
             supersede = true,
         })
-    end
-    -- bare `:Differ` during a conflicted merge routes to the merge tool — that's
-    -- the "help me resolve this" moment. only the no-arg form reroutes; `:Differ <rev>`
-    -- still opens that diff. the merge tool picks the target (current/sole/picker)
-    if not fargs[1] and has_conflicts() then
-        return require("differ.merge").open({})
     end
     -- `:Differ <rev>` is idempotent: re-running it over a live session opens the new diff
     -- and closes the previous one (supersede). a bare `:Differ` over a live session just

--- a/lua/differ/command.lua
+++ b/lua/differ/command.lua
@@ -391,6 +391,7 @@ local VALUES = {
 -- nothing here, which is correct
 ---@type table<string, string[]>
 local PR_SUB = {
+    list = { "open", "mine", "review_requested" },
     review = { "start", "submit", "discard", "resume" },
     merge = { "squash", "merge", "rebase" },
 }

--- a/lua/differ/config.lua
+++ b/lua/differ/config.lua
@@ -163,6 +163,8 @@ M.defaults = {
         -- rather than shadowing live operators
         next_conflict = "]x", -- merge: jump to the next/prev conflict
         prev_conflict = "[x",
+        next_marker = "]n", -- merge: jump to the next/prev conflict marker line
+        prev_marker = "[n",
         choose_ours = "<leader>co", -- merge: take ours / theirs / base for the conflict
         choose_theirs = "<leader>ct",
         choose_base = "<leader>cb",

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -37,6 +37,29 @@ end
 -- how long a network git call may block the editor; `wait()` has no budget of its own
 M.fetch_timeout_ms = 20000
 
+-- roots we've already reported conflicts for, cleared once a tree is clean
+local notified = {} ---@type table<string, true>
+
+-- report conflicts and point at the merge tool
+---@param root string
+---@param paths string[]
+---@param rerouted boolean|nil
+function M.notify_conflicts(root, paths, rerouted)
+    if #paths == 0 then
+        notified[root] = nil
+        return
+    end
+    local files = #paths == 1 and "1 file" or (#paths .. " files")
+    if rerouted then
+        return notify(files .. " conflicted, opening the merge tool")
+    end
+    if notified[root] then
+        return
+    end
+    notified[root] = true
+    notify(files .. " conflicted; :Differ mergetool to resolve")
+end
+
 -- what a network call runs under. git prompts for credentials on the controlling
 -- terminal, which under nvim is one nothing can be typed into, so prompting off turns
 -- a hang into an error. read per call: the budget is settable
@@ -1454,6 +1477,9 @@ function M.panel(opts)
         if not panel:is_alive() then
             return -- the change set emptied and on_empty ended the session
         end
+        -- a merge started under a live session runs no command, so the dispatch gate
+        -- never sees it
+        M.notify_conflicts(root, M.conflicted(root))
         if view and view:is_open() and active_entry then
             -- the content shifted underneath the user; hold the cursor near where it was
             -- (the nearest hunk to its new-side line) rather than snapping to the top

--- a/lua/differ/git/rev.lua
+++ b/lua/differ/git/rev.lua
@@ -94,6 +94,18 @@ function M.source(args)
     return { old = rev_ref(first), new = WORKTREE }
 end
 
+-- whether a (old, new) label pairing puts the file on disk on the new side, editable in
+-- place: HEAD/index vs worktree, and HEAD vs index
+---@param old string
+---@param new string
+---@return boolean
+function M.editable(old, new)
+    if new == "WORKTREE" then
+        return old == "HEAD" or old == "INDEX"
+    end
+    return new == "INDEX" and old == "HEAD"
+end
+
 -- the arguments to append after `git diff --name-status -z` to list this source's
 -- changed files. expects a *resolved* source (merge_base already turned into a
 -- rev by git/init.lua), so old is always a rev:

--- a/lua/differ/merge/init.lua
+++ b/lua/differ/merge/init.lua
@@ -525,6 +525,52 @@ local function goto_conflict(dir)
     on_cursor_moved()
 end
 
+-- every marker line in the file, in order. mark_base is nil under the default
+-- conflictStyle, set under diff3/zdiff3
+---@return integer[]
+local function marker_lines()
+    local lines = {}
+    for _, r in ipairs(session.regions) do
+        lines[#lines + 1] = r.result_start
+        if r.mark_base then
+            lines[#lines + 1] = r.mark_base
+        end
+        lines[#lines + 1] = r.mark_sep
+        lines[#lines + 1] = r.result_end
+    end
+    table.sort(lines)
+    return lines
+end
+
+-- step the result cursor marker to marker, wrapping at the ends like goto_conflict
+---@param dir "next"|"prev"
+local function goto_marker(dir)
+    if not live_session() then
+        return
+    end
+    local cur = vim.api.nvim_win_get_cursor(session.result_win)[1]
+    local lines = marker_lines()
+    if #lines == 0 then
+        return notify("no conflicts remain")
+    end
+    local target
+    for _, lnum in ipairs(lines) do
+        if dir == "next" and lnum > cur then
+            target = target or lnum
+        elseif dir == "prev" and lnum < cur then
+            target = lnum
+        end
+    end
+    if not target then -- wrap
+        target = dir == "next" and lines[1] or lines[#lines]
+    end
+    vim.api.nvim_win_set_cursor(session.result_win, { target, 0 })
+    vim.api.nvim_win_call(session.result_win, function()
+        vim.cmd("normal! zz")
+    end)
+    on_cursor_moved()
+end
+
 -- the conflict at the cursor, else the first one at or below it (so a take-this from just
 -- above a block still resolves it)
 ---@param regions differ.merge.Region[]
@@ -750,6 +796,7 @@ local function show_help()
     local fmt, pair = help.fmt, help.pair
     local rows = {
         { pair(km.next_conflict, km.prev_conflict), "next / previous conflict" },
+        { pair(km.next_marker, km.prev_marker), "next / previous marker line" },
         { fmt(km.choose_ours), "take ours" },
         { fmt(km.choose_theirs), "take theirs" },
         { fmt(km.choose_base), "take base" },
@@ -930,6 +977,12 @@ function lay_out(root, relpath, model, layout)
     rb("prev_conflict", function()
         goto_conflict("prev")
     end, "differ: previous conflict")
+    rb("next_marker", function()
+        goto_marker("next")
+    end, "differ: next conflict marker")
+    rb("prev_marker", function()
+        goto_marker("prev")
+    end, "differ: previous conflict marker")
     rb("choose_ours", function()
         resolve_choice("ours")
     end, "differ: take ours")

--- a/lua/differ/ui/compose.lua
+++ b/lua/differ/ui/compose.lua
@@ -9,11 +9,11 @@
 
 local M = {}
 
--- window-local keys: <CR> submits in normal mode (insert keeps <CR> for newlines),
--- <C-s> submits from insert, q / <Esc> cancel in normal mode
+-- window-local keys: <CR> submits normal mode, default behaviour in insert mode
+-- <C-s> submits from insert, q cancels (:q too, via the autocmd below).
 local SUBMIT_N = "<CR>"
 local SUBMIT_I = "<C-s>"
-local CANCEL = { "q", "<Esc>" }
+local CANCEL = "q"
 
 -- open the compose split and put `buf` in it. stacked -> a horizontal split below the
 -- anchor (diff) window; split -> a vertical split on the far left
@@ -109,9 +109,7 @@ function M.open(opts)
 
     vim.keymap.set("n", SUBMIT_N, submit, { buffer = buf, nowait = true, desc = "differ: submit" })
     vim.keymap.set("i", SUBMIT_I, submit, { buffer = buf, desc = "differ: submit" })
-    for _, lhs in ipairs(CANCEL) do
-        vim.keymap.set("n", lhs, cancel, { buffer = buf, nowait = true, desc = "differ: cancel" })
-    end
+    vim.keymap.set("n", CANCEL, cancel, { buffer = buf, nowait = true, desc = "differ: cancel" })
     -- a wipe from any other path (e.g. :q) counts as a cancel, so the caller's state
     -- doesn't get stranded waiting on a submit that never comes. if instead a picker /
     -- :edit swapped another buffer into the compose window (the window survives holding

--- a/lua/differ/util/keymap.lua
+++ b/lua/differ/util/keymap.lua
@@ -38,4 +38,27 @@ function M.unbind(bufnr, spec, mode)
     end
 end
 
+-- true when every lhs in `spec` is mapped buffer-locally on `bufnr`
+---@param bufnr integer
+---@param spec string|string[]|false|nil
+---@param mode? string
+---@return boolean
+function M.mapped(bufnr, spec, mode)
+    if not spec or not vim.api.nvim_buf_is_valid(bufnr) then
+        return true
+    end
+    local list = type(spec) == "table" and spec or { spec }
+    local all = true
+    -- maparg, not get_keymap: it normalises <leader> / termcodes as keymap.set did
+    vim.api.nvim_buf_call(bufnr, function()
+        for _, lhs in ipairs(list) do
+            local m = vim.fn.maparg(lhs, mode or "n", false, true)
+            if vim.tbl_isempty(m) or m.buffer ~= 1 then
+                all = false
+            end
+        end
+    end)
+    return all
+end
+
 return M

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -1626,6 +1626,12 @@ function View:_open_edit_window(abs, target, tcol, anchor_win)
                 end
             end,
         })
+        vim.api.nvim_create_autocmd("WinEnter", {
+            group = self._edit_group,
+            callback = function()
+                self:_rearm_edit_map()
+            end,
+        })
     end
     vim.cmd.edit(vim.fn.fnameescape(abs))
     if target then
@@ -1635,11 +1641,34 @@ function View:_open_edit_window(abs, target, tcol, anchor_win)
     -- edit window (shadows native g?/rot13, inert in this review flow). recorded
     -- because that buffer is the user's: teardown has to take the map off by hand
     self:_drop_edit_map() -- a reused edit window may hold an earlier file's map
-    local buf = vim.api.nvim_get_current_buf()
+    self:_bind_edit_map(vim.api.nvim_get_current_buf())
+end
+
+-- bind g? on `buf` and record it: teardown has to unbind by hand on a buffer we don't own
+---@param buf integer
+function View:_bind_edit_map(buf)
     bind(buf, self.keymaps.help, function()
         self:show_help()
     end, "differ: keymap help")
     self._edit_map = { buf = buf, spec = self.keymaps.help }
+end
+
+-- the merge tool loads the same real file, so on a conflicted path it shares this bufnr
+-- and its teardown takes g? off. re-arm on focus, leaving a live merge tool's own bind
+function View:_rearm_edit_map()
+    local m = self._edit_map
+    if not m or not self.edit_win or vim.api.nvim_get_current_win() ~= self.edit_win then
+        return
+    end
+    -- only the buffer we bound; a file swapped into the window isn't ours to map
+    if
+        not vim.api.nvim_buf_is_valid(m.buf)
+        or vim.api.nvim_win_get_buf(self.edit_win) ~= m.buf
+        or keymap.mapped(m.buf, m.spec)
+    then
+        return
+    end
+    self:_bind_edit_map(m.buf)
 end
 
 -- take our g? back off the real file buffer. it isn't ours to delete, so nothing

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -1453,11 +1453,7 @@ end
 -- sources (rev↔rev, history, PR) never do
 ---@return boolean
 function View:_editable_source()
-    local old, new = self.model.old_rev, self.model.new_rev
-    if new == "WORKTREE" then
-        return old == "HEAD" or old == "INDEX"
-    end
-    return new == "INDEX" and old == "HEAD"
+    return require("differ.git.rev").editable(self.model.old_rev, self.model.new_rev)
 end
 
 -- edit-in-review: pop the real working-tree file into a transient editable

--- a/test/nvim/command_spec.lua
+++ b/test/nvim/command_spec.lua
@@ -109,18 +109,27 @@ describe("command base shortcut", function()
 end)
 
 describe("command bare dispatch reroute", function()
+    -- the hint fires once per conflict episode, and that flag outlives a test
+    before_each(function()
+        require("differ.git").notify_conflicts("/repo", {})
+    end)
+
     -- stub root + conflicted so the routing is checked without a repo; record which
     -- surface dispatch reaches
     local function run(args, conflicted)
         local git = require("differ.git")
         local merge = require("differ.merge")
         local sr, sc, sp, so = git.root, git.conflicted, git.panel, merge.open
+        local sb = git.resolve_base
         local routed = {}
         git.root = function()
             return "/repo"
         end
         git.conflicted = function()
             return conflicted
+        end
+        git.resolve_base = function() -- `base` needs a trunk to expand against
+            return "origin/HEAD"
         end
         git.panel = function()
             routed.panel = true
@@ -130,6 +139,7 @@ describe("command bare dispatch reroute", function()
         end
         command.dispatch(args)
         git.root, git.conflicted, git.panel, merge.open = sr, sc, sp, so
+        git.resolve_base = sb
         return routed
     end
 
@@ -145,10 +155,70 @@ describe("command bare dispatch reroute", function()
         assert.is_nil(routed.merge)
     end)
 
-    it("never reroutes :Differ <rev>, even mid-conflict", function()
-        local routed = run({ "main..." }, { "f.txt" })
+    -- the reroute follows the question, not the arg count: `:Differ HEAD` asks the same
+    -- thing the bare form does, so it gets the same answer
+    it("routes :Differ HEAD to the merge tool", function()
+        local routed = run({ "HEAD" }, { "f.txt" })
+        assert.is_true(routed.merge)
+        assert.is_nil(routed.panel)
+    end)
+
+    -- a named rev or range asked something else; it opens, with a hint. `base` included:
+    -- it stands for `<base>...`, and the two spellings must not diverge
+    for _, args in ipairs({ { "HEAD~1" }, { "main..." }, { "base" }, { "a..b" }, { "a", "b" } }) do
+        it("keeps :Differ " .. table.concat(args, " ") .. " on the diff", function()
+            local routed = run(args, { "f.txt" })
+            assert.is_true(routed.panel)
+            assert.is_nil(routed.merge)
+        end)
+    end
+
+    it("keeps :Differ HEAD on the diff when nothing is conflicted", function()
+        local routed = run({ "HEAD" }, {})
         assert.is_true(routed.panel)
         assert.is_nil(routed.merge)
+    end)
+
+    it("says why it rerouted", function()
+        _G.notifs = {}
+        run({ "HEAD" }, { "f.txt", "g.txt" })
+        assert.are.equal("differ: 2 files conflicted, opening the merge tool", _G.notifs[1].msg)
+    end)
+
+    it("points a committed range at the merge tool without blocking it", function()
+        _G.notifs = {}
+        local routed = run({ "a..b" }, { "f.txt" })
+        assert.is_true(routed.panel)
+        assert.are.equal(
+            "differ: 1 file conflicted; :Differ mergetool to resolve",
+            _G.notifs[1].msg
+        )
+    end)
+
+    it("tracks the hint per repo, so alternating trees don't re-nag", function()
+        local git = require("differ.git")
+        _G.notifs = {}
+        git.notify_conflicts("/a", { "f.txt" })
+        git.notify_conflicts("/b", { "f.txt" })
+        git.notify_conflicts("/a", { "f.txt" }) -- back to a: already spoken for
+        assert.are.equal(2, #_G.notifs)
+        git.notify_conflicts("/b", {}) -- b resolved; a's hint is untouched
+        git.notify_conflicts("/a", { "f.txt" })
+        assert.are.equal(2, #_G.notifs)
+        git.notify_conflicts("/b", { "f.txt" }) -- a fresh merge in b speaks again
+        assert.are.equal(3, #_G.notifs)
+        git.notify_conflicts("/a", {})
+        git.notify_conflicts("/b", {})
+    end)
+
+    it("hints once per conflict episode, not once per command", function()
+        _G.notifs = {}
+        run({ "a..b" }, { "f.txt" })
+        run({ "a..b" }, { "f.txt" })
+        assert.are.equal(1, #_G.notifs)
+        run({ "a..b" }, {}) -- resolved: the next merge speaks again
+        run({ "a..b" }, { "f.txt" })
+        assert.are.equal(2, #_G.notifs)
     end)
 end)
 

--- a/test/nvim/compose_spec.lua
+++ b/test/nvim/compose_spec.lua
@@ -1,0 +1,100 @@
+-- runs under headless nvim: the shared compose window (comments, replies, review
+-- summaries) in isolation. compose.open needs no session and no sidecar, so each case
+-- opens it directly, drives a buffer-local key, and asserts on what it fired
+
+require("differ").setup({})
+
+local compose = require("differ.ui.compose")
+
+---@param key string
+local function feed(key)
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(key, true, false, true), "x", false)
+end
+
+---@param opts table|nil
+local function open(opts)
+    local state = { submitted = nil, cancelled = false }
+    local handle = compose.open(vim.tbl_extend("force", {
+        title = "Comment",
+        on_submit = function(text)
+            state.submitted = text
+        end,
+        on_cancel = function()
+            state.cancelled = true
+        end,
+    }, opts or {}))
+    state.win = vim.api.nvim_get_current_win()
+    state.buf = vim.api.nvim_get_current_buf()
+    state.handle = handle
+    vim.cmd("stopinsert") -- open() lands in insert; these keys are normal-mode
+    return state
+end
+
+---@param lines string[]
+local function type_body(state, lines)
+    vim.api.nvim_buf_set_lines(state.buf, 0, -1, false, lines)
+end
+
+describe("the compose window", function()
+    before_each(function()
+        vim.cmd("silent! only")
+    end)
+
+    it("keeps the body on <Esc>, so leaving insert never discards a draft", function()
+        local state = open()
+        type_body(state, { "half a thought" })
+
+        feed("<Esc>")
+        feed("<Esc>") -- the reflex double-tap out of insert
+
+        assert.is_true(vim.api.nvim_win_is_valid(state.win))
+        assert.is_false(state.cancelled)
+        assert.are.same({ "half a thought" }, vim.api.nvim_buf_get_lines(state.buf, 0, -1, false))
+        state.handle.close()
+    end)
+
+    it("binds no normal-mode <Esc> on the compose buffer", function()
+        local state = open()
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(state.buf, "n")) do
+            assert.are_not.equal("<Esc>", m.lhs)
+        end
+        state.handle.close()
+    end)
+
+    it("cancels on q", function()
+        local state = open()
+        type_body(state, { "abandon this" })
+
+        feed("q")
+
+        assert.is_false(vim.api.nvim_win_is_valid(state.win))
+        assert.is_true(state.cancelled)
+    end)
+
+    it("cancels on :q, via the close autocmd", function()
+        local state = open()
+
+        vim.api.nvim_win_close(state.win, true)
+
+        assert.is_true(vim.wait(1000, function()
+            return state.cancelled
+        end, 10))
+    end)
+
+    it("submits the body on <CR>", function()
+        local state = open()
+        type_body(state, { "ship it", "", "looks right" })
+
+        feed("<CR>")
+
+        assert.are.equal("ship it\n\nlooks right", state.submitted)
+        assert.is_false(vim.api.nvim_win_is_valid(state.win))
+        assert.is_false(state.cancelled)
+    end)
+
+    it("seeds the body from opts.initial, as the conflict retry path does", function()
+        local state = open({ initial = "first attempt" })
+        assert.are.same({ "first attempt" }, vim.api.nvim_buf_get_lines(state.buf, 0, -1, false))
+        state.handle.close()
+    end)
+end)

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -1227,3 +1227,67 @@ describe(":Differ mergetool teardown", function()
         assert.is_nil(merge.current()) -- and takes the session down with it
     end)
 end)
+
+-- the merge result column and the `df` edit window load the same real file, so on a
+-- conflicted path they share a bufnr and the second g? bind replaces the first
+describe("g? over a buffer the merge tool shares", function()
+    local git_src = require("differ.git")
+    local Panel = require("differ.panel")
+
+    ---@return table view, integer buf
+    local function edit_window_over(root)
+        vim.cmd.edit(root .. "/f.txt")
+        git_src.panel({ rev = {}, open_first = true })
+        local p = assert(Panel.current())
+        local view = require("differ.view").for_buf(vim.api.nvim_win_get_buf(p.origin_win))
+        view:edit_file() -- the df key: the real file in a transient split
+        return view, vim.api.nvim_get_current_buf()
+    end
+
+    -- the desc of whatever holds g? on `buf`, so a failure names the owner
+    ---@return string
+    local function help_desc(buf)
+        for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+            if m.lhs == "g?" then
+                return m.desc or "<no desc>"
+            end
+        end
+        return "<unmapped>"
+    end
+
+    after_each(function()
+        if merge.current() then
+            merge.close()
+        end
+        local p = Panel.current()
+        if p then
+            p:close()
+        end
+    end)
+
+    it("restores the diff session's g? once the merge tool closes", function()
+        local root = conflict_repo()
+        local _, edit_buf = edit_window_over(root)
+        assert.are.equal("differ: keymap help", help_desc(edit_buf))
+        local edit_win = vim.api.nvim_get_current_win()
+
+        merge.open({})
+        assert.are.equal(edit_buf, assert(merge.current()).result_buf) -- the shared bufnr
+        merge.close()
+
+        vim.api.nvim_set_current_win(edit_win) -- focus fires the re-arm
+        assert.are.equal("differ: keymap help", help_desc(edit_buf))
+    end)
+
+    it("leaves g? to the merge tool while its session is live", function()
+        local root = conflict_repo()
+        local _, edit_buf = edit_window_over(root)
+        local edit_win = vim.api.nvim_get_current_win()
+
+        merge.open({})
+        local merge_desc = help_desc(edit_buf)
+        vim.api.nvim_set_current_win(edit_win)
+
+        assert.are.equal(merge_desc, help_desc(edit_buf)) -- not stolen back mid-merge
+    end)
+end)

--- a/test/nvim/mergetool_spec.lua
+++ b/test/nvim/mergetool_spec.lua
@@ -26,8 +26,11 @@ local function write(path, content)
     fd:close()
 end
 
--- a repo where merging `feature` into `main` conflicts on f.txt (both changed line 2)
-local function conflict_repo()
+-- a repo where merging `feature` into `main` conflicts on f.txt (both changed line 2).
+-- `style` picks the merge.conflictStyle: nil for git's default, "diff3" to get the
+-- ||||||| base marker as well
+---@param style string|nil
+local function conflict_repo(style)
     local root = vim.fn.tempname()
     vim.fn.mkdir(root, "p")
     git_ok(root, "init", "-q")
@@ -40,7 +43,11 @@ local function conflict_repo()
     git_ok(root, "checkout", "-q", "main")
     write(root .. "/f.txt", "a\nOURS\nc\n")
     git_ok(root, "commit", "-q", "-am", "ours")
-    git(root, "merge", "feature") -- conflicts: exit non-zero, expected
+    if style then
+        git(root, "-c", "merge.conflictStyle=" .. style, "merge", "feature")
+    else
+        git(root, "merge", "feature") -- conflicts: exit non-zero, expected
+    end
     return root
 end
 
@@ -474,6 +481,44 @@ describe(":Differ mergetool navigation", function()
         if merge.current() then
             merge.close()
         end
+    end)
+
+    it("steps marker to marker with ]n and wraps, leaving ]x alone", function()
+        local root = conflict_repo_multi()
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = merge.current()
+        local function cur()
+            return vim.api.nvim_win_get_cursor(s.result_win)[1]
+        end
+        -- default conflictStyle: no ||||||| line, so three markers per conflict
+        local first = s.regions[1]
+        assert.is_nil(first.mark_base)
+        assert.are.equal(first.result_start, cur())
+        fire(s.result_buf, "differ: next conflict marker")
+        assert.are.equal(first.mark_sep, cur())
+        fire(s.result_buf, "differ: next conflict marker")
+        assert.are.equal(first.result_end, cur())
+        fire(s.result_buf, "differ: next conflict marker")
+        assert.are.equal(s.regions[2].result_start, cur()) -- straight into the next block
+
+        fire(s.result_buf, "differ: previous conflict marker")
+        assert.are.equal(first.result_end, cur())
+
+        vim.api.nvim_win_set_cursor(s.result_win, { s.regions[3].result_end, 0 })
+        fire(s.result_buf, "differ: next conflict marker")
+        assert.are.equal(first.result_start, cur()) -- wrapped to the first marker
+    end)
+
+    it("includes the base marker under diff3", function()
+        local root = conflict_repo("diff3")
+        vim.cmd.edit(root .. "/f.txt")
+        merge.open({})
+        local s = merge.current()
+        local r = s.regions[1]
+        assert.is_not_nil(r.mark_base) -- diff3 adds the ||||||| line
+        fire(s.result_buf, "differ: next conflict marker")
+        assert.are.equal(r.mark_base, vim.api.nvim_win_get_cursor(s.result_win)[1])
     end)
 
     it("walks every conflict with ]x and wraps at the end", function()

--- a/test/unit/rev_spec.lua
+++ b/test/unit/rev_spec.lua
@@ -1,5 +1,35 @@
 local rev = require("differ.git.rev")
 
+describe("git.rev.editable", function()
+    -- the daily staging sources put the file on disk on the new side; that pairing is
+    -- what binds df, and what reroutes to the merge tool mid-conflict
+    it("accepts the staging pairings", function()
+        assert.is_true(rev.editable("HEAD", "WORKTREE"))
+        assert.is_true(rev.editable("INDEX", "WORKTREE"))
+        assert.is_true(rev.editable("HEAD", "INDEX"))
+    end)
+
+    it("rejects a committed rev on either side", function()
+        assert.is_false(rev.editable("HEAD~1", "WORKTREE"))
+        assert.is_false(rev.editable("main...", "WORKTREE"))
+        assert.is_false(rev.editable("abc", "def"))
+        assert.is_false(rev.editable("INDEX", "HEAD"))
+    end)
+
+    it("agrees with what source() resolves the arg forms to", function()
+        local function editable(args)
+            local s = rev.source(args)
+            return rev.editable(s.old.label, s.new.label)
+        end
+        assert.is_true(editable({}))
+        assert.is_true(editable({ "HEAD" }))
+        assert.is_false(editable({ "HEAD~1" }))
+        assert.is_false(editable({ "main..." }))
+        assert.is_false(editable({ "abc..def" }))
+        assert.is_false(editable({ "abc", "def" }))
+    end)
+end)
+
 describe("git.rev.source", function()
     it("defaults to HEAD vs worktree (uncommitted changes)", function()
         local s = rev.source({})


### PR DESCRIPTION
## Summary
- mid-conflict, `:Differ` and `:Differ HEAD` now open the merge tool rather than diff view by default.
every other source still opens its diff and reports the merge once per repo
- `:Differ HEAD` behaved oppositely to bare `:Differ` despite resolving to the same
source, and `:Differ base` never reached the conflict gate at all, sitting above it
in the dispatcher
- the diff session re-arms its `g?` on focus. the merge tool loads the same real file,
so on a conflicted path it shares the bufnr and its teardown took the key off
- `<Esc>` no longer cancels the compose window, where a double-tap out of insert mode
discarded a half-written comment or review summary. `q` and `:q` still cancel
- `]n` / `[n` step conflict marker to marker in the merge tool. `]x` / `[x` unchanged
- `:Differ pr list` completes `open` / `mine` / `review_requested`, plumbed end to end
since it was written but reachable only if you already knew
