### PR TITLE
docs: split recipes and troubleshooting out of the readme

### DIFF
--- a/.github/workflows/vimdoc.yml
+++ b/.github/workflows/vimdoc.yml
@@ -1,9 +1,10 @@
 name: Vimdoc
 
-# doc/differ.txt is generated from README.md, so a PR touching the readme has to carry
-# the regenerated vimdoc with it. this only checks that, it never commits: a commit
-# pushed here with GITHUB_TOKEN triggers no workflows, which leaves every required
-# check parked at action_required on the new head and the pr unmergeable.
+# every doc/*.txt is generated from its markdown source (README, RECIPES, TROUBLESHOOTING),
+# so a PR touching one has to carry the regenerated vimdoc with it. this only checks
+# that, it never commits: a commit pushed here with GITHUB_TOKEN triggers no workflows,
+# which leaves every required check parked at action_required on the new head and the
+# pr unmergeable.
 #
 # `make vimdoc` fetches its own pinned panvimdoc and pandoc into .tools and pins the
 # locale, and the header carries no datestamp, so the output is reproducible and a
@@ -33,12 +34,15 @@ jobs:
           path: .tools
           key: vimdoc-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
-      - name: Regenerate doc/differ.txt
+      - name: Regenerate the vimdocs
         run: make vimdoc
 
       - name: Check it matches what's committed
         run: |
-          if ! git diff --exit-code -- doc/differ.txt; then
-            echo "::error::doc/differ.txt is stale; run 'make vimdoc' and commit the result"
+          # --porcelain, not `git diff`: an added source doc leaves its generated
+          # .txt untracked, which a diff of tracked paths alone would pass
+          if [ -n "$(git status --porcelain doc/)" ]; then
+            git status --short doc/
+            echo "::error::the vimdoc is stale; run 'make vimdoc' and commit the result"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `:h differ-recipes` and `:h differ-troubleshooting`: launchers, the statusline drop-in and the highlight groups in one, diagnosis and the plugin-interaction edge cases in the other
+- `:h differ` carries the installation section, including the two hooks mini.deps needs to rebuild the sidecar on update
+
+## [0.1.38] — 2026-09-01
+
+### Added
+
 - `panel.icons = false` turns off filetype devicons in the file panel
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,17 +36,17 @@ Its stderr is piped to the client, never to your terminal. `:checkhealth differ`
 
 ## Docs
 
-`doc/differ.txt` is generated from `README.md`, so a change to the readme has to carry the regenerated vimdoc with it:
+Each `doc/*.txt` is generated from a markdown source: `differ.txt` from `README.md`, `differ-recipes.txt` from `RECIPES.md`, `differ-troubleshooting.txt` from `TROUBLESHOOTING.md`. A change to any of them has to carry the regenerated vimdoc with it:
 
 ```sh
-make vimdoc   # rewrites doc/differ.txt (needs pandoc 3.10.1 on PATH)
+make vimdoc   # rewrites every doc/*.txt (needs pandoc 3.10.1 on PATH)
 ```
 
-Commit both files together. CI regenerates and fails if what's committed doesn't match, so a readme change on its own turns the Vimdoc job red.
+Commit the source and its generated doc together. CI regenerates and fails if what's committed doesn't match, so a readme change on its own turns the Vimdoc job red.
 
 pandoc is pinned because its output shifts between releases, and `make vimdoc` refuses to run against any other version rather than producing a doc CI will reject. panvimdoc is pinned too, fetched into gitignored `.tools/` on first use like lua_ls. The recipe forces `LC_ALL=C`: the panvimdoc writer wraps with Lua patterns, whose `%s` class is locale-dependent, and a UTF-8 locale on BSD libc counts `0xa0` as whitespace and splits the no-break space pandoc emits after "e.g." into U+FFFD.
 
-Regions fenced with `<!-- panvimdoc-ignore-start -->` / `<!-- panvimdoc-ignore-end -->` in the readme (badges, installation, architecture, licence) are left out of the vimdoc, which keeps `:h differ` a usage reference.
+Regions fenced with `<!-- panvimdoc-ignore-start -->` / `<!-- panvimdoc-ignore-end -->` are left out of the vimdoc. In the readme that's the badges, the nav line and the demo, so `:h differ` opens on why it exists.
 
 ## UI changes
 

--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,8 @@ go-fmt-check: ## Verify Go formatting without writing
 ##@ Docs
 # ──────────────────────────────────────────────────────────────────────────────
 
-vimdoc: $(PANVIMDOC_BIN) $(PANDOC_BIN) ## Regenerate doc/differ.txt from README.md
-	@$(INFO) "Generating doc/differ.txt (panvimdoc $(PANVIMDOC_VERSION), pandoc $(PANDOC_VERSION))"
+vimdoc: $(PANVIMDOC_BIN) $(PANDOC_BIN) ## Regenerate doc/*.txt from the markdown sources
+	@$(INFO) "Generating doc/*.txt (panvimdoc $(PANVIMDOC_VERSION), pandoc $(PANDOC_VERSION))"
 	@# LC_ALL=C keeps the nbsp pandoc puts after "e.g." intact: the writer wraps with
 	@# lua patterns, and %s is locale-dependent, so bsd libc in a utf-8 locale counts
 	@# 0xa0 as space and splits it into u+fffd. --description replaces the header's
@@ -194,16 +194,19 @@ vimdoc: $(PANVIMDOC_BIN) $(PANDOC_BIN) ## Regenerate doc/differ.txt from README.
 	@# hardcodes /scripts when it's set, over --scripts-dir. output prints on failure.
 	@# panvimdoc.sh calls `pandoc` by name, so the pinned one leads on PATH: pandoc's
 	@# output differs between releases, and a brew upgrade would otherwise decide it
-	@out=$$(PATH="$(CURDIR)/$(PANDOC_DIR)/bin:$$PATH" LC_ALL=C GITHUB_ACTIONS=false bash $(PANVIMDOC_BIN) \
-		--scripts-dir "$(PANVIMDOC_DIR)/scripts" \
-		--project-name differ \
-		--input-file README.md \
-		--description "For Neovim >= 0.12" \
-		--toc true \
-		--demojify true \
-		--dedup-subheadings true \
-		--shift-heading-level-by -1 2>&1) || { printf '%s\n' "$$out"; exit 1; }
-	@$(OK) "doc/differ.txt regenerated"
+	@set -e; for pair in "differ:README.md" "differ-recipes:RECIPES.md" "differ-troubleshooting:TROUBLESHOOTING.md"; do \
+		name=$${pair%%:*}; input=$${pair#*:}; \
+		out=$$(PATH="$(CURDIR)/$(PANDOC_DIR)/bin:$$PATH" LC_ALL=C GITHUB_ACTIONS=false bash $(PANVIMDOC_BIN) \
+			--scripts-dir "$(PANVIMDOC_DIR)/scripts" \
+			--project-name "$$name" \
+			--input-file "$$input" \
+			--description "For Neovim >= 0.12" \
+			--toc true \
+			--demojify true \
+			--dedup-subheadings true \
+			--shift-heading-level-by -1 2>&1) || { printf '%s\n' "$$out"; exit 1; }; \
+		$(OK) "doc/$$name.txt regenerated"; \
+	done
 	@# doc/tags is gitignored and lazy only generates helptags for plugins it installed,
 	@# never for a `dir` dev checkout, so :help differ breaks in-tree without this. skipped
 	@# where there's no nvim (ci runs pandoc only), and invisible to ci's differ.txt diff

--- a/README.md
+++ b/README.md
@@ -12,51 +12,33 @@
 [![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?style=flat&logo=lua&logoColor=white)](https://www.lua.org)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go&logoColor=white)](https://go.dev)
 [![Neovim](https://img.shields.io/badge/Neovim-0.12+-57A143?style=flat&logo=neovim&logoColor=white)](https://neovim.io)
-[![macOS](https://img.shields.io/badge/macOS-supported-6e7681?style=flat&logo=apple&logoColor=white)]()
-[![Linux](https://img.shields.io/badge/Linux-supported-6e7681?style=flat&logo=linux&logoColor=white)]()
 
-[Features](#features) · [Installation](#installation) · [Configuration](#configuration) · [Usage](#usage)
+[Installation](#installation) · [Configuration](#configuration) · [Usage](#usage) · [Recipes](RECIPES.md)
 
 </div>
 
 ![differ demo](.demo/demo.gif)
 
----
+<!-- panvimdoc-ignore-end -->
 
-You can already get most of this from existing plugins, just not all of it in one tool with the same feel. I wanted to see how feasible it would be, and what the result *could* feel like.
+## Why this exists
 
-Everything runs through one renderer, so staging a hunk and replying to a review comment behave like the same tool, because they are. The default view is a stacked dual-rail layout: one scroll surface with old and new lines interleaved per hunk and both line numbers in the gutter. Side-by-side is a keystroke away from the same model. Word-level highlighting and Treesitter syntax are on by default.
+You can already get most of the functionality from combining some existing plugins (I was using diffview + octo.nvim with custom keymaps), but for me, it just never felt like a cohesive experience. I wanted to see how feasible it would be to build everything together, and what the result *could* feel like.
+
+Everything runs through one renderer, so staging a hunk and replying to a review comment behave like the same tool; that covers local diffs against any revspec, file history for a single file or a branch range, hunk and file-level staging, PR review with inline threads and all of the lifecycle of a PR around it, and a 3-way (or 4-way if you choose) merge tool that resolves into the working-tree file. All of these views get data from the same diff engine (using `vim.text.diff()`).
+
+The default view is a stacked dual-rail layout: one scroll surface with old and new lines interleaved per hunk. Side-by-side layout is available in the config or with a toggle in-session. Word-level highlighting and Treesitter syntax are on by default, and every surface is real buffer lines rather than virtual text, so search, yank and motions work as normal.
 
 The GitHub side runs in a separate process rather than the editor, so opening a PR or posting a review doesn't block on the API, and results are cached between calls.
 
-<!-- panvimdoc-ignore-end -->
-
-## Features
-
-- Stacked dual-rail layout: one scroll surface, old and new interleaved
-- Side-by-side layout from the same hunk model, toggled at runtime
-- PR review in the diff: inline threads, drafts, resolve, viewed-state
-- PR lifecycle: merge, checkout, ready/draft, close, and CI checks
-- File panel with the changed-file tree, status icons, and +/- counts
-- Hunk- and file-level staging from the diff or the panel
-- File history for single files and branch ranges, commit by commit
-- 3-way/4-way merge tool, resolved into the working-tree file
-- Word-level highlighting and Treesitter syntax, both on by default
-- Real buffer lines, so search, yank, and motions work as normal
-- One diff engine (`vim.text.diff()`, histogram) shared by every source
-
 ## Requirements
 
-- Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
-- `termguicolors` on - nvim enables it itself on any terminal it detects as 24-bit capable, so this is usually already true; without it the diff, merge and thread highlights render uncoloured
-- git on `PATH`
+- Neovim 0.12+ and git
+- `termguicolors` on (usually already the case; without it the highlights render uncoloured)
+- For PR review: Go, make, and an authenticated `gh`
 - A Treesitter parser for the languages you diff (optional)
-- For PR review: Go + make on `PATH`, and `gh` authenticated
-- Local diffs need none of the above beyond git
 
 `:checkhealth differ` reports which of these are satisfied.
-
-<!-- panvimdoc-ignore-start -->
 
 ## Installation
 
@@ -72,13 +54,13 @@ The GitHub side runs in a separate process rather than the editor, so opening a 
 }
 ```
 
-`setup()` is only needed to change defaults and register highlight groups eagerly. The `:Differ` command is registered on startup either way.
+`setup()` is only needed to change defaults and register highlight groups eagerly.
 
-The `build` hook compiles the Go sidecar (used by PR review) on install and update. It needs Go and make on `PATH`; local diffs work without it, so you can drop the hook if you only want local diffing.
+The `build` hook compiles the Go sidecar (used by PR review) on install and update. It needs Go and make on `PATH`; if you're only here for local diffs, feel free to drop the hook.
 
 ### vim.pack
 
-Neovim 0.12+. `vim.pack` has no inline build key, so register a `PackChanged` hook (before `vim.pack.add`, so it also runs on first install):
+Neovim 0.12+. `vim.pack` has no inline build key, so the best solution is to register a `PackChanged` hook (before `vim.pack.add`, so it also runs on first install):
 
 ```lua
 vim.api.nvim_create_autocmd("PackChanged", {
@@ -93,13 +75,29 @@ vim.pack.add({ "https://github.com/undont/differ.nvim" })
 require("differ").setup()
 ```
 
-Pin a release with `{ src = "https://github.com/undont/differ.nvim", version = "v0.1.1" }`.
+You can also pin a release with `{ src = "https://github.com/undont/differ.nvim", version = "v0.1.1" }`, or follow a range with `version = vim.version.range("0.1")`.
+
+### [mini.deps](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-deps.md)
+
+mini.deps splits the build hook in two, so differ needs both. `post_install` fires on the initial clone and `post_checkout` on every update, so wiring only the first leaves updates on the binary built at install time, and only the second never builds one at all:
+
+```lua
+local build = function(args)
+  vim.system({ "make", "go-build" }, { cwd = args.path }):wait()
+end
+
+MiniDeps.add({
+  source = "undont/differ.nvim",
+  hooks = { post_install = build, post_checkout = build },
+})
+require("differ").setup()
+```
 
 ### Other managers
 
-differ's only install step is building the Go sidecar, so point your manager's build / post-update hook at `make go-build`: pckr `run`, vim-plug `do`, or the equivalent.
+differ's only install step is building the Go sidecar, so point your manager's build hook at `make go-build`. Managers with one hook covering both install and update need a single key: pckr `run`, vim-plug `do`, paq `build`.
 
-<!-- panvimdoc-ignore-end -->
+Wiring the install hook but not the update one leaves a stale binary. If you're in doubt, `:Differ sidecar` reports which one is actually running.
 
 ## Configuration
 
@@ -107,102 +105,109 @@ differ's only install step is building the Go sidecar, so point your manager's b
 
 ```lua
 require("differ").setup({
-  layout = "stacked",            -- "stacked" | "split", toggleable per-view
+  base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
+  relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
+  command_alias = nil,           -- extra :command(s) routing to :Differ, e.g. "D" or { "D", "Df" }
+  panel = {                      -- can also be overridden with :Differ panel <position> in-session
+    position = "right",          -- "bottom" | "top" | "left" | "right"
+    height = 9,                  -- only applies to top/bottom
+    width = 35,                  -- only applies to left/right
+    listing = "tree",            -- "tree" | "name" (tree/flat list)
+    icons = true,                -- (requires nvim-web-devicons)
+    progress = true,             -- list position meter in the panel winbar
+  },
+
+  layout = "stacked",            -- "stacked" | "split" (can be toggled with :Differ layout in-session)
   context = math.huge,           -- fold threshold; math.huge = whole file, no folds
   wrap = true,                   -- soft-wrap long lines in the diff view
-  diff_counter = true,           -- "hunk K/N" counter in the diff window's winbar
-  cursorline_tint = true,        -- tint the cursor line by add/remove so the change
-                                 -- kind reads under the cursor; false = plain neutral
-  deep_diff = {
+  diff_counter = true,           -- hunk counter in the diff window's winbar
+  cursorline_tint = true,        -- allow the cursorline to inherit the add/delete highlights
+  deep_diff = {                  -- word-level diffing
     enabled = true,
     granularity = "word",        -- "word" | "char"
     similarity_threshold = 0.5,  -- line-pairing cutoff for word-level diffing
   },
-  comments = {                   -- pr review threads
+
+  history = {                    -- log/history sidebar default placement/size
+    position = "bottom",         -- "bottom" | "top" | "left" | "right"
+    height = 10,                 -- only applies to top/bottom
+    width = 40,                  -- only applies to left/right
+  },
+
+  merge = {                      -- no override in-session
+    layout = "default",          -- "default" (ours | theirs) | "diff4" (adds base)
+  },
+
+  comments = {                   -- in pr review threads
     display = "peek",            -- "expanded" | "peek" | "markers"
                                  -- "expanded" doesn't collapse any, all stay open
                                  -- "peek" has boxes below the line, opening on the cursor's row
                                  -- "markers" gives eol markers with a float, which split
                                  -- always does anyway
   },
-  panel = {                      -- file panel default placement/size; `:Differ panel`
-                                 -- and the runtime Panel.current() setters override per-session
-    position = "right",          -- "bottom" | "top" | "left" | "right"
-    height = 9,                  -- top/bottom
-    width = 35,                  -- left/right
-    listing = "tree",            -- "tree" | "name"
-    icons = true,                -- filetype devicons in the file list, when
-                                 -- nvim-web-devicons is installed
-    progress = true,             -- "file K/N" position meter in the panel winbar
-  },
-  history = {                    -- log/history sidebar default placement/size
-    position = "bottom",
-    height = 10,                 -- top/bottom
-    width = 40,                  -- left/right
-  },
-  merge = {                      -- merge tool pane layout; no per-invocation override
-    layout = "default",          -- "default" (ours | theirs) | "diff4" (adds base)
-  },
-  keymaps = {                    -- one flat action -> lhs table, shared across the diff,
-    -- a value is a string, a list of strings, or false to disable. override globally
-    -- here, or scope to one surface via a diff/panel/history/merge = {...} subtable
-    next_hunk = "]c",            -- diff, panel, history
+  sidecar_bin = nil,             -- override the go sidecar path
+
+  keymaps = {
+    next_hunk = "]c",
     prev_hunk = "[c",
-    next_file = "]f",            -- diff; panel/history step the selection
+    next_file = "]f",
     prev_file = "[f",
-    first_file = "gg",           -- panel/history: jump to the first/last file or commit
+    first_file = "gg",
     last_file = "G",
-    next_section = "]]",         -- panel: sections (Staged/Unstaged); history: commits
+    next_section = "]]",         -- sections in the panel, commits in log
     prev_section = "[[",
     scroll_down = "f",           -- shadows native f/b; set false to restore
     scroll_up = "b",
-    select = { "<CR>", "o" },    -- diff, pr overview, panel, history
-    details = "K",               -- history: float the full commit message
-    help = "g?",                 -- diff, pr overview, panel, history
-    toggle_listing = "i",        -- panel: toggle tree / name
-    close_node = "c",            -- panel: collapse the dir under the cursor; history: the commit
-    close_all = "C",             -- panel/history: collapse every dir / commit
-    open_all = "O",              -- panel/history: expand every dir / commit
-    stage = "s", unstage = "u",  -- diff (hunk-level), panel (file-level)
+    select = { "<CR>", "o" },
+    help = "g?",
+    close = "dc",                -- end the session
+    toggle_panel = "dd",         -- hide/show the file panel
+
+    -- diffs
+    toggle_layout = "dl",        -- flip between stacked / split
+    more_context = "d=", less_context = "d-",
+    stage = "s", unstage = "u",  -- stage/unstage[all] work on hunks/files (diff buffer/panel)
     stage_all = "S", unstage_all = "U",
-    more_context = "d=", less_context = "d-",  -- diff
-    edit_file = "df",            -- diff: edit-in-review; pr diff: worktree split beside the pinned diff
-    goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
-    discard = "X",               -- diff (revert a hunk), panel (discard a file)
-    refresh = "R",               -- panel
-    toggle_fold = "za",          -- history (range mode)
-    close = "dc",                -- diff/panel/history: end the session
-    toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
-    toggle_layout = "dl",        -- diff: flip stacked / split
-    -- pr review (pr diff + panel)
-    toggle_viewed = "<Tab>",     -- pr panel: flip the github viewed checkbox
-    next_unviewed = "]u", prev_unviewed = "[u",  -- pr panel + diff
-    next_thread = "]t", prev_thread = "[t",      -- pr diff
-    comment = "ga",              -- pr diff: comment on the line (normal) or selection (visual)
-    reply = "gp",                -- pr diff: reply to the thread under the cursor
-    delete_comment = "gx",       -- pr diff: delete the latest comment of the thread
-    toggle_thread = "gc",        -- pr diff: collapse/expand the thread under the cursor
-    resolve_thread = "gr",       -- pr diff: resolve/unresolve the thread under the cursor
-    overview = "go",             -- pr diff + panel: back to the PR overview home
-    review_submit = "gS",        -- pr: submit the pending review
-    review_discard = "gD",       -- pr: discard the pending review and its drafts
-    -- merge tool, bound on the result buffer
-    next_conflict = "]x", prev_conflict = "[x",
-    next_marker = "]n", prev_marker = "[n",  -- step marker line to marker line
+    discard = "X",               -- revert works on hunks/files (diff buffer/panel)
+    edit_file = "df",            -- open window to edit current file
+    goto_file = "de",            -- open the real file and close the session; in a pr it opens
+                                 -- the real file in a new tab
+    toggle_listing = "i",        -- tree/flat list
+    close_node = "c",
+    close_all = "C",
+    open_all = "O",
+    refresh = "R",               -- refreshes the panel (as a safety net, it shouldn't go stale)
+    toggle_fold = "za",
+    details = "K",               -- in the log panel to see full commit messages
+
+    -- mergetool
+    next_conflict = "]x", prev_conflict = "[x", -- step between conflicts
+    next_marker = "]n", prev_marker = "[n",  -- step between conflict markers
     choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
     choose_all = "<leader>ca",   -- take both (ours then theirs)
     choose_none = "<leader>cx",  -- drop the conflict region
+
+    -- pr
+    toggle_viewed = "<Tab>",
+    next_unviewed = "]u", prev_unviewed = "[u",
+    next_thread = "]t", prev_thread = "[t",
+    comment = "ga",              -- comment on the line (normal) or selection (visual)
+    reply = "gp",                -- reply to the thread under the cursor
+    delete_comment = "gx",       -- delete the latest comment of the thread
+    toggle_thread = "gc",        -- collapse/expand the thread under the cursor
+    resolve_thread = "gr",       -- resolve/unresolve the thread under the cursor
+    overview = "go",             -- back to the PR overview home
+    review_submit = "gS",        -- submit the pending review
+    review_discard = "gD",       -- discard the pending review and its drafts
   },
-  relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
-  base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
-  sidecar_bin = nil,             -- override the go sidecar path
-  command_alias = nil,           -- extra :command(s) routing to :Differ, e.g. "D" or { "D", "Df" }
 })
 ```
 
+The highlight groups differ defines are listed in [recipes](RECIPES.md#highlight-groups) (`:h differ-recipes-highlight-groups`); all carry `default = true`, so a `:highlight` of your own wins.
+
 ## Usage
 
-`:Differ [revspec]` opens the file panel over the changed files for a resolved source, landing on the file you ran it from, or on the first file in the list when that file isn't one of them. The grammar mirrors git:
+`:Differ [revspec]` opens the file panel over the changed files for a resolved source, landing on the file you ran it from at its closest modified hunk, or on the first file in the list when your current file isn't one of them. I modelled this on git's grammar:
 
 | Command | Diffs |
 |---|---|
@@ -212,111 +217,72 @@ require("differ").setup({
 | `:Differ <a>...<b>` | merge-base(`<a>`, `<b>`) vs `<b>` |
 | `:Differ <a>...` | merge-base vs worktree (branch total) |
 | `:Differ <a> <b>` | `<a>` vs `<b>` |
+| `:Differ base` | branch total vs the base branch; `base` auto-detects `origin/HEAD` |
+| `:Differ log [path]` | history of one file, commit by commit; no argument takes the current buffer |
+| `:Differ log <range>` | branch-range history, driving commit then file |
+| `:Differ log base` | branch-range history of `<base>...HEAD` |
 
-Any source with worktree on the new side (the first three rows above) also lists untracked files: `git diff` can't see them no matter what refs you pass it, so differ unions in `git ls-files --others --exclude-standard` to fill the gap. They show with a `?` status and their line count as the addition count (0 for binary content), same as the default panel's Untracked section.
+Sources with worktree on the new side (`:Differ`, `:Differ <rev>`, `:Differ <a>...`) also list untracked files. `git diff` can't see them whatever refs you pass it, so differ unions in `git ls-files --others --exclude-standard` to bring them in with the other changes.
 
 ### Runtime controls
 
-These re-render the active view only. No refetch, no re-diff, and the state is local to that view.
+| Command | Effect |
+|---|---|
+| `:Differ layout [stacked\|split]` | Set layout; no argument toggles between |
+| `:Differ panel [left\|right\|top\|bottom]` | Reposition the live panel or history sidebar |
+| `:Differ context full` | Show the whole file, no folds (the default) |
+| `:Differ context <n>` | Set the fold threshold around hunks |
+| `:Differ context +` / `-` | Widen / narrow the threshold by one |
+
+`context` decides where a native fold forms once an unchanged run exceeds it either side of a hunk; every line is in the buffer either way, so search, yank and motions are unaffected. Folds are created open, so nothing is hidden until you close one (`zc` / `za` / `zM`). `d-` narrows out of whole-file by landing on a threshold of 10 and stepping down from there; `d=` has nothing wider to reach, so it does nothing.
+
+Set `command_alias` in `setup()` to register a shorter name for the same command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. If you lazy-load on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see [troubleshooting](TROUBLESHOOTING.md#command_alias-and-lazy-loading) (`:h differ-troubleshooting-command_alias-and-lazy-loading`) for why.
+
+### PR review
+
+`:Differ pr [<n>]` opens a pull request and lands on the overview, its home page; no argument lists the repo's PRs and picks from them. `owner/repo#<n>` targets another repo, which is how you reach a fork. From the overview, `e` enters the files and `r` enters and starts a review; `<CR>` on a thread jumps straight to that comment's file and line. The review keymaps (`ga` comment, `gp` reply, `gr` resolve, `<Tab>` viewed) are live once you're in the diff.
 
 | Command | Effect |
 |---|---|
-| `:Differ layout [stacked\|split]` | Set layout; no argument flips it |
-| `:Differ context <n>` | Set the fold threshold around hunks |
-| `:Differ context full` | Show the whole file, no folds (the default) |
-| `:Differ context +` / `-` | Widen / narrow the threshold by one |
-| `:Differ panel [left\|right\|top\|bottom]` | Reposition the live panel or history sidebar |
+| `:Differ pr [<n>]` | Open a PR on its overview; no argument picks from the repo's open PRs |
+| `:Differ pr <owner>/<repo>#<n>` | Open a PR in another repo, e.g. a fork |
+| `:Differ pr list [filter]` | List pull requests. The filter is `open` (the default), `mine`, or `review_requested` |
+| `:Differ pr view [<n>]` | Enter the diff read-only, without starting a review |
+| `:Differ pr overview` | Back to the overview from anywhere in the session (same as the `go` keymap) |
+| `:Differ pr checks` | The CI checks view for the open PR |
 
-`context` defaults to the whole file, so no folds are created at all and a diff reads as the file it came from. Set it to a number to fold the long unchanged runs away instead: every line is in the buffer either way (search, yank, and motions all work), and `context` only decides where a native fold forms once an unchanged run exceeds it either side of a hunk. Folds are created open, not closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`). `d-` narrows out of whole-file the same way, landing on a threshold of 10 and stepping down a line at a time from there; `d=` has nothing wider to reach, so it does nothing.
+Review drafts are a separate group. A review accumulates comments locally and posts them in one submission:
 
-Set `command_alias` in `setup()` to register a shorter name for the same command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must start with an uppercase letter (enforced by vim, not by me). If you lazy-load on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see [troubleshooting](TROUBLESHOOTING.md#command_alias-and-lazy-loading) for why.
+| Command | Effect |
+|---|---|
+| `:Differ pr review [<n>]` | Start (or resume) a review; a number opens that PR and starts one |
+| `:Differ pr review resume` | Resume the pending review on the active session |
+| `:Differ pr review submit` | Submit the pending review and its drafts. The `gS` key |
+| `:Differ pr review discard` | Discard the pending review and its drafts. The `gD` key |
+
+The lifecycle verbs act on the active session's PR:
+
+| Command | Effect |
+|---|---|
+| `:Differ pr merge [method]` | Merge the PR; the method is `squash`, `merge`, or `rebase` |
+| `:Differ pr checkout` | Check the PR branch out locally |
+| `:Differ pr ready` / `draft` | Flip the PR between ready-for-review and draft |
+| `:Differ pr close` / `reopen` | Close or reopen the PR |
+| `:Differ pr browser` | Open the PR on github.com |
+| `:Differ pr url` | Yank the PR's URL to the system clipboard |
 
 ### Session and sidecar commands
 
 | Command | Effect |
 |---|---|
-| `:Differ pr list [filter]` | List the repo's open pull requests. The filter is `open` (the default), `mine` for the ones you opened, or `review_requested` for the ones waiting on your review |
-| `:Differ mergetool [path]` | Open the merge tool on a conflicted file; no argument takes the current file, else the only conflicted one, else a picker |
-| `:Differ edit` | Edit the real file in a transient split at the cursor's mapped line, keeping the session; `:w` re-sources the diff. The `df` key |
 | `:Differ gofile` | Open the real file at the cursor's mapped line and end the session. The `de` key |
+| `:Differ edit` | Edit the real file in a transient split at the cursor's mapped line, keeping the session; `:w` re-sources the diff. The `df` key |
+| `:Differ mergetool [path]` | Open the merge tool on a conflicted file; no argument takes the current file, else the only conflicted one, else a picker |
 | `:Differ sidecar` | Smoke-check the Go sidecar: start it, round-trip a handshake, and report the binary and protocol version |
 | `:Differ sidecar stop` | Stop the supervised sidecar; the next PR command starts a fresh one |
 | `:Differ cache clear` | Flush the sidecar's in-process caches (file blobs and PR review threads) |
 
-`:Differ sidecar` is the diagnostic to reach for when PR review doesn't work. It tells a sidecar that was never built (`make go-build`) apart from a protocol mismatch or a `gh` auth failure, and it's the only thing that reports which binary is actually running.
-
-`:Differ cache clear` is worth knowing about because the sidecar memoises review threads for the life of the process and flushes them only on your own mutations, so a colleague's comment posted while you have the PR open won't show up until you clear it. File blobs are keyed by commit sha and can't go stale, so clearing those only costs a refetch.
-
-### Diagnostics
-
-`:checkhealth differ` is the first thing to run when something doesn't work. It reports the Neovim floor and `termguicolors`, git, the options you passed to `setup()`, the resolved sidecar binary and whether it completes a handshake, and whether a GitHub token is available. A sidecar that died during the session is reported there too, with the last thing it wrote.
-
-An option that doesn't name a real key, or that carries a value outside a closed set (`panel.position = "middle"`), is reported once at startup and again by `:checkhealth`. differ still starts, and the value it can't honour falls back to its default.
-
-The sidecar logs to its stderr, which differ keeps rather than lets through to your terminal, so `:checkhealth differ` is where it surfaces: what a process said before it died, and what a running one has said since. The tail also comes with the error when a request fails on a sidecar that has just died. Nothing there carries your token.
-
-### Launchers
-
-differ ships no global launchers - only the in-view buffer maps above and the optional `command_alias`. Everything you do *inside* a session already has a key, so a launcher only earns its place for the handful of entry points you reach from an ordinary file, where no differ buffer exists yet to bind to. These are the ones I drive it with; lift them wholesale or trim to taste.
-
-<details>
-<summary><b>lazy.nvim spec with <code>&lt;leader&gt;d*</code> / <code>&lt;leader&gt;p*</code> launchers</b></summary>
-
-```lua
-{
-  "undont/differ.nvim",
-  build = "make go-build",
-  cmd = { "Differ", "D" }, -- "D" matches command_alias below; see note above
-  keys = {
-    -- local diff / history
-    { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
-    { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
-    { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
-    { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
-    -- pr review (sidecar + github)
-    { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
-    {
-      "<leader>po",
-      function()
-        vim.ui.input({ prompt = "PR number: " }, function(input)
-          if input and input ~= "" then vim.cmd("Differ pr " .. input) end
-        end)
-      end,
-      desc = "PR: open by number",
-    },
-  },
-  config = function()
-    require("differ").setup({ command_alias = "D" })
-  end,
-}
-```
-
-Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and layout, and `gS` / `gD` submit or discard a review without leaving the files. The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`, `merge`, `browser`, `url`) stay as `:Differ pr <verb>` - once-per-PR actions that don't earn a keymap.
-
-</details>
-
-If which-key's `<leader>` popup doesn't open over differ's buffers, that's a trigger-registration quirk on scratch buffers, not a differ bug; [troubleshooting](TROUBLESHOOTING.md#which-key-popups-over-differ-buffers) has the workaround.
-
-### Statusline
-
-The diff buffers use a private `differdiff` filetype rather than the source file's, so foreign `FileType <lang>` autocmds (LSP, linters, semantic tokens) don't attach to a throwaway `differ://` buffer. The source filetype is stashed in `b:differ_filetype`, so a statusline can still show the language.
-
-For lualine, differ ships a drop-in for the stock `filetype` component, which shows the source filetype (with its devicon) on differ buffers and the native filetype everywhere else:
-
-```lua
-sections = { lualine_x = { require("differ.lualine").filetype } }
-```
-
-Any custom statusline can read the buffer var directly, lualine or not (it's simply absent on every other buffer):
-
-```lua
-local function diff_filetype()
-  local ft = vim.b.differ_filetype
-  return (type(ft) == "string" and ft ~= "") and ft or vim.bo.filetype
-end
-```
-
-Under a `cmd` lazy-load, prefer that over `require("differ.lualine")`, which loads the whole plugin at startup; see [troubleshooting](TROUBLESHOOTING.md#statusline-requires-under-lazy-loading).
+`:checkhealth differ` reports the requirements, your `setup()` options, the resolved sidecar and its handshake, and a GitHub token if one is available. [Troubleshooting](TROUBLESHOOTING.md) (`:h differ-troubleshooting.txt`) covers what to do when one of them is wrong.
 
 ### Lua API
 
@@ -354,3 +320,5 @@ require("differ").goto_hunk("next", {
   end,
 })
 ```
+
+Launchers for the entry points differ leaves unbound, and a lualine drop-in for the diff buffers' private filetype, are in [recipes](RECIPES.md) (`:h differ-recipes.txt`).

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -1,0 +1,129 @@
+# differ.nvim recipes
+
+Snippets to copy and paste: launchers for the entry points (these are what I use in my setup), a statusline integration, and the highlight groups listed out in case you want to override.
+
+## Launchers
+
+```lua
+{
+  "undont/differ.nvim",
+  build = "make go-build",
+  cmd = { "Differ", "D" }, -- "D" matches command_alias below
+  keys = {
+    { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
+    { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
+    { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
+    { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
+    { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
+    {
+      "<leader>po",
+      function()
+        vim.ui.input({ prompt = "PR number: " }, function(input)
+          if input and input ~= "" then vim.cmd("Differ pr " .. input) end
+        end)
+      end,
+      desc = "PR: open by number",
+    },
+  },
+  config = function()
+    require("differ").setup({ command_alias = "D" })
+  end,
+}
+```
+
+Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and layout, and `gS` / `gD` submit or discard a review without leaving the files. The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`, `reopen`, `merge`, `browser`, `url`) stay as `:Differ pr <verb>`.
+
+If which-key's `<leader>` popup doesn't open over differ's buffers, that's a trigger-registration quirk on scratch buffers; check in [troubleshooting](TROUBLESHOOTING.md#which-key-popups-over-differ-buffers) (`:h differ-troubleshooting-which-key-popups-over-differ-buffers`) for a solution.
+
+## Statusline
+
+The diff buffers use a private `differdiff` filetype rather than the source file's, so any other `FileType <lang>` autocmds (LSP, linters, semantic tokens) in your setup don't attach to a throwaway `differ://` buffer. The source filetype is still read and stored in `b:differ_filetype`, so a statusline can still show the language.
+
+For lualine, differ ships a drop-in for the stock `filetype` component, which shows the source filetype (with its devicon) on differ buffers and the native filetype everywhere else:
+
+```lua
+sections = { lualine_x = { require("differ.lualine").filetype } }
+```
+
+Any custom statusline can read the buffer var directly, lualine or not:
+
+```lua
+local function diff_filetype()
+  local ft = vim.b.differ_filetype
+  return (type(ft) == "string" and ft ~= "") and ft or vim.bo.filetype
+end
+```
+
+Under a `cmd` lazy-load, prefer that over `require("differ.lualine")`; see [troubleshooting](TROUBLESHOOTING.md#statusline-requires-under-lazy-loading) (`:h differ-troubleshooting-statusline-requires-under-lazy-loading`).
+
+## Highlight groups
+
+Every group is defined with `default = true`, so a `:highlight` of your own wins and survives a colorscheme change. The palette is re-resolved on `ColorScheme`, so the defaults track your theme without a reload. Typing `:hi differ` and pressing `<Tab>` completes all highlights with their current values.
+
+### Diff lines and words
+
+| Group | Applies to |
+|---|---|
+| `differLineAdd` / `differLineDelete` | the quiet per-line tint on a changed line |
+| `differWordAdd` / `differWordDelete` | the deeper same-hue patch on the changed words |
+| `differCursorLine` | the cursor line over unchanged text (links `CursorLine`) |
+| `differCursorLineAdd` / `differCursorLineDelete` | the cursor line over an added or deleted line |
+| `differFiller` | split's padding row opposite an inserted or deleted block (links `NonText`) |
+
+### Staging
+
+| Group | Applies to |
+|---|---|
+| `differStagedLineAdd` / `differStagedLineDelete` | a staged line, dimmer than the live tint |
+| `differStagedWordAdd` / `differStagedWordDelete` | the word patch inside a staged line |
+| `differStagedLine` | a staged line with no add/delete kind (links `CursorLine`) |
+| `differStagedSign` | the staged-hunk gutter glyph |
+
+### File panel
+
+| Group | Applies to |
+|---|---|
+| `differPanelHeader` / `differPanelRoot` / `differPanelHelp` | panel chrome (link `Title` / `Directory` / `Comment`) |
+| `differPanelDir` / `differPanelContext` | a tree directory row, and the dimmed `·parent/` trailer in the name listing |
+| `differPanelAdd` / `differPanelModify` / `differPanelDelete` | the status glyph, by kind |
+| `differPanelRename` / `differPanelUnmerged` / `differPanelUntracked` | the status glyph, by kind |
+| `differPanelCountAdd` / `differPanelCountDelete` | the per-file +/- counts |
+
+### File history
+
+| Group | Applies to |
+|---|---|
+| `differHistoryAuthor` | the author column on a commit row (links `Identifier`) |
+| `differHistoryRef` | the ref decoration in branch-range mode (links `Special`) |
+
+### Review threads
+
+| Group | Applies to |
+|---|---|
+| `differThread` | an open thread's spine, rules and author |
+| `differThreadResolved` / `differThreadResolvedTag` | a resolved thread, and its footer tag |
+| `differThreadPending` | a thread carrying an unsubmitted draft |
+| `differThreadMeta` / `differThreadBody` | the dim header line, and the comment text |
+| `differThreadRange` | the diff lines a range comment covers |
+| `differReviewDraft` | the pending-review badge in the diff winbar |
+
+### PR overview
+
+| Group | Applies to |
+|---|---|
+| `differOverviewTitle` / `differOverviewMeta` / `differOverviewBody` | the page's title, dim chrome and body (title links `Title`) |
+| `differOverviewApproved` / `differOverviewChanges` | a review verdict, approved or changes-requested |
+| `differOverviewAuthor` | the author's handle |
+| `differOverviewDiffContext` | the unchanged rows of a code thread's inline hunk |
+
+### Merge tool
+
+| Group | Applies to |
+|---|---|
+| `differMergeOurs` / `differMergeTheirs` / `differMergeBase` | one conflict slab per side, in the result pane |
+| `differMergeOursActive` / `differMergeTheirsActive` / `differMergeBaseActive` | the same, for the conflict under the cursor |
+| `differMergeOursStrong` / `differMergeTheirsStrong` / `differMergeBaseStrong` | the conflicting lines in an input pane, over the rest of the file |
+| `differMergeSignOurs` / `differMergeSignTheirs` / `differMergeSignBase` | the input-slab gutter sign |
+| `differMergeConflict` | an unresolved block in the result |
+| `differMergeMarker` | a raw conflict marker left in the buffer |
+| `differMergeFlash` | the transient flash on lines a take-this produced |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,26 @@
 # Troubleshooting
 
-Edge cases in how differ interacts with lazy-loading and other plugins. None of these are needed for a default install; they're here so the README stays a reference rather than a FAQ.
+Working out what's wrong, and the edge cases in how differ interacts with lazy-loading and other plugins. It lives here rather than in the README so that stays a reference rather than a FAQ.
+
+## PR review fails
+
+`:checkhealth differ` is the first thing to run. It reports the Neovim floor and `termguicolors`, git, the options you passed to `setup()`, the resolved sidecar binary and whether it completes a handshake, and whether a GitHub token is available. A sidecar that died during the session is reported there too, with the last thing it wrote.
+
+`:Differ sidecar` is the narrower diagnostic. It tells a sidecar that was never built (`make go-build`) apart from a protocol mismatch or a `gh` auth failure, and it's the only thing that reports which binary is actually running. A binary left stale by a missing update hook is the case it earns its keep on: the handshake only rejects one whose wire protocol has moved, so an otherwise-current sidecar fails later, as `unknown method` on the first call into something it doesn't have.
+
+`:Differ sidecar stop` ends the supervised process; the next PR command starts a fresh one.
+
+## Review threads look stale
+
+The sidecar memoises review threads for the life of the process and flushes them only on your own mutations, so a comment posted while you have the PR open won't appear until `:Differ cache clear`. File blobs are keyed by commit sha and can't go stale, so clearing those only costs a refetch.
+
+## An option is ignored
+
+An option that doesn't name a real key, or that carries a value outside a closed set (`panel.position = "middle"`), is reported once at startup and again by `:checkhealth differ`. differ still starts, and the value it can't honour falls back to its default.
+
+## Reading the sidecar log
+
+The sidecar logs to its stderr, which differ keeps rather than lets through to your terminal, so `:checkhealth differ` is where it surfaces: what a process said before it died, and what a running one has said since. The tail also comes with the error when a request fails on a sidecar that has just died. Nothing there carries your token.
 
 ## `command_alias` and lazy-loading
 

--- a/doc/differ-recipes.txt
+++ b/doc/differ-recipes.txt
@@ -1,0 +1,250 @@
+*differ-recipes.txt*                                        For Neovim >= 0.12
+
+==============================================================================
+Table of Contents                           *differ-recipes-table-of-contents*
+
+1. Launchers                                        |differ-recipes-launchers|
+2. Statusline                                      |differ-recipes-statusline|
+3. Highlight groups                          |differ-recipes-highlight-groups|
+  - Diff lines and words|differ-recipes-highlight-groups-diff-lines-and-words|
+  - Staging                          |differ-recipes-highlight-groups-staging|
+  - File panel                    |differ-recipes-highlight-groups-file-panel|
+  - File history                |differ-recipes-highlight-groups-file-history|
+  - Review threads            |differ-recipes-highlight-groups-review-threads|
+  - PR overview                  |differ-recipes-highlight-groups-pr-overview|
+  - Merge tool                    |differ-recipes-highlight-groups-merge-tool|
+Snippets to copy and paste: launchers for the entry points (these are what I
+use in my setup), a statusline integration, and the highlight groups listed out
+in case you want to override.
+
+
+==============================================================================
+1. Launchers                                        *differ-recipes-launchers*
+
+>lua
+    {
+      "undont/differ.nvim",
+      build = "make go-build",
+      cmd = { "Differ", "D" }, -- "D" matches command_alias below
+      keys = {
+        { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
+        { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
+        { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
+        { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
+        { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
+        {
+          "<leader>po",
+          function()
+            vim.ui.input({ prompt = "PR number: " }, function(input)
+              if input and input ~= "" then vim.cmd("Differ pr " .. input) end
+            end)
+          end,
+          desc = "PR: open by number",
+        },
+      },
+      config = function()
+        require("differ").setup({ command_alias = "D" })
+      end,
+    }
+<
+
+Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and
+layout, and `gS` / `gD` submit or discard a review without leaving the files.
+The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`,
+`reopen`, `merge`, `browser`, `url`) stay as `:Differ pr <verb>`.
+
+If which-key’s `<leader>` popup doesn’t open over differ’s buffers,
+that’s a trigger-registration quirk on scratch buffers; check in
+troubleshooting <TROUBLESHOOTING.md#which-key-popups-over-differ-buffers>
+(|differ-troubleshooting-which-key-popups-over-differ-buffers|) for a solution.
+
+
+==============================================================================
+2. Statusline                                      *differ-recipes-statusline*
+
+The diff buffers use a private `differdiff` filetype rather than the source
+file’s, so any other `FileType <lang>` autocmds (LSP, linters, semantic
+tokens) in your setup don’t attach to a throwaway `differ://` buffer. The
+source filetype is still read and stored in `b:differ_filetype`, so a
+statusline can still show the language.
+
+For lualine, differ ships a drop-in for the stock `filetype` component, which
+shows the source filetype (with its devicon) on differ buffers and the native
+filetype everywhere else:
+
+>lua
+    sections = { lualine_x = { require("differ.lualine").filetype } }
+<
+
+Any custom statusline can read the buffer var directly, lualine or not:
+
+>lua
+    local function diff_filetype()
+      local ft = vim.b.differ_filetype
+      return (type(ft) == "string" and ft ~= "") and ft or vim.bo.filetype
+    end
+<
+
+Under a `cmd` lazy-load, prefer that over `require("differ.lualine")`; see
+troubleshooting <TROUBLESHOOTING.md#statusline-requires-under-lazy-loading>
+(|differ-troubleshooting-statusline-requires-under-lazy-loading|).
+
+
+==============================================================================
+3. Highlight groups                          *differ-recipes-highlight-groups*
+
+Every group is defined with `default = true`, so a `:highlight` of your own
+wins and survives a colorscheme change. The palette is re-resolved on
+`ColorScheme`, so the defaults track your theme without a reload. Typing `:hi
+differ` and pressing `<Tab>` completes all highlights with their current
+values.
+
+
+DIFF LINES AND WORDS    *differ-recipes-highlight-groups-diff-lines-and-words*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differLineAdd / differLineDelete    the quiet per-line tint on a
+                                      changed line
+
+  differWordAdd / differWordDelete    the deeper same-hue patch on the
+                                      changed words
+
+  differCursorLine                    the cursor line over unchanged text
+                                      (links CursorLine)
+
+  differCursorLineAdd /               the cursor line over an added or
+  differCursorLineDelete              deleted line
+
+  differFiller                        split’s padding row opposite an
+                                      inserted or deleted block (links
+                                      NonText)
+  -----------------------------------------------------------------------
+
+STAGING                              *differ-recipes-highlight-groups-staging*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differStagedLineAdd /               a staged line, dimmer than the live
+  differStagedLineDelete              tint
+
+  differStagedWordAdd /               the word patch inside a staged line
+  differStagedWordDelete              
+
+  differStagedLine                    a staged line with no add/delete
+                                      kind (links CursorLine)
+
+  differStagedSign                    the staged-hunk gutter glyph
+  -----------------------------------------------------------------------
+
+FILE PANEL                        *differ-recipes-highlight-groups-file-panel*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differPanelHeader / differPanelRoot panel chrome (link Title /
+  / differPanelHelp                   Directory / Comment)
+
+  differPanelDir / differPanelContext a tree directory row, and the
+                                      dimmed ·parent/ trailer in the name
+                                      listing
+
+  differPanelAdd / differPanelModify  the status glyph, by kind
+  / differPanelDelete                 
+
+  differPanelRename /                 the status glyph, by kind
+  differPanelUnmerged /               
+  differPanelUntracked                
+
+  differPanelCountAdd /               the per-file +/- counts
+  differPanelCountDelete              
+  -----------------------------------------------------------------------
+
+FILE HISTORY                    *differ-recipes-highlight-groups-file-history*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differHistoryAuthor                 the author column on a commit row
+                                      (links Identifier)
+
+  differHistoryRef                    the ref decoration in branch-range
+                                      mode (links Special)
+  -----------------------------------------------------------------------
+
+REVIEW THREADS                *differ-recipes-highlight-groups-review-threads*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differThread                        an open thread’s spine, rules and
+                                      author
+
+  differThreadResolved /              a resolved thread, and its footer
+  differThreadResolvedTag             tag
+
+  differThreadPending                 a thread carrying an unsubmitted
+                                      draft
+
+  differThreadMeta / differThreadBody the dim header line, and the
+                                      comment text
+
+  differThreadRange                   the diff lines a range comment
+                                      covers
+
+  differReviewDraft                   the pending-review badge in the
+                                      diff winbar
+  -----------------------------------------------------------------------
+
+PR OVERVIEW                      *differ-recipes-highlight-groups-pr-overview*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differOverviewTitle /               the page’s title, dim chrome and
+  differOverviewMeta /                body (title links Title)
+  differOverviewBody                  
+
+  differOverviewApproved /            a review verdict, approved or
+  differOverviewChanges               changes-requested
+
+  differOverviewAuthor                the author’s handle
+
+  differOverviewDiffContext           the unchanged rows of a code
+                                      thread’s inline hunk
+  -----------------------------------------------------------------------
+
+MERGE TOOL                        *differ-recipes-highlight-groups-merge-tool*
+
+  -----------------------------------------------------------------------
+  Group                               Applies to
+  ----------------------------------- -----------------------------------
+  differMergeOurs / differMergeTheirs one conflict slab per side, in the
+  / differMergeBase                   result pane
+
+  differMergeOursActive /             the same, for the conflict under
+  differMergeTheirsActive /           the cursor
+  differMergeBaseActive               
+
+  differMergeOursStrong /             the conflicting lines in an input
+  differMergeTheirsStrong /           pane, over the rest of the file
+  differMergeBaseStrong               
+
+  differMergeSignOurs /               the input-slab gutter sign
+  differMergeSignTheirs /             
+  differMergeSignBase                 
+
+  differMergeConflict                 an unresolved block in the result
+
+  differMergeMarker                   a raw conflict marker left in the
+                                      buffer
+
+  differMergeFlash                    the transient flash on lines a
+                                      take-this produced
+  -----------------------------------------------------------------------
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/differ-troubleshooting.txt
+++ b/doc/differ-troubleshooting.txt
@@ -1,0 +1,152 @@
+*differ-troubleshooting.txt*                                For Neovim >= 0.12
+
+==============================================================================
+Table of Contents                   *differ-troubleshooting-table-of-contents*
+
+1. PR review fails                    |differ-troubleshooting-pr-review-fails|
+2. Review threads look stale|differ-troubleshooting-review-threads-look-stale|
+3. An option is ignored          |differ-troubleshooting-an-option-is-ignored|
+4. Reading the sidecar log    |differ-troubleshooting-reading-the-sidecar-log|
+5. command_alias and lazy-loading|differ-troubleshooting-command_alias-and-lazy-loading|
+6. which-key popups over differ buffers|differ-troubleshooting-which-key-popups-over-differ-buffers|
+7. Statusline requires under lazy-loading|differ-troubleshooting-statusline-requires-under-lazy-loading|
+8. Format-on-save over conflict markers|differ-troubleshooting-format-on-save-over-conflict-markers|
+9. render-markdown.nvim in the merge result|differ-troubleshooting-render-markdown.nvim-in-the-merge-result|
+Working out what’s wrong, and the edge cases in how differ interacts with
+lazy-loading and other plugins. It lives here rather than in the README so that
+stays a reference rather than a FAQ.
+
+
+==============================================================================
+1. PR review fails                    *differ-troubleshooting-pr-review-fails*
+
+`:checkhealth differ` is the first thing to run. It reports the Neovim floor
+and `termguicolors`, git, the options you passed to `setup()`, the resolved
+sidecar binary and whether it completes a handshake, and whether a GitHub token
+is available. A sidecar that died during the session is reported there too,
+with the last thing it wrote.
+
+`:Differ sidecar` is the narrower diagnostic. It tells a sidecar that was never
+built (`make go-build`) apart from a protocol mismatch or a `gh` auth failure,
+and it’s the only thing that reports which binary is actually running. A
+binary left stale by a missing update hook is the case it earns its keep on:
+the handshake only rejects one whose wire protocol has moved, so an
+otherwise-current sidecar fails later, as `unknown method` on the first call
+into something it doesn’t have.
+
+`:Differ sidecar stop` ends the supervised process; the next PR command starts
+a fresh one.
+
+
+==============================================================================
+2. Review threads look stale*differ-troubleshooting-review-threads-look-stale*
+
+The sidecar memoises review threads for the life of the process and flushes
+them only on your own mutations, so a comment posted while you have the PR open
+won’t appear until `:Differ cache clear`. File blobs are keyed by commit sha
+and can’t go stale, so clearing those only costs a refetch.
+
+
+==============================================================================
+3. An option is ignored          *differ-troubleshooting-an-option-is-ignored*
+
+An option that doesn’t name a real key, or that carries a value outside a
+closed set (`panel.position = "middle"`), is reported once at startup and again
+by `:checkhealth differ`. differ still starts, and the value it can’t honour
+falls back to its default.
+
+
+==============================================================================
+4. Reading the sidecar log    *differ-troubleshooting-reading-the-sidecar-log*
+
+The sidecar logs to its stderr, which differ keeps rather than lets through to
+your terminal, so `:checkhealth differ` is where it surfaces: what a process
+said before it died, and what a running one has said since. The tail also comes
+with the error when a request fails on a sidecar that has just died. Nothing
+there carries your token.
+
+
+==============================================================================
+5. command_alias and lazy-loading*differ-troubleshooting-command_alias-and-lazy-loading*
+
+`command_alias` is registered by `setup()`, so it can’t trigger differ’s
+own load. If you lazy-load on `cmd = "Differ"`, the first `:D` of a session
+errors with `E464` before differ has loaded (it prefix-matches the `Differ`
+load stub).
+
+Either list the alias in `cmd` as well:
+
+>lua
+    cmd = { "Differ", "D" },
+<
+
+or skip `command_alias` and use a cmdline abbrev, which expands before the
+plugin loads so the name lives in one place:
+
+>lua
+    vim.cmd [[cnoreabbrev <expr> D (getcmdtype() == ':' && getcmdline() ==# 'D') ? 'Differ' : 'D']]
+<
+
+
+==============================================================================
+6. which-key popups over differ buffers*differ-troubleshooting-which-key-popups-over-differ-buffers*
+
+differ’s surfaces are scratch buffers (`buftype=nofile`) with their own
+filetypes (`differdiff` for the diff buffers, `differpanel`, `differhistory`),
+so no foreign `FileType <lang>` autocmds attach to them. Some which-key setups
+gate their trigger (re)registration on `buftype == ""`, or rebuild triggers in
+a way that briefly clears them globally (each `wk.add` calls `Buf.clear()`). In
+those setups the `<leader>` / `]` / `[` popups can fail to open over a scratch
+buffer during which-key’s trigger suspension windows, even though the same
+keys work in a normal file.
+
+This is a property of the which-key integration, not of differ. If you hit it,
+pin permanent buffer-local maps on differ buffers (a plain keymap isn’t
+managed by the trigger system, so it can’t be cleared). differ’s buffers
+carry stable filetypes, so key off those:
+
+>lua
+    vim.api.nvim_create_autocmd("FileType", {
+      group = vim.api.nvim_create_augroup("differ-whichkey", { clear = true }),
+      pattern = { "differdiff", "differpanel", "differhistory" },
+      callback = function(ev)
+        local wk = require("which-key")
+        for _, key in ipairs({ " ", "]", "[" }) do
+          vim.keymap.set("n", key, function() wk.show(key) end, { buffer = ev.buf })
+        end
+      end,
+    })
+<
+
+
+==============================================================================
+7. Statusline requires under lazy-loading*differ-troubleshooting-statusline-requires-under-lazy-loading*
+
+Requiring any `differ.*` module from your statusline config makes lazy load the
+whole plugin at startup, which defeats a `cmd` lazy-load. That includes
+`require("differ.lualine")`. Read `vim.b.differ_filetype` directly instead: it
+never triggers a load, works whether or not differ is loaded, and is simply
+absent on every other buffer.
+
+
+==============================================================================
+8. Format-on-save over conflict markers*differ-troubleshooting-format-on-save-over-conflict-markers*
+
+The merge result buffer is the real worktree file, so a format-on-save would
+otherwise run over the conflict markers. The merge tool sets
+`vim.b.disable_autoformat` (conform’s opt-out) for the session, so honour
+that flag in your `format_on_save` gate if you format on save.
+
+If a formatter reformats the markers anyway, differ notices on save, refuses to
+stage the file, and warns once that the flag isn’t being honoured.
+
+
+==============================================================================
+9. render-markdown.nvim in the merge result*differ-troubleshooting-render-markdown.nvim-in-the-merge-result*
+
+The merge result disables in-buffer markdown rendering for the session so the
+conflict markers aren’t concealed as block-quotes, restoring it on close.
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/differ.txt
+++ b/doc/differ.txt
@@ -3,230 +3,410 @@
 ==============================================================================
 Table of Contents                                   *differ-table-of-contents*
 
-1. Features                                                  |differ-features|
+1. Why this exists                                    |differ-why-this-exists|
 2. Requirements                                          |differ-requirements|
-3. Configuration                                        |differ-configuration|
-4. Usage                                                        |differ-usage|
+3. Installation                                          |differ-installation|
+  - lazy.nvim                                  |differ-installation-lazy.nvim|
+  - vim.pack                                    |differ-installation-vim.pack|
+  - mini.deps                                  |differ-installation-mini.deps|
+  - Other managers                        |differ-installation-other-managers|
+4. Configuration                                        |differ-configuration|
+5. Usage                                                        |differ-usage|
   - Runtime controls                           |differ-usage-runtime-controls|
+  - PR review                                         |differ-usage-pr-review|
   - Session and sidecar commands   |differ-usage-session-and-sidecar-commands|
-  - Diagnostics                                     |differ-usage-diagnostics|
-  - Launchers                                         |differ-usage-launchers|
-  - Statusline                                       |differ-usage-statusline|
   - Lua API                                             |differ-usage-lua-api|
 
 ==============================================================================
-1. Features                                                  *differ-features*
+1. Why this exists                                    *differ-why-this-exists*
 
-- Stacked dual-rail layout: one scroll surface, old and new interleaved
-- Side-by-side layout from the same hunk model, toggled at runtime
-- PR review in the diff: inline threads, drafts, resolve, viewed-state
-- PR lifecycle: merge, checkout, ready/draft, close, and CI checks
-- File panel with the changed-file tree, status icons, and +/- counts
-- Hunk- and file-level staging from the diff or the panel
-- File history for single files and branch ranges, commit by commit
-- 3-way/4-way merge tool, resolved into the working-tree file
-- Word-level highlighting and Treesitter syntax, both on by default
-- Real buffer lines, so search, yank, and motions work as normal
-- One diff engine (`vim.text.diff()`, histogram) shared by every source
+You can already get most of the functionality from combining some existing
+plugins (I was using diffview + octo.nvim with custom keymaps), but for me, it
+just never felt like a cohesive experience. I wanted to see how feasible it
+would be to build everything together, and what the result _could_ feel like.
+
+Everything runs through one renderer, so staging a hunk and replying to a
+review comment behave like the same tool; that covers local diffs against any
+revspec, file history for a single file or a branch range, hunk and file-level
+staging, PR review with inline threads and all of the lifecycle of a PR around
+it, and a 3-way (or 4-way if you choose) merge tool that resolves into the
+working-tree file. All of these views get data from the same diff engine (using
+`vim.text.diff()`).
+
+The default view is a stacked dual-rail layout: one scroll surface with old and
+new lines interleaved per hunk. Side-by-side layout is available in the config
+or with a toggle in-session. Word-level highlighting and Treesitter syntax are
+on by default, and every surface is real buffer lines rather than virtual text,
+so search, yank and motions work as normal.
+
+The GitHub side runs in a separate process rather than the editor, so opening a
+PR or posting a review doesn’t block on the API, and results are cached
+between calls.
 
 
 ==============================================================================
 2. Requirements                                          *differ-requirements*
 
-- Neovim 0.12+ (`vim.text.diff` sets the floor; also uses `vim.system` and `vim.uv`)
-- `termguicolors` on - nvim enables it itself on any terminal it detects as 24-bit capable, so this is usually already true; without it the diff, merge and thread highlights render uncoloured
-- git on `PATH`
+- Neovim 0.12+ and git
+- `termguicolors` on (usually already the case; without it the highlights render uncoloured)
+- For PR review: Go, make, and an authenticated `gh`
 - A Treesitter parser for the languages you diff (optional)
-- For PR review: Go + make on `PATH`, and `gh` authenticated
-- Local diffs need none of the above beyond git
 
 `:checkhealth differ` reports which of these are satisfied.
 
 
 ==============================================================================
-3. Configuration                                        *differ-configuration*
+3. Installation                                          *differ-installation*
+
+
+LAZY.NVIM                                      *differ-installation-lazy.nvim*
+
+>lua
+    {
+      "undont/differ.nvim",
+      build = "make go-build",
+      config = function()
+        require("differ").setup()
+      end,
+    }
+<
+
+`setup()` is only needed to change defaults and register highlight groups
+eagerly.
+
+The `build` hook compiles the Go sidecar (used by PR review) on install and
+update. It needs Go and make on `PATH`; if you’re only here for local diffs,
+feel free to drop the hook.
+
+
+VIM.PACK                                        *differ-installation-vim.pack*
+
+Neovim 0.12+. `vim.pack` has no inline build key, so the best solution is to
+register a `PackChanged` hook (before `vim.pack.add`, so it also runs on first
+install):
+
+>lua
+    vim.api.nvim_create_autocmd("PackChanged", {
+      callback = function(ev)
+        if ev.data.spec.name == "differ.nvim" and (ev.data.kind == "install" or ev.data.kind == "update") then
+          vim.system({ "make", "go-build" }, { cwd = ev.data.path }):wait()
+        end
+      end,
+    })
+    
+    vim.pack.add({ "https://github.com/undont/differ.nvim" })
+    require("differ").setup()
+<
+
+You can also pin a release with `{ src =
+"https://github.com/undont/differ.nvim", version = "v0.1.1" }`, or follow a
+range with `version = vim.version.range("0.1")`.
+
+
+MINI.DEPS                                      *differ-installation-mini.deps*
+
+mini.deps splits the build hook in two, so differ needs both. `post_install`
+fires on the initial clone and `post_checkout` on every update, so wiring only
+the first leaves updates on the binary built at install time, and only the
+second never builds one at all:
+
+>lua
+    local build = function(args)
+      vim.system({ "make", "go-build" }, { cwd = args.path }):wait()
+    end
+    
+    MiniDeps.add({
+      source = "undont/differ.nvim",
+      hooks = { post_install = build, post_checkout = build },
+    })
+    require("differ").setup()
+<
+
+
+OTHER MANAGERS                            *differ-installation-other-managers*
+
+differ’s only install step is building the Go sidecar, so point your
+manager’s build hook at `make go-build`. Managers with one hook covering both
+install and update need a single key: pckr `run`, vim-plug `do`, paq `build`.
+
+Wiring the install hook but not the update one leaves a stale binary. If
+you’re in doubt, `:Differ sidecar` reports which one is actually running.
+
+
+==============================================================================
+4. Configuration                                        *differ-configuration*
 
 `setup()` merges over these defaults:
 
 >lua
     require("differ").setup({
-      layout = "stacked",            -- "stacked" | "split", toggleable per-view
+      base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
+      relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
+      command_alias = nil,           -- extra :command(s) routing to :Differ, e.g. "D" or { "D", "Df" }
+      panel = {                      -- can also be overridden with :Differ panel <position> in-session
+        position = "right",          -- "bottom" | "top" | "left" | "right"
+        height = 9,                  -- only applies to top/bottom
+        width = 35,                  -- only applies to left/right
+        listing = "tree",            -- "tree" | "name" (tree/flat list)
+        icons = true,                -- (requires nvim-web-devicons)
+        progress = true,             -- list position meter in the panel winbar
+      },
+    
+      layout = "stacked",            -- "stacked" | "split" (can be toggled with :Differ layout in-session)
       context = math.huge,           -- fold threshold; math.huge = whole file, no folds
       wrap = true,                   -- soft-wrap long lines in the diff view
-      diff_counter = true,           -- "hunk K/N" counter in the diff window's winbar
-      cursorline_tint = true,        -- tint the cursor line by add/remove so the change
-                                     -- kind reads under the cursor; false = plain neutral
-      deep_diff = {
+      diff_counter = true,           -- hunk counter in the diff window's winbar
+      cursorline_tint = true,        -- allow the cursorline to inherit the add/delete highlights
+      deep_diff = {                  -- word-level diffing
         enabled = true,
         granularity = "word",        -- "word" | "char"
         similarity_threshold = 0.5,  -- line-pairing cutoff for word-level diffing
       },
-      comments = {                   -- pr review threads
+    
+      history = {                    -- log/history sidebar default placement/size
+        position = "bottom",         -- "bottom" | "top" | "left" | "right"
+        height = 10,                 -- only applies to top/bottom
+        width = 40,                  -- only applies to left/right
+      },
+    
+      merge = {                      -- no override in-session
+        layout = "default",          -- "default" (ours | theirs) | "diff4" (adds base)
+      },
+    
+      comments = {                   -- in pr review threads
         display = "peek",            -- "expanded" | "peek" | "markers"
                                      -- "expanded" doesn't collapse any, all stay open
                                      -- "peek" has boxes below the line, opening on the cursor's row
                                      -- "markers" gives eol markers with a float, which split
                                      -- always does anyway
       },
-      panel = {                      -- file panel default placement/size; `:Differ panel`
-                                     -- and the runtime Panel.current() setters override per-session
-        position = "right",          -- "bottom" | "top" | "left" | "right"
-        height = 9,                  -- top/bottom
-        width = 35,                  -- left/right
-        listing = "tree",            -- "tree" | "name"
-        icons = true,                -- filetype devicons in the file list, when
-                                     -- nvim-web-devicons is installed
-        progress = true,             -- "file K/N" position meter in the panel winbar
-      },
-      history = {                    -- log/history sidebar default placement/size
-        position = "bottom",
-        height = 10,                 -- top/bottom
-        width = 40,                  -- left/right
-      },
-      merge = {                      -- merge tool pane layout; no per-invocation override
-        layout = "default",          -- "default" (ours | theirs) | "diff4" (adds base)
-      },
-      keymaps = {                    -- one flat action -> lhs table, shared across the diff,
-        -- a value is a string, a list of strings, or false to disable. override globally
-        -- here, or scope to one surface via a diff/panel/history/merge = {...} subtable
-        next_hunk = "]c",            -- diff, panel, history
+      sidecar_bin = nil,             -- override the go sidecar path
+    
+      keymaps = {
+        next_hunk = "]c",
         prev_hunk = "[c",
-        next_file = "]f",            -- diff; panel/history step the selection
+        next_file = "]f",
         prev_file = "[f",
-        first_file = "gg",           -- panel/history: jump to the first/last file or commit
+        first_file = "gg",
         last_file = "G",
-        next_section = "]]",         -- panel: sections (Staged/Unstaged); history: commits
+        next_section = "]]",         -- sections in the panel, commits in log
         prev_section = "[[",
         scroll_down = "f",           -- shadows native f/b; set false to restore
         scroll_up = "b",
-        select = { "<CR>", "o" },    -- diff, pr overview, panel, history
-        details = "K",               -- history: float the full commit message
-        help = "g?",                 -- diff, pr overview, panel, history
-        toggle_listing = "i",        -- panel: toggle tree / name
-        close_node = "c",            -- panel: collapse the dir under the cursor; history: the commit
-        close_all = "C",             -- panel/history: collapse every dir / commit
-        open_all = "O",              -- panel/history: expand every dir / commit
-        stage = "s", unstage = "u",  -- diff (hunk-level), panel (file-level)
+        select = { "<CR>", "o" },
+        help = "g?",
+        close = "dc",                -- end the session
+        toggle_panel = "dd",         -- hide/show the file panel
+    
+        -- diffs
+        toggle_layout = "dl",        -- flip between stacked / split
+        more_context = "d=", less_context = "d-",
+        stage = "s", unstage = "u",  -- stage/unstage[all] work on hunks/files (diff buffer/panel)
         stage_all = "S", unstage_all = "U",
-        more_context = "d=", less_context = "d-",  -- diff
-        edit_file = "df",            -- diff: edit-in-review; pr diff: worktree split beside the pinned diff
-        goto_file = "de",            -- diff: open the real file and end the session; pr diff: zoom-edit in a tab instead
-        discard = "X",               -- diff (revert a hunk), panel (discard a file)
-        refresh = "R",               -- panel
-        toggle_fold = "za",          -- history (range mode)
-        close = "dc",                -- diff/panel/history: end the session
-        toggle_panel = "dd",         -- diff/panel: hide/show the file panel sidebar
-        toggle_layout = "dl",        -- diff: flip stacked / split
-        -- pr review (pr diff + panel)
-        toggle_viewed = "<Tab>",     -- pr panel: flip the github viewed checkbox
-        next_unviewed = "]u", prev_unviewed = "[u",  -- pr panel + diff
-        next_thread = "]t", prev_thread = "[t",      -- pr diff
-        comment = "ga",              -- pr diff: comment on the line (normal) or selection (visual)
-        reply = "gp",                -- pr diff: reply to the thread under the cursor
-        delete_comment = "gx",       -- pr diff: delete the latest comment of the thread
-        toggle_thread = "gc",        -- pr diff: collapse/expand the thread under the cursor
-        resolve_thread = "gr",       -- pr diff: resolve/unresolve the thread under the cursor
-        overview = "go",             -- pr diff + panel: back to the PR overview home
-        review_submit = "gS",        -- pr: submit the pending review
-        review_discard = "gD",       -- pr: discard the pending review and its drafts
-        -- merge tool, bound on the result buffer
-        next_conflict = "]x", prev_conflict = "[x",
-        next_marker = "]n", prev_marker = "[n",  -- step marker line to marker line
+        discard = "X",               -- revert works on hunks/files (diff buffer/panel)
+        edit_file = "df",            -- open window to edit current file
+        goto_file = "de",            -- open the real file and close the session; in a pr it opens
+                                     -- the real file in a new tab
+        toggle_listing = "i",        -- tree/flat list
+        close_node = "c",
+        close_all = "C",
+        open_all = "O",
+        refresh = "R",               -- refreshes the panel (as a safety net, it shouldn't go stale)
+        toggle_fold = "za",
+        details = "K",               -- in the log panel to see full commit messages
+    
+        -- mergetool
+        next_conflict = "]x", prev_conflict = "[x", -- step between conflicts
+        next_marker = "]n", prev_marker = "[n",  -- step between conflict markers
         choose_ours = "<leader>co", choose_theirs = "<leader>ct", choose_base = "<leader>cb",
         choose_all = "<leader>ca",   -- take both (ours then theirs)
         choose_none = "<leader>cx",  -- drop the conflict region
+    
+        -- pr
+        toggle_viewed = "<Tab>",
+        next_unviewed = "]u", prev_unviewed = "[u",
+        next_thread = "]t", prev_thread = "[t",
+        comment = "ga",              -- comment on the line (normal) or selection (visual)
+        reply = "gp",                -- reply to the thread under the cursor
+        delete_comment = "gx",       -- delete the latest comment of the thread
+        toggle_thread = "gc",        -- collapse/expand the thread under the cursor
+        resolve_thread = "gr",       -- resolve/unresolve the thread under the cursor
+        overview = "go",             -- back to the PR overview home
+        review_submit = "gS",        -- submit the pending review
+        review_discard = "gD",       -- discard the pending review and its drafts
       },
-      relative_dates = false,        -- "3 days ago" instead of YYYY-MM-DD wherever a date shows
-      base = nil,                    -- base branch for `base`/`log base`; nil auto-detects origin/HEAD
-      sidecar_bin = nil,             -- override the go sidecar path
-      command_alias = nil,           -- extra :command(s) routing to :Differ, e.g. "D" or { "D", "Df" }
     })
 <
 
+The highlight groups differ defines are listed in recipes
+<RECIPES.md#highlight-groups> (|differ-recipes-highlight-groups|); all carry
+`default = true`, so a `:highlight` of your own wins.
+
 
 ==============================================================================
-4. Usage                                                        *differ-usage*
+5. Usage                                                        *differ-usage*
 
 `:Differ [revspec]` opens the file panel over the changed files for a resolved
-source, landing on the file you ran it from, or on the first file in the list
-when that file isn’t one of them. The grammar mirrors git:
+source, landing on the file you ran it from at its closest modified hunk, or on
+the first file in the list when your current file isn’t one of them. I
+modelled this on git’s grammar:
 
-  Command             Diffs
-  ------------------- ---------------------------------------
-  :Differ             HEAD vs worktree (all uncommitted)
-  :Differ <rev>       <rev> vs worktree
-  :Differ <a>..<b>    <a> vs <b> (two-dot)
-  :Differ <a>...<b>   merge-base(<a>, <b>) vs <b>
-  :Differ <a>...      merge-base vs worktree (branch total)
-  :Differ <a> <b>     <a> vs <b>
-Any source with worktree on the new side (the first three rows above) also
-lists untracked files: `git diff` can’t see them no matter what refs you pass
-it, so differ unions in `git ls-files --others --exclude-standard` to fill the
-gap. They show with a `?` status and their line count as the addition count (0
-for binary content), same as the default panel’s Untracked section.
+  -----------------------------------------------------------------------
+  Command                             Diffs
+  ----------------------------------- -----------------------------------
+  :Differ                             HEAD vs worktree (all uncommitted)
+
+  :Differ <rev>                       <rev> vs worktree
+
+  :Differ <a>..<b>                    <a> vs <b> (two-dot)
+
+  :Differ <a>...<b>                   merge-base(<a>, <b>) vs <b>
+
+  :Differ <a>...                      merge-base vs worktree (branch
+                                      total)
+
+  :Differ <a> <b>                     <a> vs <b>
+
+  :Differ base                        branch total vs the base branch;
+                                      base auto-detects origin/HEAD
+
+  :Differ log [path]                  history of one file, commit by
+                                      commit; no argument takes the
+                                      current buffer
+
+  :Differ log <range>                 branch-range history, driving
+                                      commit then file
+
+  :Differ log base                    branch-range history of
+                                      <base>...HEAD
+  -----------------------------------------------------------------------
+Sources with worktree on the new side (`:Differ`, `:Differ <rev>`, `:Differ
+<a>...`) also list untracked files. `git diff` can’t see them whatever refs
+you pass it, so differ unions in `git ls-files --others --exclude-standard` to
+bring them in with the other changes.
 
 
 RUNTIME CONTROLS                               *differ-usage-runtime-controls*
 
-These re-render the active view only. No refetch, no re-diff, and the state is
-local to that view.
-
   ------------------------------------------------------------------------------
   Command                                    Effect
   ------------------------------------------ -----------------------------------
-  :Differ layout [stacked\|split]            Set layout; no argument flips it
+  :Differ layout [stacked\|split]            Set layout; no argument toggles
+                                             between
 
-  :Differ context <n>                        Set the fold threshold around hunks
+  :Differ panel [left\|right\|top\|bottom]   Reposition the live panel or
+                                             history sidebar
 
   :Differ context full                       Show the whole file, no folds (the
                                              default)
 
-  :Differ context + / -                      Widen / narrow the threshold by one
+  :Differ context <n>                        Set the fold threshold around hunks
 
-  :Differ panel [left\|right\|top\|bottom]   Reposition the live panel or
-                                             history sidebar
+  :Differ context + / -                      Widen / narrow the threshold by one
   ------------------------------------------------------------------------------
-`context` defaults to the whole file, so no folds are created at all and a diff
-reads as the file it came from. Set it to a number to fold the long unchanged
-runs away instead: every line is in the buffer either way (search, yank, and
-motions all work), and `context` only decides where a native fold forms once an
-unchanged run exceeds it either side of a hunk. Folds are created open, not
-closed, so nothing is hidden until you close one yourself (`zc`/`za`/`zM`).
-`d-` narrows out of whole-file the same way, landing on a threshold of 10 and
-stepping down a line at a time from there; `d=` has nothing wider to reach, so
-it does nothing.
+`context` decides where a native fold forms once an unchanged run exceeds it
+either side of a hunk; every line is in the buffer either way, so search, yank
+and motions are unaffected. Folds are created open, so nothing is hidden until
+you close one (`zc` / `za` / `zM`). `d-` narrows out of whole-file by landing
+on a threshold of 10 and stepping down from there; `d=` has nothing wider to
+reach, so it does nothing.
 
 Set `command_alias` in `setup()` to register a shorter name for the same
-command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. Names must
-start with an uppercase letter (enforced by vim, not by me). If you lazy-load
-on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see
-troubleshooting <TROUBLESHOOTING.md#command_alias-and-lazy-loading> for why.
+command, e.g. `command_alias = "D"` gives `:D HEAD~1`, `:D log`. If you
+lazy-load on `cmd`, list the alias there too (`cmd = { "Differ", "D" }`); see
+troubleshooting <TROUBLESHOOTING.md#command_alias-and-lazy-loading>
+(|differ-troubleshooting-command_alias-and-lazy-loading|) for why.
 
+
+PR REVIEW                                             *differ-usage-pr-review*
+
+`:Differ pr [<n>]` opens a pull request and lands on the overview, its home
+page; no argument lists the repo’s PRs and picks from them. `owner/repo#<n>`
+targets another repo, which is how you reach a fork. From the overview, `e`
+enters the files and `r` enters and starts a review; `<CR>` on a thread jumps
+straight to that comment’s file and line. The review keymaps (`ga` comment,
+`gp` reply, `gr` resolve, `<Tab>` viewed) are live once you’re in the diff.
+
+  -----------------------------------------------------------------------
+  Command                             Effect
+  ----------------------------------- -----------------------------------
+  :Differ pr [<n>]                    Open a PR on its overview; no
+                                      argument picks from the repo’s open
+                                      PRs
+
+  :Differ pr <owner>/<repo>#<n>       Open a PR in another repo, e.g. a
+                                      fork
+
+  :Differ pr list [filter]            List pull requests. The filter is
+                                      open (the default), mine, or
+                                      review_requested
+
+  :Differ pr view [<n>]               Enter the diff read-only, without
+                                      starting a review
+
+  :Differ pr overview                 Back to the overview from anywhere
+                                      in the session (same as the go
+                                      keymap)
+
+  :Differ pr checks                   The CI checks view for the open PR
+  -----------------------------------------------------------------------
+Review drafts are a separate group. A review accumulates comments locally and
+posts them in one submission:
+
+  -----------------------------------------------------------------------
+  Command                             Effect
+  ----------------------------------- -----------------------------------
+  :Differ pr review [<n>]             Start (or resume) a review; a
+                                      number opens that PR and starts one
+
+  :Differ pr review resume            Resume the pending review on the
+                                      active session
+
+  :Differ pr review submit            Submit the pending review and its
+                                      drafts. The gS key
+
+  :Differ pr review discard           Discard the pending review and its
+                                      drafts. The gD key
+  -----------------------------------------------------------------------
+The lifecycle verbs act on the active session’s PR:
+
+  -----------------------------------------------------------------------
+  Command                             Effect
+  ----------------------------------- -----------------------------------
+  :Differ pr merge [method]           Merge the PR; the method is squash,
+                                      merge, or rebase
+
+  :Differ pr checkout                 Check the PR branch out locally
+
+  :Differ pr ready / draft            Flip the PR between
+                                      ready-for-review and draft
+
+  :Differ pr close / reopen           Close or reopen the PR
+
+  :Differ pr browser                  Open the PR on github.com
+
+  :Differ pr url                      Yank the PR’s URL to the system
+                                      clipboard
+  -----------------------------------------------------------------------
 
 SESSION AND SIDECAR COMMANDS       *differ-usage-session-and-sidecar-commands*
 
   -----------------------------------------------------------------------
   Command                             Effect
   ----------------------------------- -----------------------------------
-  :Differ pr list [filter]            List the repo’s open pull requests.
-                                      The filter is open (the default),
-                                      mine for the ones you opened, or
-                                      review_requested for the ones
-                                      waiting on your review
-
-  :Differ mergetool [path]            Open the merge tool on a conflicted
-                                      file; no argument takes the current
-                                      file, else the only conflicted one,
-                                      else a picker
+  :Differ gofile                      Open the real file at the cursor’s
+                                      mapped line and end the session.
+                                      The de key
 
   :Differ edit                        Edit the real file in a transient
                                       split at the cursor’s mapped line,
                                       keeping the session; :w re-sources
                                       the diff. The df key
 
-  :Differ gofile                      Open the real file at the cursor’s
-                                      mapped line and end the session.
-                                      The de key
+  :Differ mergetool [path]            Open the merge tool on a conflicted
+                                      file; no argument takes the current
+                                      file, else the only conflicted one,
+                                      else a picker
 
   :Differ sidecar                     Smoke-check the Go sidecar: start
                                       it, round-trip a handshake, and
@@ -240,117 +420,10 @@ SESSION AND SIDECAR COMMANDS       *differ-usage-session-and-sidecar-commands*
                                       caches (file blobs and PR review
                                       threads)
   -----------------------------------------------------------------------
-`:Differ sidecar` is the diagnostic to reach for when PR review doesn’t work.
-It tells a sidecar that was never built (`make go-build`) apart from a protocol
-mismatch or a `gh` auth failure, and it’s the only thing that reports which
-binary is actually running.
-
-`:Differ cache clear` is worth knowing about because the sidecar memoises
-review threads for the life of the process and flushes them only on your own
-mutations, so a colleague’s comment posted while you have the PR open won’t
-show up until you clear it. File blobs are keyed by commit sha and can’t go
-stale, so clearing those only costs a refetch.
-
-
-DIAGNOSTICS                                         *differ-usage-diagnostics*
-
-`:checkhealth differ` is the first thing to run when something doesn’t work.
-It reports the Neovim floor and `termguicolors`, git, the options you passed to
-`setup()`, the resolved sidecar binary and whether it completes a handshake,
-and whether a GitHub token is available. A sidecar that died during the session
-is reported there too, with the last thing it wrote.
-
-An option that doesn’t name a real key, or that carries a value outside a
-closed set (`panel.position = "middle"`), is reported once at startup and again
-by `:checkhealth`. differ still starts, and the value it can’t honour falls
-back to its default.
-
-The sidecar logs to its stderr, which differ keeps rather than lets through to
-your terminal, so `:checkhealth differ` is where it surfaces: what a process
-said before it died, and what a running one has said since. The tail also comes
-with the error when a request fails on a sidecar that has just died. Nothing
-there carries your token.
-
-
-LAUNCHERS                                             *differ-usage-launchers*
-
-differ ships no global launchers - only the in-view buffer maps above and the
-optional `command_alias`. Everything you do _inside_ a session already has a
-key, so a launcher only earns its place for the handful of entry points you
-reach from an ordinary file, where no differ buffer exists yet to bind to.
-These are the ones I drive it with; lift them wholesale or trim to taste.
-
-lazy.nvim spec with <leader>d_ / <leader>p_ launchers ~
-
->lua
-    {
-      "undont/differ.nvim",
-      build = "make go-build",
-      cmd = { "Differ", "D" }, -- "D" matches command_alias below; see note above
-      keys = {
-        -- local diff / history
-        { '<leader>do', '<cmd>Differ<CR>',                        desc = "Diff: open (vs index)" },
-        { "<leader>dt", "<cmd>Differ base<CR>",                   desc = "Diff: branch total (vs base)" },
-        { "<leader>dh", "<cmd>Differ log<CR>",                    desc = "Diff: file history" },
-        { "<leader>dp", "<cmd>Differ log origin/HEAD...HEAD<CR>", desc = "Diff: PR range (local, no API)" },
-        -- pr review (sidecar + github)
-        { "<leader>pl", "<cmd>Differ pr list<CR>",                desc = "PR: list" },
-        {
-          "<leader>po",
-          function()
-            vim.ui.input({ prompt = "PR number: " }, function(input)
-              if input and input ~= "" then vim.cmd("Differ pr " .. input) end
-            end)
-          end,
-          desc = "PR: open by number",
-        },
-      },
-      config = function()
-        require("differ").setup({ command_alias = "D" })
-      end,
-    }
-<
-
-Once a session is open, `dc` / `dd` / `dl` close it and toggle the panel and
-layout, and `gS` / `gD` submit or discard a review without leaving the files.
-The rest of the PR verbs (`checks`, `checkout`, `ready`, `draft`, `close`,
-`merge`, `browser`, `url`) stay as `:Differ pr <verb>` - once-per-PR actions
-that don’t earn a keymap.
-
-If which-key’s `<leader>` popup doesn’t open over differ’s buffers,
-that’s a trigger-registration quirk on scratch buffers, not a differ bug;
-troubleshooting <TROUBLESHOOTING.md#which-key-popups-over-differ-buffers> has
-the workaround.
-
-
-STATUSLINE                                           *differ-usage-statusline*
-
-The diff buffers use a private `differdiff` filetype rather than the source
-file’s, so foreign `FileType <lang>` autocmds (LSP, linters, semantic tokens)
-don’t attach to a throwaway `differ://` buffer. The source filetype is
-stashed in `b:differ_filetype`, so a statusline can still show the language.
-
-For lualine, differ ships a drop-in for the stock `filetype` component, which
-shows the source filetype (with its devicon) on differ buffers and the native
-filetype everywhere else:
-
->lua
-    sections = { lualine_x = { require("differ.lualine").filetype } }
-<
-
-Any custom statusline can read the buffer var directly, lualine or not (it’s
-simply absent on every other buffer):
-
->lua
-    local function diff_filetype()
-      local ft = vim.b.differ_filetype
-      return (type(ft) == "string" and ft ~= "") and ft or vim.bo.filetype
-    end
-<
-
-Under a `cmd` lazy-load, prefer that over `require("differ.lualine")`, which
-loads the whole plugin at startup; see troubleshooting
-<TROUBLESHOOTING.md#statusline-requires-under-lazy-loading>.
+`:checkhealth differ` reports the requirements, your `setup()` options, the
+resolved sidecar and its handshake, and a GitHub token if one is available.
+Troubleshooting <TROUBLESHOOTING.md> (|differ-troubleshooting.txt|) covers what
+to do when one of them is wrong.
 
 
 LUA API                                                 *differ-usage-lua-api*
@@ -389,6 +462,10 @@ LUA API                                                 *differ-usage-lua-api*
       end,
     })
 <
+
+Launchers for the entry points differ leaves unbound, and a lualine drop-in for
+the diff buffers’ private filetype, are in recipes <RECIPES.md>
+(|differ-recipes.txt|).
 
 Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
 


### PR DESCRIPTION
## Summary

- `RECIPES.md` and `TROUBLESHOOTING.md` each generate a helpfile now; `make vimdoc` loops over three source/doc pairs and ci checks `doc/` wholesale
- unfence `## Installation`; `:h differ` carried no install guidance
- config defaults grouped by area, keys unchanged; usage covers the full `:Differ pr` surface and the `base` / `log` entry points

## Test plan

- [x] `make check`
- [x] `make vimdoc` reproduces all three `doc/*.txt`
