### PR TITLE
fix: stage, discard and review renamed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `:checkhealth differ` warns when `status.renames` and `diff.renames` disagree, which is what leaves the file panel listing a rename as an add and a delete where a rev-pair diff lists it as a rename
+
+### Fixed
+
+- `s` and `u` refused to act on a renamed or copied file, so the review walk stopped dead at the first one and a staged rename showed its hunks unmarked. Both now stage and unstage the rename as a unit, moving its old and new path together
+- `u` on a renamed file's panel row unstaged only its new path, leaving the old path's deletion staged behind. The panel row and the diff window now cover the same paths
+- Staging a whole-file change back after unstaging it also staged the file's unstaged changes, which its diff never showed, without saying so. It now warns when that happens
+- A git change made outside differ could swap the open diff onto the file's other pair without a word, leaving the staging keys acting on something other than what was being reviewed. The swap is now reported
+- The `s` and `u` review walk stepped over a rename with no lines to show, so it announced the review finished with that rename still staged. The walk now stops on one; `gg`, `G` and the initial open still skip past them
+- `X` on a renamed file always refused with "changed since the prompt". It now undoes the rename, restoring the old path and dropping the new one, and says which path it will restore before you confirm
+
+## [0.1.39] — 2026-09-05
+
+### Added
+
 - `:h differ-recipes` and `:h differ-troubleshooting`: launchers, the statusline drop-in and the highlight groups in one, diagnosis and the plugin-interaction edge cases in the other
 - `:h differ` carries the installation section, including the two hooks mini.deps needs to rebuild the sidecar on update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- `s` and `u` refused to act on a renamed or copied file, so the review walk stopped dead at the first one and a staged rename showed its hunks unmarked. Both now stage and unstage the rename as a unit, moving its old and new path together
+- `s` and `u` refused to act on a renamed or copied file, so the review walk stopped dead at the first one and a staged rename showed its hunks unmarked. A rename now stages like anything else: hunk by hunk where it carries content edits, and as a whole where it does not, moving its old and new path together
 - `u` on a renamed file's panel row unstaged only its new path, leaving the old path's deletion staged behind. The panel row and the diff window now cover the same paths
 - Staging a whole-file change back after unstaging it also staged the file's unstaged changes, which its diff never showed, without saying so. It now warns when that happens
 - A git change made outside differ could swap the open diff onto the file's other pair without a word, leaving the staging keys acting on something other than what was being reviewed. The swap is now reported
-- The `s` and `u` review walk stepped over a rename with no lines to show, so it announced the review finished with that rename still staged. The walk now stops on one; `gg`, `G` and the initial open still skip past them
+- The `s` and `u` review walk stepped over a rename with no lines to show, so it announced the review finished with that rename still staged, and `gg`, `G`, `]]`, `[[` and the initial open all started past one. Nothing skips them now
 - `X` on a renamed file always refused with "changed since the prompt". It now undoes the rename, restoring the old path and dropping the new one, and says which path it will restore before you confirm
 
 ## [0.1.39] — 2026-09-05

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -761,6 +761,38 @@ function M.unstage_all(root)
     return git_ok({ "reset", "-q", "HEAD" }, root, "unstage all")
 end
 
+-- the paths one entry's staging ops act on. a rename moves two and they go together:
+-- resetting only the new one leaves the old path's deletion staged, a half-undone
+-- rename, and `git add` on the old path stages that same deletion back. a copy leaves
+-- its source alone, so it owns the new path only
+---@param entry differ.FileEntry
+---@return string[]
+local function entry_paths(entry)
+    if entry.status == "R" and entry.previous_path then
+        return { entry.path, entry.previous_path }
+    end
+    return { entry.path }
+end
+
+-- move every path an entry owns into or out of the index. the panel's file-level keys
+-- and the diff view's whole-file staging both run through here, so they can't disagree
+-- about what a rename covers
+---@param root string
+---@param entry differ.FileEntry
+---@param staged boolean
+---@return boolean ok
+local function set_staged(root, entry, staged)
+    local ok = true
+    for _, p in ipairs(entry_paths(entry)) do
+        if staged then
+            ok = M.stage(root, p) and ok
+        else
+            ok = M.unstage(root, p) and ok
+        end
+    end
+    return ok
+end
+
 -- apply a single-hunk patch, atomically. `--unidiff-zero` because the patch carries
 -- no context (built straight from the hunk model); `--reverse` undoes rather than
 -- applies. `target` picks the side written: the index for hunk staging, the worktree
@@ -825,7 +857,13 @@ end
 ---@param entry differ.FileEntry
 ---@return string|nil status
 local function live_status(root, entry)
-    local out = git({ "status", "--porcelain=v1", "-z", "-uall", "--", entry.path }, root)
+    local args = { "status", "--porcelain=v1", "-z", "-uall", "--", entry.path }
+    -- git pairs a rename only when both its paths are in the pathspec; narrowed to the
+    -- new one, it reports a plain add
+    if entry.previous_path then
+        args[#args + 1] = entry.previous_path
+    end
+    local out = git(args, root)
     for _, s in ipairs(rev.parse_status(out or "")) do
         if s.path == entry.path then
             return s.x == "?" and "?" or (entry.staged and s.x or s.y)
@@ -914,10 +952,18 @@ function M.discard(root, entry)
     local ok
     if entry.status == "?" then
         ok = remove_ok(abs)
-    elseif entry.status == "A" then
+    elseif entry.status == "A" or entry.status == "C" then
         -- unstage the add before dropping the file, and don't drop it if that failed:
-        -- the index would keep an add for a file no longer on disk
+        -- the index would keep an add for a file no longer on disk. a copy's source is
+        -- untouched, so its new path is an add like any other
         ok = git_ok({ "reset", "-q", "HEAD", "--", entry.path }, root, "discard") and remove_ok(abs)
+    elseif entry.status == "R" and entry.previous_path then
+        -- a move rather than a change: bring the old path back from HEAD, then drop the
+        -- new one like an add. `checkout HEAD -- <new path>` is what the else branch
+        -- would run, and HEAD has no such path for it to read
+        ok = git_ok({ "checkout", "HEAD", "--", entry.previous_path }, root, "discard")
+            and git_ok({ "reset", "-q", "HEAD", "--", entry.path }, root, "discard")
+            and remove_ok(abs)
     else
         ok = git_ok({ "checkout", "HEAD", "--", entry.path }, root, "discard") -- index + worktree
     end
@@ -925,6 +971,9 @@ function M.discard(root, entry)
         return false
     end
     reload_buffer(root, entry.path)
+    if entry.previous_path then
+        reload_buffer(root, entry.previous_path) -- back on disk, so a buffer on it is stale
+    end
     return true
 end
 
@@ -1107,10 +1156,10 @@ function M.panel(opts)
         end
         actions = {
             stage = function(entry)
-                M.stage(root, entry.path)
+                set_staged(root, entry, true)
             end,
             unstage = function(entry)
-                M.unstage(root, entry.path)
+                set_staged(root, entry, false)
             end,
             stage_all = function()
                 M.stage_all(root)
@@ -1154,15 +1203,12 @@ function M.panel(opts)
     local on_edit_unstage ---@type fun(path: string)|nil -- assigned below; passed to the view
     local settle_pair ---@type fun(): boolean -- assigned below; the staging follow hook
 
-    -- hunk-level staging: plain modifications (status "M", same path both
-    -- sides) stage by hunk; a new file (untracked "?" or staged add "A") diffs
-    -- empty<->content as one whole-file hunk, so it stages as a unit; renames/
-    -- copies/deletes stay file-level in the panel. the view keeps its diff frozen
-    -- and marks staged hunks in place, so it tracks per-hunk state and asks `apply`
-    -- to patch one hunk: forward stages, `reverse` unstages, and `offset` shifts the
-    -- patch past already-staged hunks before it. `initial` is every hunk's starting
-    -- state (an unstaged diff opens unstaged, a staged one opens staged). the panel
-    -- refreshes its counts after each op
+    -- hunk-level staging. only a plain modification with hunks patches by hunk; every
+    -- other status sets `whole_file`, which the view acts on as one slot however many
+    -- hunks it shows. the view keeps its diff frozen and marks staged hunks in place,
+    -- so it asks `apply` to patch one hunk: forward stages, `reverse` unstages,
+    -- `offset` shifts the patch past the hunks staged before it. `initial` is the
+    -- starting state, matching the pair on screen
     local stageable = is_worktree_status(source)
     local active_entry ---@type differ.FileEntry|nil -- the file the view currently shows
 
@@ -1295,19 +1341,24 @@ function M.panel(opts)
                 settle = settle,
             }
         end
-        -- a new file and a deletion are each one whole-file hunk against an empty side,
-        -- so there's nothing to patch partially: staging is a wholesale `git add`,
-        -- unstaging a `git reset`. only the revert tells the two apart
-        local function whole_file_apply(_, _, _, reverse)
+        -- shared by every whole-file status below, which differ only in their revert.
+        -- `git add` reads the file off disk, so on a staged pair (HEAD↔index) it also
+        -- stages whatever the file's unstaged row holds, which this diff never showed.
+        -- reachable by unstaging a whole-file change and staging it back
+        local function whole_file_apply(model, _, _, reverse)
             if reverse then
-                return M.unstage(root, entry.path)
+                return set_staged(root, entry, false)
             end
-            return M.stage(root, entry.path)
+            local ok = set_staged(root, entry, true)
+            if ok and entry.staged and M.read(WORKTREE, root, entry.path) ~= model.new_text then
+                local msg = "%s is fully staged now, including the edits you had left unstaged"
+                notify(msg:format(entry.path), vim.log.levels.WARN)
+            end
+            return ok
         end
-        -- a modification with no hunks to patch: a mode change, a submodule pointer, a
-        -- binary file, a change git normalises away. `git add` stages exactly what git
-        -- would. no revert: `git checkout --` would also throw away content the diff
-        -- never showed, and the panel's own X still discards behind its confirm
+        -- a modification with no hunks: a mode change, a submodule pointer, a binary
+        -- file, a change git normalises away. no revert, since the diff never showed
+        -- the content `git checkout --` would drop
         if entry.status == "M" then
             return {
                 initial = entry.staged and "staged" or "unstaged",
@@ -1322,8 +1373,7 @@ function M.panel(opts)
                 initial = entry.staged and "staged" or "unstaged",
                 whole_file = true,
                 apply = whole_file_apply,
-                -- the file is the hunk, so reverting it is deleting it; `discard`
-                -- already knows to drop the staged add first
+                -- `discard` drops the staged add before removing the file
                 revert = function()
                     return M.discard(root, entry)
                 end,
@@ -1337,11 +1387,22 @@ function M.panel(opts)
                 initial = entry.staged and "staged" or "unstaged",
                 whole_file = true,
                 apply = whole_file_apply,
-                -- the mirror: a deletion is restored rather than removed
                 revert = function()
                     return restore_deleted(entry)
                 end,
                 revert_label = "restores the file",
+                refresh = refresh_panel,
+                settle = settle,
+            }
+        end
+        -- no revert: undoing a move isn't a patch, and the panel's X does it. unlike the
+        -- statuses above this one can carry several hunks, which the view's `whole_file`
+        -- slot marks and clears as a unit
+        if entry.status == "R" or entry.status == "C" then
+            return {
+                initial = entry.staged and "staged" or "unstaged",
+                whole_file = true,
+                apply = whole_file_apply,
                 refresh = refresh_panel,
                 settle = settle,
             }
@@ -1460,6 +1521,49 @@ function M.panel(opts)
         end
     end
 
+    -- point the view at the shown file's current changes after the list moved under it,
+    -- preferring the pair it was on; staging the whole file empties that pair, so fall
+    -- back to the other, and to the nearest surviving change when the file went clean
+    -- (committed on its own, checked out) rather than strand the window on a diff that
+    -- matches HEAD. `outside` says the change wasn't differ's own doing, which is the
+    -- only case where landing on a different pair is worth reporting: the staging keys
+    -- now act on a diff the user didn't choose. returns whether the view was re-sourced
+    ---@param outside boolean
+    ---@return boolean
+    local function retarget_view(outside)
+        if not (view and view:is_open() and active_entry) then
+            return false
+        end
+        -- the content shifted underneath the user; hold the cursor near where it was
+        -- (the nearest hunk to its new-side line) rather than snapping to the top
+        local focus_line, focus_col = view:cursor_new_line()
+        local candidates = entries_for_path(active_entry.path)
+        local pick = candidates[1]
+        for _, e in ipairs(candidates) do
+            if e.staged == active_entry.staged then
+                pick = e
+                break
+            end
+        end
+        local was = active_entry
+        if pick and show_entry(pick, focus_line, focus_col) then
+            if outside and (pick.staged ~= was.staged or pick.status ~= was.status) then
+                local msg = "%s changed outside differ; showing its %s change instead"
+                notify(msg:format(pick.path, pick.staged and "staged" or "unstaged"))
+            end
+            return true
+        end
+        -- nothing here is user-driven, so focus goes back where it was
+        local focused = vim.api.nvim_get_current_win()
+        if panel:open_nearest(true) then
+            if vim.api.nvim_win_is_valid(focused) then
+                vim.api.nvim_set_current_win(focused)
+            end
+            return true
+        end
+        return false
+    end
+
     -- after an external git change (lazygit, a tmux-pane commit, `:!git`): refresh the
     -- list, then re-source the open diff so it reflects the new state too rather than
     -- staying frozen. gated on the signature so unrelated terminal events are no-ops
@@ -1480,36 +1584,8 @@ function M.panel(opts)
         -- a merge started under a live session runs no command, so the dispatch gate
         -- never sees it
         M.notify_conflicts(root, M.conflicted(root))
-        if view and view:is_open() and active_entry then
-            -- the content shifted underneath the user; hold the cursor near where it was
-            -- (the nearest hunk to its new-side line) rather than snapping to the top
-            local focus_line, focus_col = view:cursor_new_line()
-            -- re-target the view to the file's current changes, preferring the pair it
-            -- was on; staging the whole file empties that pair, so fall back to the
-            -- other. show_entry records the signature when it sources
-            local candidates = entries_for_path(active_entry.path)
-            local pick = candidates[1]
-            for _, e in ipairs(candidates) do
-                if e.staged == active_entry.staged then
-                    pick = e
-                    break
-                end
-            end
-            if pick and show_entry(pick, focus_line, focus_col) then
-                return
-            end
-            -- the shown file went clean while others survived (committed on its own,
-            -- checked out). there's nothing to re-source it to, so hand the window to
-            -- the nearest surviving change rather than strand it on a diff of a file
-            -- that now matches HEAD, which no later refresh would ever move off.
-            -- nothing here is user-driven, so focus goes back where it was
-            local focused = vim.api.nvim_get_current_win()
-            if panel:open_nearest(true) then
-                if vim.api.nvim_win_is_valid(focused) then
-                    vim.api.nvim_set_current_win(focused)
-                end
-                return
-            end
+        if retarget_view(true) then
+            return
         end
         -- no view, and nothing to hand over to: just record the state
         record_state()
@@ -1538,6 +1614,15 @@ function M.panel(opts)
         actions = actions,
         on_external_change = refresh_external,
         on_refresh = record_state,
+        -- the panel's own staging keys move the pair the diff was built from, so the
+        -- window has to follow. differ's own doing, so it re-sources without reporting.
+        -- only for the file on screen: staging some other row must leave this diff
+        -- frozen, since its in-place marks are the staging session's own state
+        on_staged = function(paths)
+            if active_entry and not (paths and not paths[active_entry.path]) then
+                retarget_view(false)
+            end
+        end,
         keymaps = cfg.keymaps.panel --[[@as differ.KeymapSet]],
         listing = opts.listing or panel_cfg.listing,
         position = opts.position or panel_cfg.position,
@@ -1587,8 +1672,8 @@ function M.panel(opts)
     panel.return_tab = return_tab
     if opts.open_first then
         -- land on the file (and line) :Differ was run from when it's in the change
-        -- set, else the first unstaged file (skipping the Staged section, and pure
-        -- renames which diff to a blank view); leave the cursor in the diff, not the panel.
+        -- set, else the first unstaged file (skipping the Staged section); leave the
+        -- cursor in the diff, not the panel.
         -- a file changed on both pairs ("MM") takes its unstaged row: origin_line is a
         -- worktree line, and index↔worktree is the only pair in that coordinate space
         local on_origin = origin_rel and panel:focus_file(origin_rel, true)

--- a/lua/differ/git/init.lua
+++ b/lua/differ/git/init.lua
@@ -761,10 +761,8 @@ function M.unstage_all(root)
     return git_ok({ "reset", "-q", "HEAD" }, root, "unstage all")
 end
 
--- the paths one entry's staging ops act on. a rename moves two and they go together:
--- resetting only the new one leaves the old path's deletion staged, a half-undone
--- rename, and `git add` on the old path stages that same deletion back. a copy leaves
--- its source alone, so it owns the new path only
+-- the paths one entry's staging ops act on: a rename owns both ends of the move, a copy
+-- only its new path
 ---@param entry differ.FileEntry
 ---@return string[]
 local function entry_paths(entry)
@@ -774,9 +772,8 @@ local function entry_paths(entry)
     return { entry.path }
 end
 
--- move every path an entry owns into or out of the index. the panel's file-level keys
--- and the diff view's whole-file staging both run through here, so they can't disagree
--- about what a rename covers
+-- move every path an entry owns into or out of the index. the panel's file keys and the
+-- diff view's whole-file staging share it
 ---@param root string
 ---@param entry differ.FileEntry
 ---@param staged boolean
@@ -858,8 +855,7 @@ end
 ---@return string|nil status
 local function live_status(root, entry)
     local args = { "status", "--porcelain=v1", "-z", "-uall", "--", entry.path }
-    -- git pairs a rename only when both its paths are in the pathspec; narrowed to the
-    -- new one, it reports a plain add
+    -- git pairs a rename only with both paths in the pathspec; with one it reports an add
     if entry.previous_path then
         args[#args + 1] = entry.previous_path
     end
@@ -955,12 +951,10 @@ function M.discard(root, entry)
     elseif entry.status == "A" or entry.status == "C" then
         -- unstage the add before dropping the file, and don't drop it if that failed:
         -- the index would keep an add for a file no longer on disk. a copy's source is
-        -- untouched, so its new path is an add like any other
+        -- untouched, so its new path is an add
         ok = git_ok({ "reset", "-q", "HEAD", "--", entry.path }, root, "discard") and remove_ok(abs)
     elseif entry.status == "R" and entry.previous_path then
-        -- a move rather than a change: bring the old path back from HEAD, then drop the
-        -- new one like an add. `checkout HEAD -- <new path>` is what the else branch
-        -- would run, and HEAD has no such path for it to read
+        -- undoing a move: the old path comes back from HEAD, the new one goes like an add
         ok = git_ok({ "checkout", "HEAD", "--", entry.previous_path }, root, "discard")
             and git_ok({ "reset", "-q", "HEAD", "--", entry.path }, root, "discard")
             and remove_ok(abs)
@@ -1203,12 +1197,9 @@ function M.panel(opts)
     local on_edit_unstage ---@type fun(path: string)|nil -- assigned below; passed to the view
     local settle_pair ---@type fun(): boolean -- assigned below; the staging follow hook
 
-    -- hunk-level staging. only a plain modification with hunks patches by hunk; every
-    -- other status sets `whole_file`, which the view acts on as one slot however many
-    -- hunks it shows. the view keeps its diff frozen and marks staged hunks in place,
-    -- so it asks `apply` to patch one hunk: forward stages, `reverse` unstages,
-    -- `offset` shifts the patch past the hunks staged before it. `initial` is the
-    -- starting state, matching the pair on screen
+    -- hunk-level staging. content edits patch by hunk; anything with no lines to patch
+    -- sets `whole_file`. the view keeps its diff frozen, so `apply` patches one hunk:
+    -- forward stages, `reverse` unstages, `offset` shifts past the hunks staged before it
     local stageable = is_worktree_status(source)
     local active_entry ---@type differ.FileEntry|nil -- the file the view currently shows
 
@@ -1320,7 +1311,11 @@ function M.panel(opts)
         local function settle()
             return settle_pair()
         end
-        if entry.status == "M" and #diff.hunks > 0 then
+        -- git records no rename, only the old path gone from the index and the new one
+        -- present, so a hunk patches an ordinary blob and the move rides along untouched.
+        -- the move is whole-file and belongs to the panel row's keys
+        local hunk_level = entry.status == "M" or entry.status == "R" or entry.status == "C"
+        if hunk_level and #diff.hunks > 0 then
             return {
                 initial = entry.staged and "staged" or "unstaged",
                 apply = function(model, hunk, offset, reverse)
@@ -1341,10 +1336,8 @@ function M.panel(opts)
                 settle = settle,
             }
         end
-        -- shared by every whole-file status below, which differ only in their revert.
-        -- `git add` reads the file off disk, so on a staged pair (HEAD↔index) it also
-        -- stages whatever the file's unstaged row holds, which this diff never showed.
-        -- reachable by unstaging a whole-file change and staging it back
+        -- shared by every whole-file status below. `git add` reads the file off disk, so
+        -- on a staged pair it also stages whatever the file's unstaged row holds
         local function whole_file_apply(model, _, _, reverse)
             if reverse then
                 return set_staged(root, entry, false)
@@ -1357,8 +1350,7 @@ function M.panel(opts)
             return ok
         end
         -- a modification with no hunks: a mode change, a submodule pointer, a binary
-        -- file, a change git normalises away. no revert, since the diff never showed
-        -- the content `git checkout --` would drop
+        -- file, a change git normalises away
         if entry.status == "M" then
             return {
                 initial = entry.staged and "staged" or "unstaged",
@@ -1395,9 +1387,7 @@ function M.panel(opts)
                 settle = settle,
             }
         end
-        -- no revert: undoing a move isn't a patch, and the panel's X does it. unlike the
-        -- statuses above this one can carry several hunks, which the view's `whole_file`
-        -- slot marks and clears as a unit
+        -- a rename or copy with no content to patch: the move is all there is
         if entry.status == "R" or entry.status == "C" then
             return {
                 initial = entry.staged and "staged" or "unstaged",
@@ -1521,21 +1511,16 @@ function M.panel(opts)
         end
     end
 
-    -- point the view at the shown file's current changes after the list moved under it,
-    -- preferring the pair it was on; staging the whole file empties that pair, so fall
-    -- back to the other, and to the nearest surviving change when the file went clean
-    -- (committed on its own, checked out) rather than strand the window on a diff that
-    -- matches HEAD. `outside` says the change wasn't differ's own doing, which is the
-    -- only case where landing on a different pair is worth reporting: the staging keys
-    -- now act on a diff the user didn't choose. returns whether the view was re-sourced
+    -- re-source the view onto the shown file's current changes, preferring the pair it
+    -- was on, then the other pair, then the nearest surviving change. `outside` announces
+    -- a landing on a different change
     ---@param outside boolean
-    ---@return boolean
+    ---@return boolean sourced
     local function retarget_view(outside)
         if not (view and view:is_open() and active_entry) then
             return false
         end
-        -- the content shifted underneath the user; hold the cursor near where it was
-        -- (the nearest hunk to its new-side line) rather than snapping to the top
+        -- hold the cursor near where it was rather than snapping to the top
         local focus_line, focus_col = view:cursor_new_line()
         local candidates = entries_for_path(active_entry.path)
         local pick = candidates[1]
@@ -1553,7 +1538,7 @@ function M.panel(opts)
             end
             return true
         end
-        -- nothing here is user-driven, so focus goes back where it was
+        -- restore focus: nothing here came from a keypress
         local focused = vim.api.nvim_get_current_win()
         if panel:open_nearest(true) then
             if vim.api.nvim_win_is_valid(focused) then
@@ -1614,10 +1599,8 @@ function M.panel(opts)
         actions = actions,
         on_external_change = refresh_external,
         on_refresh = record_state,
-        -- the panel's own staging keys move the pair the diff was built from, so the
-        -- window has to follow. differ's own doing, so it re-sources without reporting.
-        -- only for the file on screen: staging some other row must leave this diff
-        -- frozen, since its in-place marks are the staging session's own state
+        -- the panel's keys move the pair the diff was built from, so the window follows.
+        -- only for the file on screen: another row's diff keeps its frozen marks
         on_staged = function(paths)
             if active_entry and not (paths and not paths[active_entry.path]) then
                 retarget_view(false)

--- a/lua/differ/health.lua
+++ b/lua/differ/health.lua
@@ -30,9 +30,8 @@ local function check_nvim()
     end
 end
 
--- a boolean git config key, or nil when it isn't set. `--type=bool` collapses the
--- spellings git accepts (`0`, `no`, `off`); it refuses `copies`, which is rename
--- detection plus copy detection and so reads as on
+-- a boolean git config key, or nil when unset. `--type=bool` collapses git's spellings
+-- (`0`, `no`, `off`) and refuses `copies`, which is renames plus copies, so reads as on
 ---@param key string
 ---@return boolean|nil
 local function git_bool(key)
@@ -46,10 +45,9 @@ local function git_bool(key)
     return true
 end
 
--- git pairs renames off two keys, and `status.renames` defaults to `diff.renames`, so
--- the two only disagree when it was set on its own. the file panel lists through `git
--- status` and a rev-pair diff through `git diff`, so that split shows one change set
--- two ways, with different file counts
+-- `status.renames` defaults to `diff.renames`, so the two only disagree when it was set
+-- on its own. the file panel lists through `git status` and a rev-pair diff through
+-- `git diff`, so that split shows one change set two ways
 local function check_renames()
     local status_renames = git_bool("status.renames")
     if status_renames == nil then

--- a/lua/differ/health.lua
+++ b/lua/differ/health.lua
@@ -30,6 +30,51 @@ local function check_nvim()
     end
 end
 
+-- a boolean git config key, or nil when it isn't set. `--type=bool` collapses the
+-- spellings git accepts (`0`, `no`, `off`); it refuses `copies`, which is rename
+-- detection plus copy detection and so reads as on
+---@param key string
+---@return boolean|nil
+local function git_bool(key)
+    local res = vim.system({ "git", "config", "--get", "--type=bool", key }, { text = true }):wait()
+    if res.code == 0 then
+        return vim.trim(res.stdout or "") == "true"
+    end
+    if res.code == 1 then
+        return nil -- not set
+    end
+    return true
+end
+
+-- git pairs renames off two keys, and `status.renames` defaults to `diff.renames`, so
+-- the two only disagree when it was set on its own. the file panel lists through `git
+-- status` and a rev-pair diff through `git diff`, so that split shows one change set
+-- two ways, with different file counts
+local function check_renames()
+    local status_renames = git_bool("status.renames")
+    if status_renames == nil then
+        return
+    end
+    local diff_renames = git_bool("diff.renames")
+    if diff_renames == nil then
+        diff_renames = true -- git's own default
+    end
+    if status_renames == diff_renames then
+        return
+    end
+    local panel, pair = "an add and a delete", "a rename"
+    if status_renames then
+        panel, pair = pair, panel
+    end
+    health.warn(
+        ("status.renames is `%s` but diff.renames is `%s`"):format(status_renames, diff_renames),
+        {
+            ("the file panel lists a rename as %s, a rev-pair diff as %s"):format(panel, pair),
+            "set diff.renames to cover both, or unset status.renames",
+        }
+    )
+end
+
 local function check_git()
     health.start("git")
     if vim.fn.executable("git") ~= 1 then
@@ -42,6 +87,7 @@ local function check_git()
         return health.error("git is on PATH but `git --version` failed: " .. (res.stderr or ""))
     end
     health.ok(vim.trim(res.stdout or "git found"))
+    check_renames()
 end
 
 local function check_config()

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -126,8 +126,8 @@ Panel.__index = Panel
 -- and the watcher doesn't read them back as an outside change
 ---@field on_refresh? fun()
 -- fired after the panel's own staging keys, so the session can re-source the diff it
--- drives. not on_refresh, which every reload fires: the diff window's own s/u keep their
--- frozen model and repaint in place, and re-sourcing there would drop the staged marks
+-- drives. separate from on_refresh, which every reload fires: the diff window's own
+-- s / u keep their frozen marks
 ---@field on_staged? fun(paths: table<string, boolean>|nil)
 ---@field root? string  -- repo/worktree path shown in the panel header
 ---@field footer? string -- rev spec shown under "Showing changes for:"
@@ -785,10 +785,8 @@ function Panel:stage_op(op)
     self:_after_stage_op(paths)
 end
 
--- reload the list after one of the panel's own staging ops, then hand the session its
--- chance to re-source the driven diff. `paths` names what the op moved, nil meaning
--- every file, so the session can leave a diff of some other file alone. a reload that
--- empties the change set can end the session, so the hook only runs while it's alive
+-- reload the list after one of the panel's own staging ops, then let the session
+-- re-source the diff it drives. `paths` is what the op moved, nil meaning every file
 ---@param paths table<string, boolean>|nil
 function Panel:_after_stage_op(paths)
     self:refresh()
@@ -797,8 +795,7 @@ function Panel:_after_stage_op(paths)
     end
 end
 
--- what X names in its confirm for one entry: undoing a rename puts the old path back
--- on disk, which the path being discarded doesn't say on its own
+-- what X names in its confirm: undoing a rename puts the old path back on disk too
 ---@param e differ.FileEntry
 ---@return string
 local function discard_label(e)
@@ -934,15 +931,13 @@ function Panel:goto_file(direction, keep_focus, wrap)
     return true
 end
 
--- the first/last file row. a pure rename lands like any other: it diffs to nothing, but
--- it stages, unstages and discards as a file, so passing over it would put a row that
--- needs acting on out of reach of the motion that names it
+-- the first/last file row. a pure rename lands like any other: it diffs to nothing but
+-- still stages, unstages and discards as a file
 ---@param edge "first"|"last"
 ---@return integer|nil
 function Panel:_edge_file_row(edge)
     local from = edge == "first" and 0 or #self.meta + 1
-    -- bound, not tail-returned: _file_row also reports whether it wrapped, which is
-    -- no part of this answer
+    -- bound, not tail-returned: _file_row also reports whether it wrapped
     local row = self:_file_row(from, edge == "first" and "next" or "prev", false)
     return row
 end
@@ -965,13 +960,9 @@ function Panel:focus_first_unstaged()
     self:focus_first_changed()
 end
 
--- the staging review flow's file step: the nearest file row in `direction` holding
--- something to do on the `staged` pair, cycling past the list ends so the files above a
--- bottom-of-list entry stay reachable. the open file is skipped whichever row it sits
--- on, since re-opening it would re-source the frozen diff and drop the marks the
--- in-session staging put there; what's left inside it is the caller's last resort,
--- tried only once this returns false. a blank rename is a stop like any other: it shows
--- no lines but still stages and unstages as a file
+-- the review flow's file step: the nearest row in `direction` with something left to do,
+-- wrapping past the list ends. the open file is skipped, since re-opening it would
+-- re-source its frozen diff and drop the staging marks
 ---@param direction "next"|"prev"
 ---@param staged boolean  -- the pair hunted: false for a file with hunks left to stage
 ---@param keep_focus boolean|nil

--- a/lua/differ/panel/init.lua
+++ b/lua/differ/panel/init.lua
@@ -84,6 +84,7 @@ local STATUS_HL = {
 ---@field on_external_change fun()|nil
 ---@field on_empty fun()|nil
 ---@field on_refresh fun()|nil
+---@field on_staged fun(paths: table<string, boolean>|nil)|nil
 ---@field root string|nil
 ---@field footer string|nil
 ---@field actions differ.panel.Actions|nil
@@ -124,6 +125,10 @@ Panel.__index = Panel
 -- change signature here, so the panel's own staging keys are recorded as differ's doing
 -- and the watcher doesn't read them back as an outside change
 ---@field on_refresh? fun()
+-- fired after the panel's own staging keys, so the session can re-source the diff it
+-- drives. not on_refresh, which every reload fires: the diff window's own s/u keep their
+-- frozen model and repaint in place, and re-sourcing there would drop the staged marks
+---@field on_staged? fun(paths: table<string, boolean>|nil)
 ---@field root? string  -- repo/worktree path shown in the panel header
 ---@field footer? string -- rev spec shown under "Showing changes for:"
 ---@field actions? differ.panel.Actions -- file-level staging hooks (slice C)
@@ -169,6 +174,7 @@ function Panel.new(opts)
         on_external_change = opts.on_external_change,
         on_empty = opts.on_empty,
         on_refresh = opts.on_refresh,
+        on_staged = opts.on_staged,
         root = opts.root,
         footer = opts.footer,
         actions = opts.actions,
@@ -202,10 +208,7 @@ function Panel:_first_file_line()
     return 1
 end
 
--- move the cursor to the first visitable file row, skipping pure renames (which diff
--- to a blank view) but landing on untracked files (zero numstat counts, yet real
--- content). falls back to the first file when every entry is a blank rename. shares
--- the edge-jump logic so the initial open and [[/]] agree on what's visitable
+-- move the cursor to the first file row
 function Panel:focus_first_changed()
     local row = self:_edge_file_row("first")
     if row then
@@ -765,6 +768,7 @@ function Panel:stage_op(op)
     if not self.actions then
         return
     end
+    local paths ---@type table<string, boolean>|nil -- nil: the op moved every file
     if op == "stage_all" or op == "unstage_all" then
         self.actions[op]()
     else
@@ -772,11 +776,36 @@ function Panel:stage_op(op)
         if #entries == 0 then
             return
         end
+        paths = {}
         for _, e in ipairs(entries) do
             self.actions[op](e)
+            paths[e.path] = true
         end
     end
+    self:_after_stage_op(paths)
+end
+
+-- reload the list after one of the panel's own staging ops, then hand the session its
+-- chance to re-source the driven diff. `paths` names what the op moved, nil meaning
+-- every file, so the session can leave a diff of some other file alone. a reload that
+-- empties the change set can end the session, so the hook only runs while it's alive
+---@param paths table<string, boolean>|nil
+function Panel:_after_stage_op(paths)
     self:refresh()
+    if self.on_staged and self:is_alive() then
+        self.on_staged(paths)
+    end
+end
+
+-- what X names in its confirm for one entry: undoing a rename puts the old path back
+-- on disk, which the path being discarded doesn't say on its own
+---@param e differ.FileEntry
+---@return string
+local function discard_label(e)
+    if e.status == "R" and e.previous_path then
+        return ("%s (restoring %s)"):format(e.path, e.previous_path)
+    end
+    return e.path
 end
 
 -- X: discard the cursor's target after a confirm (destructive), then refresh. on a
@@ -789,13 +818,16 @@ function Panel:discard()
     if #entries == 0 then
         return
     end
-    local what = #entries == 1 and entries[1].path or ("%s (%d files)"):format(label, #entries)
+    local what = #entries == 1 and discard_label(entries[1])
+        or ("%s (%d files)"):format(label, #entries)
     local choice = vim.fn.confirm(("Discard changes to %s?"):format(what), "&Yes\n&No", 2)
     if choice == 1 then
+        local paths = {}
         for _, e in ipairs(entries) do
             self.actions.discard(e)
+            paths[e.path] = true
         end
-        self:refresh()
+        self:_after_stage_op(paths)
     end
 end
 
@@ -902,47 +934,29 @@ function Panel:goto_file(direction, keep_focus, wrap)
     return true
 end
 
--- a pure rename/copy (status R/C with no added/deleted lines) diffs to nothing, so
--- landing on it shows a blank view. untracked/added files report zero numstat counts
--- too (git doesn't diff them) but render their whole content, so they're not blank
----@param e differ.FileEntry
----@return boolean
-local function is_blank_rename(e)
-    return (e.status == "R" or e.status == "C") and (e.additions or 0) + (e.deletions or 0) == 0
-end
-
--- the first/last visitable file row, skipping pure renames (blank diffs) and falling
--- back to the absolute first/last file row when every entry is a blank rename. the
--- edge jumps skip those the way the initial open does (focus_first_changed)
+-- the first/last file row. a pure rename lands like any other: it diffs to nothing, but
+-- it stages, unstages and discards as a file, so passing over it would put a row that
+-- needs acting on out of reach of the motion that names it
 ---@param edge "first"|"last"
 ---@return integer|nil
 function Panel:_edge_file_row(edge)
-    local fallback, visitable
     local from = edge == "first" and 0 or #self.meta + 1
-    local direction = edge == "first" and "next" or "prev"
-    local i = self:_file_row(from, direction, false)
-    while i do
-        fallback = fallback or i
-        if not is_blank_rename(self.meta[i].entry) then
-            visitable = i
-            break
-        end
-        i = self:_file_row(i, direction, false)
-    end
-    return visitable or fallback
+    -- bound, not tail-returned: _file_row also reports whether it wrapped, which is
+    -- no part of this answer
+    local row = self:_file_row(from, edge == "first" and "next" or "prev", false)
+    return row
 end
 
 -- move the cursor to the first unstaged file row, skipping the Staged section so
 -- :Differ lands on the first thing left to review, falling back to the first
--- visitable file when everything is staged. mirrors the per-file _first_review_line,
--- which already prefers an unstaged hunk. pure renames are skipped as in
--- focus_first_changed; for sources without staging (rev-pair, pr) entries carry no
--- staged flag, so this degenerates to the first file
+-- first file when everything is staged. mirrors the per-file _first_review_line, which
+-- already prefers an unstaged hunk. for sources without staging (rev-pair, pr) entries
+-- carry no staged flag, so this degenerates to the first file
 function Panel:focus_first_unstaged()
     local i = self:_file_row(0, "next", false)
     while i do
         local e = self.meta[i].entry
-        if e and not e.staged and not is_blank_rename(e) then
+        if e and not e.staged then
             pcall(vim.api.nvim_win_set_cursor, self.winid, { i, 0 })
             return
         end
@@ -956,7 +970,8 @@ end
 -- bottom-of-list entry stay reachable. the open file is skipped whichever row it sits
 -- on, since re-opening it would re-source the frozen diff and drop the marks the
 -- in-session staging put there; what's left inside it is the caller's last resort,
--- tried only once this returns false. blank renames are skipped as everywhere else
+-- tried only once this returns false. a blank rename is a stop like any other: it shows
+-- no lines but still stages and unstages as a file
 ---@param direction "next"|"prev"
 ---@param staged boolean  -- the pair hunted: false for a file with hunks left to stage
 ---@param keep_focus boolean|nil
@@ -973,12 +988,7 @@ function Panel:step_review(direction, staged, keep_focus)
         end
         wrapped = wrapped or crossed
         local e = self.meta[next_row].entry
-        if
-            e
-            and (e.staged or false) == staged
-            and not is_blank_rename(e)
-            and entry_key(e) ~= self.selected_key
-        then
+        if e and (e.staged or false) == staged and entry_key(e) ~= self.selected_key then
             self.selected_row = next_row
             if self:is_open() then
                 vim.api.nvim_win_set_cursor(self.winid, { next_row, 0 })
@@ -1008,9 +1018,8 @@ function Panel:step_review(direction, staged, keep_focus)
     return false
 end
 
--- gg / G: move the cursor to the first/last visitable file row without opening it,
--- skipping pure renames (blank diffs). plain list navigation; <CR>/o opens the row
--- under the cursor
+-- gg / G: move the cursor to the first/last file row without opening it. plain list
+-- navigation; <CR>/o opens the row under the cursor
 ---@param edge "first"|"last"
 function Panel:cursor_to_edge(edge)
     if not self:is_open() then
@@ -1037,33 +1046,24 @@ function Panel:_header_rows()
     return rows
 end
 
--- the first visitable file row inside the section beginning at `header_row` (down to
--- the next header or the list end), skipping pure renames; falls back to the section's
--- first file row, or nil when the section has no visible file rows (all folded away)
+-- the first file row inside the section beginning at `header_row`, or nil when the
+-- section has no visible file rows (all folded away)
 ---@param header_row integer
 ---@return integer|nil
 function Panel:_section_first_file(header_row)
-    local stop = #self.meta
     for i = header_row + 1, #self.meta do
-        if self.meta[i].kind == "header" then
-            stop = i - 1
-            break
-        end
-    end
-    local fallback
-    for i = header_row + 1, stop do
         local m = self.meta[i]
+        if m.kind == "header" then
+            return nil -- the section holds no file rows
+        end
         if m.kind == "file" then
-            fallback = fallback or i
-            if not is_blank_rename(m.entry) then
-                return i
-            end
+            return i
         end
     end
-    return fallback
+    return nil
 end
 
--- ]] / [[: jump to the next/prev section and open its first (visitable) file. with a
+-- ]] / [[: jump to the next/prev section and open its first file. with a
 -- section fully folded away its header still gets the cursor, so the motion never
 -- stalls. inert in single-section panels. `keep_focus` is threaded to `_open`
 ---@param direction "next"|"prev"

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -81,8 +81,8 @@ local armed_view = nil
 -- what it will do to the file, the view words the question
 ---@class differ.view.Staging
 ---@field initial "staged"|"unstaged"
--- `whole_file` stages as a unit: the keys act on the file, and its hunks share one
--- staged-state slot however many the diff shows (a rename can show several)
+-- `whole_file` stages as a unit: the keys act on the file, and its diff shares one
+-- staged-state slot
 ---@field whole_file? boolean
 -- `apply` takes a nil hunk on a whole-file source, which ignores it
 ---@field apply? fun(model: differ.DiffModel, hunk: differ.Hunk|nil, offset: integer, reverse: boolean): boolean
@@ -1016,8 +1016,8 @@ function View:_whole_file()
     return (self.staging and self.staging.whole_file) == true
 end
 
--- how many staged-state slots this source has. a whole-file source has one however
--- many hunks it shows, so a rename's several hunks mark and clear together
+-- how many staged-state slots this source has. a whole-file source has one, whatever
+-- its diff shows
 ---@return integer
 function View:_slot_count()
     if self:_whole_file() then

--- a/lua/differ/view.lua
+++ b/lua/differ/view.lua
@@ -81,7 +81,9 @@ local armed_view = nil
 -- what it will do to the file, the view words the question
 ---@class differ.view.Staging
 ---@field initial "staged"|"unstaged"
----@field whole_file? boolean  -- stages as a unit: the keys act on the file, not the hunk under the cursor
+-- `whole_file` stages as a unit: the keys act on the file, and its hunks share one
+-- staged-state slot however many the diff shows (a rename can show several)
+---@field whole_file? boolean
 -- `apply` takes a nil hunk on a whole-file source, which ignores it
 ---@field apply? fun(model: differ.DiffModel, hunk: differ.Hunk|nil, offset: integer, reverse: boolean): boolean
 ---@field revert? fun(model: differ.DiffModel, hunk: differ.Hunk, offset: integer): boolean
@@ -174,16 +176,14 @@ function View.new(model, opts)
     return self
 end
 
--- seed per-hunk staged state for the current source: a staged diff (HEAD↔index)
--- opens with every hunk staged, an unstaged diff (index↔worktree) with none. a
--- whole-file source seeds its single slot whether or not a hunk backs it, so a
--- staged mode change (which has none) still opens knowing it's staged
+-- seed staged state for the current source: a staged diff (HEAD↔index) opens with
+-- everything staged, an unstaged diff (index↔worktree) with nothing
 function View:_init_staged()
     self.staged_hunks = {}
     if not (self.staging and self.staging.initial == "staged") then
         return
     end
-    for i = 1, math.max(#self.model.hunks, self:_whole_file() and 1 or 0) do
+    for i = 1, self:_slot_count() do
         self.staged_hunks[i] = true
     end
 end
@@ -340,7 +340,7 @@ function View:_paint_staged()
         vim.api.nvim_buf_clear_namespace(col.bufnr, staged_ns, 0, -1)
         local staged_lines = {}
         for i, line in ipairs(col.map.lines) do
-            if line.hunk and self.staged_hunks[line.hunk] then
+            if line.hunk and self.staged_hunks[self:_slot(line.hunk)] then
                 local row = i - 1
                 -- char-level fill with hl_eol, not line_hl_group: a line_hl_group covers
                 -- the text but loses the past-EOL tail to the diff bg's own hl_eol (it
@@ -407,7 +407,10 @@ function View:_paint_cursorline()
     -- a staged line is recoloured above the live word spans (210/215); lift the cursor
     -- tint over that so the focused line still lights up in its kind. on a normal line
     -- stay under the word spans (200) so changed words show through under the cursor
-    local staged = self.can_stage and line and line.hunk and self.staged_hunks[line.hunk]
+    local staged = self.can_stage
+        and line
+        and line.hunk
+        and self.staged_hunks[self:_slot(line.hunk)]
     vim.api.nvim_buf_set_extmark(col.bufnr, cursor_ns, row, 0, {
         end_row = row + 1,
         end_col = 0,
@@ -776,8 +779,7 @@ function View:show_help()
     if self:_editable_source() then
         rows[#rows + 1] = { fmt(km.edit_file), "edit the real file (in review)" }
     end
-    -- per-file, not session-wide: a pure rename carries no staging capability at all, so
-    -- listing s/u there would advertise keys that refuse
+    -- per-file, not session-wide: a source without `apply` would advertise keys that refuse
     if self:_can_stage_hunk() then
         local unit = self:_whole_file() and "file" or "hunk"
         rows[#rows + 1] = { pair(km.stage, km.unstage), "stage / unstage " .. unit }
@@ -866,7 +868,7 @@ end
 ---@return fun(hunk: integer): boolean
 function View:_review_filter(staged)
     return function(hunk)
-        return (self.staged_hunks[hunk] or false) == staged
+        return (self.staged_hunks[self:_slot(hunk)] or false) == staged
     end
 end
 
@@ -1014,9 +1016,28 @@ function View:_whole_file()
     return (self.staging and self.staging.whole_file) == true
 end
 
--- the slot the staging keys act on: a whole-file source always uses slot 1, which is
--- its one hunk where it has one and a virtual slot where it doesn't. anything else
--- takes the hunk under the cursor
+-- how many staged-state slots this source has. a whole-file source has one however
+-- many hunks it shows, so a rename's several hunks mark and clear together
+---@return integer
+function View:_slot_count()
+    if self:_whole_file() then
+        return 1
+    end
+    return #self.model.hunks
+end
+
+-- the slot holding hunk `h`'s staged state
+---@param h integer
+---@return integer
+function View:_slot(h)
+    if self:_whole_file() then
+        return 1
+    end
+    return h
+end
+
+-- the slot the staging keys act on: slot 1 for a whole-file source, backed by a hunk
+-- or not; anything else takes the hunk under the cursor
 ---@return integer|nil
 function View:_target_index()
     if self:_whole_file() then
@@ -1204,8 +1225,7 @@ function View:_toggle_all(want_staged)
         return false
     end
     local changed = false
-    -- a whole-file source has one slot to act on, backed by a hunk or not
-    for i = 1, math.max(#self.model.hunks, self:_whole_file() and 1 or 0) do
+    for i = 1, self:_slot_count() do
         if self:_apply_hunk(i, want_staged) then
             changed = true
         end

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -3841,6 +3841,18 @@ describe(":Differ diff rename staging", function()
         return root
     end
 
+    -- put the cursor on hunk `n` in the view's primary column
+    local function goto_hunk(v, n)
+        local col = v.columns[1]
+        for i, line in ipairs(col.map.lines) do
+            if line.hunk == n then
+                vim.api.nvim_win_set_cursor(col.winid, { i, 0 })
+                return
+            end
+        end
+        error("no hunk " .. n)
+    end
+
     local function open_staged(p, path)
         assert.is_true(p:focus_file(path))
         p:select(true)
@@ -3911,7 +3923,10 @@ describe(":Differ diff rename staging", function()
         p:close()
     end)
 
-    it("clears every hunk's mark when one u unstages the whole rename", function()
+    -- git records no rename: a staged one is the old path absent from the index and the
+    -- new path present, and `R` is a similarity reading over that. so a hunk patches the
+    -- same blob it would on a modification, and the move rides along untouched
+    it("unstages one hunk of a rename, leaving the move and the other hunks staged", function()
         local root = renamed_repo({ 5, 30, 55 })
         vim.cmd.edit(root .. "/new/big.lua")
 
@@ -3919,16 +3934,18 @@ describe(":Differ diff rename staging", function()
         local p = Panel.current()
         local v = open_staged(p, "new/big.lua")
         assert.are.equal(3, #v.model.hunks)
+        assert.is_falsy(v.staging.whole_file) -- hunk-level, like a modification
 
-        v:unstage_hunk() -- one press: a whole-file source has one slot, not three
+        goto_hunk(v, 2)
+        v:unstage_hunk()
 
-        assert.are.same({}, staged_paths(root))
-        -- a mark surviving here is a hunk painted staged that git no longer holds
-        assert.are.same({ false, false, false }, painted_hunks(view_in_origin(p)))
+        assert.are.same({ true, false, true }, painted_hunks(view_in_origin(p)))
+        -- the move survives: still one rename entry, now with content left unstaged
+        assert.are.same({ "RM old/big.lua -> new/big.lua" }, staged_paths(root))
         p:close()
     end)
 
-    it("leaves the file on the next u rather than cycling its own hunks", function()
+    it("leaves the file once every hunk of the rename is unstaged", function()
         local root = renamed_repo({ 5, 30, 55 })
         write(root .. "/other.lua", "one\ntwo\n")
         git(root, "add", "other.lua")
@@ -3937,8 +3954,9 @@ describe(":Differ diff rename staging", function()
         git_src.panel({ rev = {} })
         local p = Panel.current()
         local v = open_staged(p, "new/big.lua")
-        v:unstage_hunk() -- unstages the rename outright
+        v:unstage_all() -- U: every hunk at once, the move left alone
 
+        assert.are.same({ false, false, false }, painted_hunks(view_in_origin(p)))
         view_in_origin(p):unstage_hunk() -- nothing left here: step to the other file
 
         assert.are.equal("other.lua", view_in_origin(p).model.path)
@@ -4070,11 +4088,13 @@ describe(":Differ diff rename staging", function()
 
         -- two presses per file (unstage, then step on); the rename used to swallow the
         -- walk, leaving everything past it staged for good
-        for _ = 1, 12 do
+        for _ = 1, 20 do
             view_in_origin(p):unstage_hunk()
         end
 
-        assert.are.same({}, staged_paths(root))
+        -- every hunk is unstaged, the rename's included. the move itself is not a hunk
+        -- and stays: unstaging that is the panel row's job, as it is for any whole file
+        assert.are.same({ "RM old/big.lua -> new/big.lua" }, staged_paths(root))
         p:close()
     end)
 end)

--- a/test/nvim/git_spec.lua
+++ b/test/nvim/git_spec.lua
@@ -988,13 +988,34 @@ describe(":Differ panel", function()
 
         git_src.panel({ open_first = true })
         local p = Panel.current()
-        -- the rename is the first listed file (Staged section), but it diffs to nothing;
-        -- the landing skips it for z.lua, the first entry with real content
+        -- the rename is the first listed file, but it's staged and z.lua isn't: the
+        -- landing wants the first thing left to review, whatever the rename diffs to
         assert.are.equal(file_line(p, "z.lua"), p.selected_row)
         vim.api.nvim_set_current_win(p.origin_win)
         local v = require("differ.view").current()
         assert.is_not_nil(v)
         assert.are.equal("z.lua", v.model.path)
+        require("differ.git").close()
+    end)
+
+    -- with nothing unstaged the landing falls back to the first file, and a rename is
+    -- one: it diffs to nothing but still stages, unstages and discards, so opening past
+    -- it would start the session with work already out of sight
+    it("open_first lands on a content-less rename when nothing is unstaged", function()
+        local root = fresh_repo()
+        write(root .. "/keep.lua", "keep\n")
+        write(root .. "/z.lua", "z1\nz2\n")
+        git(root, "add", "keep.lua", "z.lua")
+        git(root, "commit", "-q", "-am", "more files")
+        git(root, "mv", "a.lua", "renamed.lua") -- staged pure rename, sorts first
+        write(root .. "/z.lua", "z1x\nz2\n")
+        git(root, "add", "z.lua") -- staged too, so nothing is left unstaged
+        vim.cmd.edit(root .. "/keep.lua")
+
+        git_src.panel({ open_first = true })
+        local p = Panel.current()
+
+        assert.are.equal(file_line(p, "renamed.lua"), p.selected_row)
         require("differ.git").close()
     end)
 
@@ -1508,6 +1529,105 @@ describe(":Differ diff hunk staging", function()
         end)
 
         assert.are.equal("local x = 99\nreturn x\n", v.model.new_text) -- diff re-sourced
+        p:close()
+    end)
+
+    -- unstaging a whole-file change splits it off the pair the review was on, and the
+    -- re-source then has only the other pair to land on. `s` there acts on that entry
+    -- instead, so the swap can't be silent
+    it("says when an external change re-sources the diff onto the other pair", function()
+        local root = fresh_repo()
+        write(root .. "/new.lua", "one\ntwo\n")
+        git(root, "add", "new.lua") -- a staged add: the only pair this file has
+        vim.cmd.edit(root .. "/new.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("new.lua"))
+        p:select(true)
+        local v = view_in_origin(p)
+        assert.are.equal("INDEX", v.model.new_rev) -- HEAD↔index, the staged pair
+        v:unstage_hunk() -- the staged pair is gone; the file is untracked now
+
+        _G.notifs = {}
+        write(root .. "/other.lua", "unrelated\n") -- something else moves the signature
+        git(root, "add", "other.lua")
+        p:reload()
+
+        local msg
+        for _, n in ipairs(_G.notifs) do
+            if tostring(n.msg):find("changed outside differ", 1, true) then
+                msg = tostring(n.msg)
+            end
+        end
+        assert.is_truthy(msg)
+        assert.is_truthy(msg:find("new.lua", 1, true))
+        p:close()
+    end)
+
+    it("stays quiet when the re-source lands on the same pair", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+
+        _G.notifs = {}
+        write(root .. "/a.lua", "local x = 99\nreturn x\n") -- same file, same pair
+        write(root .. "/b.lua", "new\n")
+        git(root, "add", "b.lua")
+        p:reload()
+
+        for _, n in ipairs(_G.notifs) do
+            assert.is_nil(tostring(n.msg):find("changed outside differ", 1, true))
+        end
+        p:close()
+    end)
+
+    -- the panel's own staging keys move the pair the diff was built from, so the window
+    -- has to follow. the diff window's own s/u keep their frozen model instead, which is
+    -- what lets the staged marks survive a stage
+    it("re-sources the open diff when the panel's own keys stage the file", function()
+        local root = fresh_repo()
+        write(root .. "/a.lua", "local x = 2\nreturn x\n")
+        vim.cmd.edit(root .. "/a.lua")
+
+        git_src.panel({ rev = {}, open_first = true })
+        local p = Panel.current()
+        assert.are.equal("WORKTREE", view_in_origin(p).model.new_rev) -- the unstaged pair
+
+        _G.notifs = {}
+        p:stage_op("stage_all") -- S on the panel row, not in the diff
+
+        assert.are.equal("INDEX", view_in_origin(p).model.new_rev) -- followed to HEAD↔index
+        -- differ's own doing, so it isn't reported the way an outside change is
+        for _, n in ipairs(_G.notifs) do
+            assert.is_nil(tostring(n.msg):find("changed outside differ", 1, true))
+        end
+        p:close()
+    end)
+
+    it("follows a delete-plus-add pair to the rename the panel then lists", function()
+        local root = fresh_repo()
+        write(root .. "/old.lua", string.rep("a line\n", 20))
+        git(root, "add", "old.lua")
+        git(root, "commit", "-q", "-m", "add old.lua")
+        git(root, "mv", "old.lua", "new.lua")
+        git(root, "reset", "-q", "HEAD") -- unstaged: a deletion plus an untracked file
+        vim.cmd.edit(root .. "/new.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("old.lua"))
+        p:select(true)
+        assert.are.equal("old.lua", view_in_origin(p).model.path)
+
+        p:stage_op("stage_all") -- both halves reach the index, and git pairs them
+
+        -- old.lua has no entry left at all, so the window moves to the rename rather
+        -- than sitting on a deletion the change set no longer holds
+        assert.are.equal("new.lua", view_in_origin(p).model.path)
         p:close()
     end)
 
@@ -3628,6 +3748,333 @@ describe(":Differ diff whole-file staging", function()
         assert.is_truthy(text:find("stage / unstage file", 1, true))
         assert.is_nil(text:find("stage / unstage hunk", 1, true))
         vim.api.nvim_win_close(0, true)
+        p:close()
+    end)
+
+    -- a file with both a staged and an unstaged row: the staged row's diff is HEAD↔index
+    -- and shows nothing of what the unstaged row holds, but staging reads the file off
+    -- disk. `u` then `s` on the staged row is what reaches it, since `s` on a row already
+    -- staged steps to the next file rather than staging
+    local function round_trip_staged(root, path)
+        vim.cmd.edit(root .. "/" .. path)
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file(path)) -- the staged row: it comes first
+        p:select(true)
+        local v = view_in_origin(p)
+        assert.is_true(v.staging.whole_file)
+        assert.are.equal("staged", v.staging.initial)
+        _G.notifs = {}
+        v:unstage_hunk()
+        view_in_origin(p):stage_hunk()
+        return p
+    end
+
+    local function absorb_warning()
+        for _, n in ipairs(_G.notifs) do
+            if tostring(n.msg):find("including the edits you had left unstaged", 1, true) then
+                return n
+            end
+        end
+        return nil
+    end
+
+    it("warns when staging a whole file sweeps in the unstaged row too", function()
+        local root = fresh_repo()
+        write(root .. "/new.lua", "one\ntwo\n")
+        git(root, "add", "new.lua") -- a staged add
+        write(root .. "/new.lua", "one\ntwo\nthree WIP\n") -- edited after, left unstaged
+
+        local p = round_trip_staged(root, "new.lua")
+
+        -- the staged diff never showed the WIP line, and it is in the index now
+        assert.are.equal("one\ntwo\nthree WIP\n", git(root, "show", ":new.lua"))
+        assert.are.equal(vim.log.levels.WARN, assert(absorb_warning()).level)
+        p:close()
+    end)
+
+    it("stays quiet when the file on disk is what the diff staged", function()
+        local root = fresh_repo()
+        write(root .. "/new.lua", "one\ntwo\n")
+        git(root, "add", "new.lua") -- staged, and the worktree matches the index
+
+        local p = round_trip_staged(root, "new.lua")
+
+        assert.are.equal("one\ntwo\n", git(root, "show", ":new.lua"))
+        assert.is_nil(absorb_warning())
+        p:close()
+    end)
+end)
+
+-- a rename is the one whole-file status that can show several hunks, and the one that
+-- owns two paths. git pairs renames only in the index, so every R entry is staged
+describe(":Differ diff rename staging", function()
+    local Panel = require("differ.panel")
+
+    local function view_in_origin(p)
+        vim.api.nvim_set_current_win(p.origin_win)
+        return require("differ.view").current()
+    end
+
+    -- a 60-line file committed at old/big.lua, then staged-renamed to new/big.lua with
+    -- `edits` (a list of line numbers) changed on the way, so the rename carries that
+    -- many hunks. 60 lines keeps a few edits well above git's 50% similarity threshold,
+    -- below which git reports an add and a delete instead of a rename
+    local function renamed_repo(edits)
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root .. "/old", "p")
+        git(root, "init", "-q")
+        local lines = {}
+        for n = 1, 60 do
+            lines[n] = "line " .. n
+        end
+        write(root .. "/old/big.lua", table.concat(lines, "\n") .. "\n")
+        git(root, "add", "-A")
+        git(root, "commit", "-q", "-m", "init")
+        vim.fn.mkdir(root .. "/new", "p")
+        git(root, "mv", "old/big.lua", "new/big.lua")
+        for _, n in ipairs(edits or {}) do
+            lines[n] = lines[n] .. " edited"
+        end
+        write(root .. "/new/big.lua", table.concat(lines, "\n") .. "\n")
+        git(root, "add", "new/big.lua")
+        return root
+    end
+
+    local function open_staged(p, path)
+        assert.is_true(p:focus_file(path))
+        p:select(true)
+        return view_in_origin(p)
+    end
+
+    -- the paths git holds a staged change for (a non-blank X column)
+    local function staged_paths(root)
+        local out = {}
+        for line in git(root, "status", "--porcelain=v1"):gmatch("[^\n]+") do
+            if line:sub(1, 1) ~= " " and line:sub(1, 1) ~= "?" then
+                out[#out + 1] = line
+            end
+        end
+        return out
+    end
+
+    -- the hunks the staged-mark overlay paints, read back from the extmarks: a mark
+    -- left behind on a hunk git no longer has staged is what the reviewer sees
+    local function painted_hunks(v)
+        local ns = vim.api.nvim_get_namespaces()["differ.staging"]
+        local col = v.columns[1]
+        local seen, out = {}, {}
+        for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(col.bufnr, ns, 0, -1, {})) do
+            local line = col.map.lines[mark[2] + 1]
+            if line and line.hunk then
+                seen[line.hunk] = true
+            end
+        end
+        for i = 1, #v.model.hunks do
+            out[i] = seen[i] or false
+        end
+        return out
+    end
+
+    it("moves both of a rename's paths together on u, and back on s", function()
+        local root = renamed_repo()
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        local v = open_staged(p, "new/big.lua")
+        assert.is_true(v.staging.whole_file)
+        assert.are.same({ "R  old/big.lua -> new/big.lua" }, staged_paths(root))
+
+        v:unstage_hunk()
+
+        -- resetting only the new path would leave "D  old/big.lua" staged behind
+        assert.are.same({}, staged_paths(root))
+
+        view_in_origin(p):stage_hunk()
+
+        assert.are.same({ "R  old/big.lua -> new/big.lua" }, staged_paths(root))
+        p:close()
+    end)
+
+    it("opens a staged rename with all of its hunks marked staged", function()
+        local root = renamed_repo({ 5, 30, 55 })
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        local v = open_staged(p, "new/big.lua")
+
+        assert.are.equal(3, #v.model.hunks)
+        assert.are.equal("staged", v.staging.initial)
+        assert.are.same({ true, true, true }, painted_hunks(v))
+        p:close()
+    end)
+
+    it("clears every hunk's mark when one u unstages the whole rename", function()
+        local root = renamed_repo({ 5, 30, 55 })
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        local v = open_staged(p, "new/big.lua")
+        assert.are.equal(3, #v.model.hunks)
+
+        v:unstage_hunk() -- one press: a whole-file source has one slot, not three
+
+        assert.are.same({}, staged_paths(root))
+        -- a mark surviving here is a hunk painted staged that git no longer holds
+        assert.are.same({ false, false, false }, painted_hunks(view_in_origin(p)))
+        p:close()
+    end)
+
+    it("leaves the file on the next u rather than cycling its own hunks", function()
+        local root = renamed_repo({ 5, 30, 55 })
+        write(root .. "/other.lua", "one\ntwo\n")
+        git(root, "add", "other.lua")
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        local v = open_staged(p, "new/big.lua")
+        v:unstage_hunk() -- unstages the rename outright
+
+        view_in_origin(p):unstage_hunk() -- nothing left here: step to the other file
+
+        assert.are.equal("other.lua", view_in_origin(p).model.path)
+        p:close()
+    end)
+
+    it("unstages both of a rename's paths from the panel row, as the diff keys do", function()
+        local root = renamed_repo({ 5 })
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("new/big.lua"))
+
+        p:stage_op("unstage") -- u on the file row, not in the diff window
+
+        -- resetting the new path alone leaves "D  old/big.lua" staged: the rename undone
+        -- on one side only, and the panel disagreeing with what u in the diff does
+        assert.are.same({}, staged_paths(root))
+        p:close()
+    end)
+
+    -- run `fn` with confirm answering `answer`, returning the prompt it was shown
+    local function under_confirm(answer, fn)
+        local orig, prompt = vim.fn.confirm, nil
+        vim.fn.confirm = function(msg)
+            prompt = msg
+            return answer
+        end
+        local okay, err = pcall(fn)
+        vim.fn.confirm = orig
+        assert(okay, err)
+        return prompt
+    end
+
+    it("undoes a rename with X, restoring the old path and dropping the new", function()
+        local root = renamed_repo({ 5, 30 })
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("new/big.lua"))
+
+        under_confirm(1, function()
+            p:discard()
+        end)
+
+        -- `checkout HEAD -- new/big.lua` would have failed here: HEAD has no such path
+        assert.are.same({}, staged_paths(root))
+        assert.are.equal(1, vim.fn.filereadable(root .. "/old/big.lua"))
+        assert.are.equal(0, vim.fn.filereadable(root .. "/new/big.lua"))
+        p:close()
+    end)
+
+    it("names the path X will restore in its confirm", function()
+        local root = renamed_repo()
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("new/big.lua"))
+
+        local prompt = under_confirm(2, function() -- answer No: nothing is discarded
+            p:discard()
+        end)
+
+        assert.is_truthy(prompt:find("new/big.lua (restoring old/big.lua)", 1, true))
+        assert.are.same({ "R  old/big.lua -> new/big.lua" }, staged_paths(root))
+        p:close()
+    end)
+
+    it("refuses a rename whose status moved under the prompt", function()
+        local root = renamed_repo()
+        vim.cmd.edit(root .. "/new/big.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        assert.is_true(p:focus_file("new/big.lua"))
+
+        _G.notifs = {}
+        local orig = vim.fn.confirm
+        vim.fn.confirm = function()
+            -- unstaged from outside while the prompt blocks, leaving an untracked new
+            -- path and an unstaged deletion: no longer a rename to undo
+            git(root, "reset", "-q", "HEAD", "--", "new/big.lua", "old/big.lua")
+            return 1
+        end
+        p:discard()
+        vim.fn.confirm = orig
+
+        assert.are.equal(1, vim.fn.filereadable(root .. "/new/big.lua"))
+        assert.are.equal(0, vim.fn.filereadable(root .. "/old/big.lua"))
+        assert.is_truthy(_G.notifs[#_G.notifs].msg:find("discard skipped: new/big.lua", 1, true))
+        p:close()
+    end)
+
+    -- a pure rename shows no lines, so the landing heuristics (gg/G, the initial open)
+    -- skip it. the review walk can't: it stages and unstages as a file, and skipping it
+    -- would announce the review done with that rename still staged
+    it("stops the u review on a rename with no lines to show", function()
+        local root = renamed_repo() -- no edits: a rename with an empty diff
+        write(root .. "/other.lua", "one\ntwo\n")
+        git(root, "add", "other.lua")
+        vim.cmd.edit(root .. "/other.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        open_staged(p, "other.lua")
+
+        for _ = 1, 4 do
+            view_in_origin(p):unstage_hunk()
+        end
+
+        assert.are.equal("new/big.lua", view_in_origin(p).model.path) -- the walk reached it
+        assert.are.same({}, staged_paths(root))
+        p:close()
+    end)
+
+    it("walks the u review past a staged rename to the files beyond it", function()
+        local root = renamed_repo({ 5, 30, 55 })
+        write(root .. "/aaa.lua", "a1\na2\n")
+        write(root .. "/zzz.lua", "z1\nz2\n")
+        git(root, "add", "aaa.lua", "zzz.lua")
+        vim.cmd.edit(root .. "/zzz.lua")
+
+        git_src.panel({ rev = {} })
+        local p = Panel.current()
+        open_staged(p, "zzz.lua")
+
+        -- two presses per file (unstage, then step on); the rename used to swallow the
+        -- walk, leaving everything past it staged for good
+        for _ = 1, 12 do
+            view_in_origin(p):unstage_hunk()
+        end
+
+        assert.are.same({}, staged_paths(root))
         p:close()
     end)
 end)

--- a/test/nvim/health_spec.lua
+++ b/test/nvim/health_spec.lua
@@ -109,6 +109,55 @@ describe("differ.health", function()
         assert.is_nil(find(calls, "github auth", "does not report auth state"))
     end)
 
+    -- a repo carrying the two rename keys. check_renames reads git config from wherever
+    -- nvim is, so the test has to run from inside one
+    local function repo_with(status_renames, diff_renames)
+        local root = vim.fn.tempname()
+        vim.fn.mkdir(root, "p")
+        vim.system({ "git", "init", "-q", root }, { text = true }):wait()
+        for key, value in pairs({
+            ["status.renames"] = status_renames,
+            ["diff.renames"] = diff_renames,
+        }) do
+            vim.system({ "git", "-C", root, "config", key, value }, { text = true }):wait()
+        end
+        return root
+    end
+
+    -- capture() from inside `dir`, putting the cwd back even when check() raises.
+    -- busted resolves `differ.*` off a cwd-relative lpath and capture() reloads the
+    -- module, so the source dir goes on the path absolutely while we sit elsewhere
+    local function capture_in(dir)
+        local cwd = vim.fn.getcwd()
+        local saved_path = package.path
+        package.path = ("%s/lua/?.lua;%s/lua/?/init.lua;%s"):format(cwd, cwd, package.path)
+        vim.cmd.cd(dir)
+        local ok, calls = pcall(capture)
+        vim.cmd.cd(cwd)
+        package.path = saved_path
+        assert.is_true(ok, tostring(calls))
+        return calls
+    end
+
+    -- git takes status.renames from diff.renames unless it is set on its own, so this
+    -- pairing is the only way the panel's listing and a rev-pair's can disagree
+    it("warns when the two rename config keys disagree", function()
+        require("differ").setup({})
+
+        local calls = capture_in(repo_with("false", "true"))
+
+        local warn = find(calls, "git", "status.renames is `false` but diff.renames is `true`")
+        assert.are.equal("warn", warn.kind)
+    end)
+
+    it("stays quiet when they agree, however each is spelled", function()
+        require("differ").setup({})
+
+        local calls = capture_in(repo_with("0", "no")) -- both false
+
+        assert.is_nil(find(calls, "git", "status.renames"))
+    end)
+
     it("surfaces config warnings in the configuration section", function()
         require("differ").setup({ pannel = {}, panel = { position = "middle" } })
         local calls = capture()

--- a/test/nvim/panel_spec.lua
+++ b/test/nvim/panel_spec.lua
@@ -92,9 +92,9 @@ describe("panel navigation", function()
         p:close()
     end)
 
-    it("gg / G skip content-less pure renames at the edges", function()
-        -- a.lua and d.lua are pure renames (no hunks); the edge jumps step past them
-        -- to the first/last file that actually has a diff, mirroring the initial open
+    -- a.lua and d.lua are pure renames (no hunks). the edge jumps move the cursor and
+    -- open nothing, so there is no blank view for them to avoid;
+    it("gg / G land on a content-less pure rename at the edges", function()
         local p = panel({
             fe("a.lua", "R", 0, 0),
             fe("b.lua", "M", 1, 0),
@@ -103,15 +103,28 @@ describe("panel navigation", function()
         })
         p:open()
         p:cursor_to_edge("first")
-        assert.are.equal("b.lua", cursor_path(p))
+        assert.are.equal("a.lua", cursor_path(p))
         p:cursor_to_edge("last")
-        assert.are.equal("c.lua", cursor_path(p))
+        assert.are.equal("d.lua", cursor_path(p))
         p:close()
     end)
 
-    it("gg / G still visit untracked files (zero numstat, but real content)", function()
-        -- untracked '?' files report 0/0 counts like a pure rename, but they render
-        -- their whole content, so the edge jumps must not skip them
+    -- the initial open lands on one too. it shows no lines, but it is a file that still
+    -- stages, unstages and discards
+    it("the initial open lands on a pure rename rather than starting past it", function()
+        local p = panel({
+            fe("a.lua", "R", 0, 0),
+            fe("b.lua", "M", 1, 0),
+        })
+        p:open()
+        p:focus_first_changed()
+        assert.are.equal("a.lua", cursor_path(p))
+        p:close()
+    end)
+
+    it("gg / G visit untracked files, which also report zero counts", function()
+        -- '?' files report 0/0 like a pure rename, so they used to need excluding by
+        -- hand from the skip the edge jumps ran; nothing is excluded now
         local p = panel({ fe("a.lua", "R", 0, 0), fe("z.lua", "?", 0, 0) })
         p:open()
         p:cursor_to_edge("last")
@@ -119,7 +132,7 @@ describe("panel navigation", function()
         p:close()
     end)
 
-    it("gg / G fall back to the absolute edge when every file is content-less", function()
+    it("gg / G land on the edges when every file is content-less", function()
         local p = panel({ fe("a.lua", "R", 0, 0), fe("b.lua", "R", 0, 0) })
         p:open()
         p:cursor_to_edge("first")

--- a/test/unit/rev_spec.lua
+++ b/test/unit/rev_spec.lua
@@ -128,6 +128,19 @@ describe("git.rev.parse_status", function()
         }, rev.parse_status(out))
     end)
 
+    it("consumes each old-path field in a run of renames", function()
+        local out = "R  new/a.txt\0old/a.txt\0"
+            .. "R  new/b.txt\0old/b.txt\0"
+            .. "RM new/c.txt\0old/c.txt\0"
+            .. " M src/tail.txt\0"
+        assert.are.same({
+            { x = "R", y = " ", path = "new/a.txt", previous_path = "old/a.txt" },
+            { x = "R", y = " ", path = "new/b.txt", previous_path = "old/b.txt" },
+            { x = "R", y = "M", path = "new/c.txt", previous_path = "old/c.txt" },
+            { x = " ", y = "M", path = "src/tail.txt" },
+        }, rev.parse_status(out))
+    end)
+
     it("returns nothing for empty output", function()
         assert.are.same({}, rev.parse_status(""))
     end)
@@ -146,6 +159,17 @@ describe("git.rev.parse_numstat", function()
         local out = "0\t0\t\0deep/old.txt\0deep/new.txt\0"
         assert.are.same({
             ["deep/new.txt"] = { additions = 0, deletions = 0 },
+        }, rev.parse_numstat(out))
+    end)
+
+    it("consumes both path fields of a rename before the next record", function()
+        local out = "1\t1\t\0old/a.txt\0new/a.txt\0"
+            .. "0\t0\t\0old/b.txt\0new/b.txt\0"
+            .. "5\t2\ttail.txt\0"
+        assert.are.same({
+            ["new/a.txt"] = { additions = 1, deletions = 1 },
+            ["new/b.txt"] = { additions = 0, deletions = 0 },
+            ["tail.txt"] = { additions = 5, deletions = 2 },
         }, rev.parse_numstat(out))
     end)
 


### PR DESCRIPTION
## Summary

- `s` and `u` refused to act on a rename or copy, so the review walk halted at the first renamed file, similarly, an already staged rename rendered as though nothing in it was staged; R/C now stages, moving both of a rename's paths together
- a rename with content edits stages hunk by hunk like any modification. git stores no rename, just the old path gone and the new one present, so a hunk patches the same blob. a pure rename has no lines to pick and stages whole, and the move itself isn't a hunk, so the panel row's `u` takes it
- a whole-file source with several hunks tracked a staged state independently per hunk, but always acted on the first, so one `u` left the rest still shaded as staged and further presses bounced the cursor between them. whole-file sources now use one slot
- `X` on a rename always refused with "changed since the prompt": `live_status` narrowed the pathspec to the new path, which left git unable to pair the rename. it now passes both, and the discard restores the old path from HEAD
- `u` on a rename's panel row reset only the new path, leaving the old path's deletion staged. the panel and the diff window now share one `set_staged`
- the panel's own `s` / `u` / `S` / `U` / `X` reloaded the list but never the open diff, so staging the file you were looking at left the window on a stale view
- the `s` / `u` walk, `gg` / `G`, `]]` / `[[` and the initial open all stepped past a rename with no lines to show, nothing skips them now
- staging a whole file back after unstaging it also staged the file's unstaged row, which that diff never showed. `git add` reads the file off disk, so this is unchanged, but no longer silent
- an external git change could re-source the open diff onto the file's other pair without a word, leaving the staging keys acting on something other than what was being reviewed
- `:checkhealth differ` warns when `status.renames` and `diff.renames` disagree, the only configuration where the file panel and a rev-pair diff list the same change differently
- several existing tests asserted the old behaviour and now assert the opposite: the blank-rename skip, and whole-file rename staging

## Test plan

- [x] `make check` clean
